### PR TITLE
Remove redundant start operations

### DIFF
--- a/ptsprojects/mynewt/iutctl.py
+++ b/ptsprojects/mynewt/iutctl.py
@@ -80,6 +80,8 @@ class MynewtCtl:
 
         self.btp_socket.accept()
 
+        self.reset(False)
+
     def flush_serial(self):
         log("%s.%s", self.__class__, self.flush_serial.__name__)
         # Try to read data or timeout
@@ -96,22 +98,21 @@ class MynewtCtl:
         if self.rtt2pty:
             self.rtt2pty.stop()
 
-    def reset(self):
+    def reset(self, full_reset=False):
         """Restart IUT related processes and reset the IUT"""
         log("%s.%s", self.__class__, self.reset.__name__)
 
-        self.stop()
-        self.start(self.test_case)
-        self.flush_serial()
+        if full_reset:
+            self.stop()
+            self.start(self.test_case)
 
+        self.flush_serial()
         self.rtt2pty_stop()
 
         self.board.reset()
 
     def wait_iut_ready_event(self):
         """Wait until IUT sends ready event after power up"""
-        self.reset()
-
         tuple_hdr, tuple_data = self.btp_socket.read()
 
         try:

--- a/ptsprojects/zephyr/iutctl.py
+++ b/ptsprojects/zephyr/iutctl.py
@@ -149,6 +149,8 @@ class ZephyrCtl:
 
         self.btp_socket.accept()
 
+        self.reset(False)
+
     def flush_serial(self):
         log("%s.%s", self.__class__, self.flush_serial.__name__)
         # Try to read data or timeout
@@ -179,12 +181,14 @@ class ZephyrCtl:
         if self.btmon:
             self.btmon.stop()
 
-    def reset(self):
+    def reset(self, full_reset=False):
         """Restart IUT related processes and reset the IUT"""
         log("%s.%s", self.__class__, self.reset.__name__)
 
-        self.stop()
-        self.start(self.test_case)
+        if full_reset:
+            self.stop()
+            self.start(self.test_case)
+
         self.flush_serial()
 
         if not self.board:
@@ -197,8 +201,6 @@ class ZephyrCtl:
 
     def wait_iut_ready_event(self):
         """Wait until IUT sends ready event after power up"""
-        self.reset()
-
         tuple_hdr, tuple_data = self.btp_socket.read()
 
         try:

--- a/ptsprojects/zephyr/sm_wid.py
+++ b/ptsprojects/zephyr/sm_wid.py
@@ -105,6 +105,7 @@ def hdl_wid_141(desc):
 def hdl_wid_143(desc):
     zephyrctl = get_iut()
 
+    zephyrctl.reset(True)
     zephyrctl.wait_iut_ready_event()
     btp.core_reg_svc_gap()
     btp.gap_read_ctrl_info()

--- a/wid/mmdl.py
+++ b/wid/mmdl.py
@@ -77,6 +77,7 @@ def iut_reset():
     time.sleep(5)
     zephyrctl = btp.get_iut_method()
 
+    zephyrctl.reset(True)
     zephyrctl.wait_iut_ready_event()
     btp.core_reg_svc_gap()
     btp.core_reg_svc_mesh()


### PR DESCRIPTION
Inside `wait_iut_ready_event` also call `self.reset()`.
This is a repetitive operation, we should remove it.

Signed-off-by: Lingao Meng <menglingao@xiaomi.com>