### PR TITLE
pybtp: Fix mesh input string command

### DIFF
--- a/autopts/pybtp/btp/mesh.py
+++ b/autopts/pybtp/btp/mesh.py
@@ -362,7 +362,7 @@ def mesh_input_string(string):
 
     iutctl = get_iut()
 
-    string_len = len(string)
+    string_len = len(string) + 1
 
     data = bytearray(struct.pack("<B", string_len))
     data.extend(string.encode('UTF-8'))


### PR DESCRIPTION
This command is a bit odd since while having length field it sends string including NULL termination. Unfortunatelly (at least) Zephyr implementation assumes NULL is present. So to allow for easier length validation (which isn't currently done by Zephyr) just include NULL in string length.