### PR TITLE
zephyr: audio: Set pixit TSPX_delete_ltk to TRUE

### DIFF
--- a/autopts/ptsprojects/zephyr/aics.py
+++ b/autopts/ptsprojects/zephyr/aics.py
@@ -48,7 +48,7 @@ def set_pixits(ptses):
     pts.set_pixit("AICS", "TSPX_delete_link_key", "FALSE")
     pts.set_pixit("AICS", "TSPX_pin_code", "0000")
     pts.set_pixit("AICS", "TSPX_use_dynamic_pin", "FALSE")
-    pts.set_pixit("AICS", "TSPX_delete_ltk", "FALSE")
+    pts.set_pixit("AICS", "TSPX_delete_ltk", "TRUE")
     pts.set_pixit("AICS", "TSPX_security_enabled", "FALSE")
     pts.set_pixit("AICS", "TSPX_iut_setup_att_over_br_edr", "FALSE")
     pts.set_pixit("AICS", "TSPX_tester_appearance", "0000")

--- a/autopts/ptsprojects/zephyr/pacs.py
+++ b/autopts/ptsprojects/zephyr/pacs.py
@@ -47,7 +47,7 @@ def set_pixits(ptses):
     pts.set_pixit("PACS", "TSPX_delete_link_key", "FALSE")
     pts.set_pixit("PACS", "TSPX_pin_code", "0000")
     pts.set_pixit("PACS", "TSPX_use_dynamic_pin", "FALSE")
-    pts.set_pixit("PACS", "TSPX_delete_ltk", "FALSE")
+    pts.set_pixit("PACS", "TSPX_delete_ltk", "TRUE")
     pts.set_pixit("PACS", "TSPX_security_enabled", "FALSE")
     pts.set_pixit("PACS", "TSPX_iut_setup_att_over_br_edr", "FALSE")
     pts.set_pixit("PACS", "TSPX_tester_appearance", "0000")

--- a/autopts/ptsprojects/zephyr/vcs.py
+++ b/autopts/ptsprojects/zephyr/vcs.py
@@ -48,7 +48,7 @@ def set_pixits(ptses):
     pts.set_pixit("VCS", "TSPX_delete_link_key", "FALSE")
     pts.set_pixit("VCS", "TSPX_pin_code", "0000")
     pts.set_pixit("VCS", "TSPX_use_dynamic_pin", "FALSE")
-    pts.set_pixit("VCS", "TSPX_delete_ltk", "FALSE")
+    pts.set_pixit("VCS", "TSPX_delete_ltk", "TRUE")
     pts.set_pixit("VCS", "TSPX_security_enabled", "FALSE")
     pts.set_pixit("VCS", "TSPX_iut_setup_att_over_br_edr", "FALSE")
     pts.set_pixit("VCS", "TSPX_tester_appearance", "0000")

--- a/autopts/ptsprojects/zephyr/vocs.py
+++ b/autopts/ptsprojects/zephyr/vocs.py
@@ -47,7 +47,7 @@ def set_pixits(ptses):
     pts.set_pixit("VOCS", "TSPX_delete_link_key", "FALSE")
     pts.set_pixit("VOCS", "TSPX_pin_code", "0000")
     pts.set_pixit("VOCS", "TSPX_use_dynamic_pin", "FALSE")
-    pts.set_pixit("VOCS", "TSPX_delete_ltk", "FALSE")
+    pts.set_pixit("VOCS", "TSPX_delete_ltk", "TRUE")
     pts.set_pixit("VOCS", "TSPX_security_enabled", "FALSE")
     pts.set_pixit("VOCS", "TSPX_iut_setup_att_over_br_edr", "FALSE")
     pts.set_pixit("VOCS", "TSPX_tester_appearance", "0000")


### PR DESCRIPTION
Every second test failed due to cached ltk.