### PR TITLE
gap: Rework GAP security elevation tests

### DIFF
--- a/autopts/ptsprojects/zephyr/gap.py
+++ b/autopts/ptsprojects/zephyr/gap.py
@@ -261,12 +261,6 @@ def test_cases(ptses):
                   [TestFunc(lambda: pts.update_pixit_param(
                    "GAP", "TSPX_encryption_before_service_request", "TRUE"))],
                   generic_wid_hdl=gap_wid_hdl),
-        ZTestCase("GAP", "GAP/SEC/AUT/BV-20-C",
-                  cmds=pre_conditions +
-                  [TestFunc(btp.gap_set_io_cap, IOCap.display_only),
-                   TestFunc(btp.gattc_read_rsp, store_val=False,
-                            post_wid=108, skip_call=(1,))],
-                  generic_wid_hdl=gap_wid_hdl),
         ZTestCase("GAP", "GAP/SEC/AUT/BV-21-C",
                   cmds=pre_conditions +
                   [TestFunc(btp.gap_set_io_cap, IOCap.display_only),
@@ -283,11 +277,6 @@ def test_cases(ptses):
         ZTestCase("GAP", "GAP/SEC/AUT/BV-24-C",
                   cmds=pre_conditions + init_gatt_db +
                   [TestFunc(btp.gap_set_io_cap, IOCap.display_only)],
-                  generic_wid_hdl=gap_wid_hdl),
-        ZTestCase("GAP", "GAP/SEC/AUT/BV-27-C",
-                  cmds=pre_conditions +
-                  [TestFunc(btp.gattc_read_rsp, store_val=False,
-                            post_wid=112)],
                   generic_wid_hdl=gap_wid_hdl),
         ZTestCase("GAP", "GAP/SEC/CSIGN/BV-01-C",
                   cmds=pre_conditions + init_gatt_db +

--- a/autopts/ptsprojects/zephyr/gap_wid.py
+++ b/autopts/ptsprojects/zephyr/gap_wid.py
@@ -37,28 +37,6 @@ def gap_wid_hdl(wid, description, test_case_name):
         return gen_wid_hdl(wid, description, test_case_name, False)
 
 
-# For tests that expect "OK" response even if read operation is not successful
-def gap_wid_hdl_failed_read(wid, description, test_case_name):
-    log("%s, %r, %r, %s", gap_wid_hdl.__name__, wid, description,
-        test_case_name)
-
-    if wid == 112:
-        bd_addr = btp.pts_addr_get()
-        bd_addr_type = btp.pts_addr_type_get()
-
-        handle = btp.parse_handle_description(description)
-        if not handle:
-            return False
-
-        try:
-            btp.gattc_read(bd_addr_type, bd_addr, handle)
-            btp.gattc_read_rsp()
-        except socket.timeout:
-            pass
-        return True
-    return gap_wid_hdl(wid, description, test_case_name)
-
-
 # For tests in SC only, mode 1 level 3
 def gap_wid_hdl_mode1_lvl2(wid, description, test_case_name):
     if wid == 139:
@@ -83,20 +61,6 @@ def hdl_wid_73(desc):
 
 
 def hdl_wid_104(desc):
-    return True
-
-
-def hdl_wid_112(desc):
-    bd_addr = btp.pts_addr_get()
-    bd_addr_type = btp.pts_addr_type_get()
-
-    handle = btp.parse_handle_description(desc)
-    if not handle:
-        return False
-
-    btp.gattc_read(bd_addr_type, bd_addr, handle)
-    # PTS doesn't respond to read req if we do not respond to this WID
-    # btp.gattc_read_rsp()
     return True
 
 

--- a/autopts/wid/gap.py
+++ b/autopts/wid/gap.py
@@ -495,7 +495,7 @@ def hdl_wid_104(_: WIDParams):
 def hdl_wid_106(params: WIDParams):
     # description: Waiting for HCI_ENCRYPTION_CHANGE_EVENT...
     # Depending on test, PTS seems to start pairing on its own here or not
-    if params.test_case_name == 'GAP/SEC/AUT/BV-19-C':
+    if params.test_case_name in ['GAP/SEC/AUT/BV-19-C', 'GAP/SEC/AUT/BV-25-C']:
         btp.gap_pair()
     return True
 
@@ -512,20 +512,17 @@ def hdl_wid_108(params: WIDParams):
     return True
 
 
-def hdl_wid_112(_: WIDParams):
+def hdl_wid_112(params: WIDParams):
     bd_addr = btp.pts_addr_get()
     bd_addr_type = btp.pts_addr_type_get()
 
-    btp.gattc_disc_all_chrc(bd_addr_type, bd_addr, 0x0001, 0xffff)
-    attrs = btp.gattc_disc_all_chrc_rsp()
+    handle = btp.parse_handle_description(params.description)
+    if not handle:
+        return False
 
-    for attr in attrs:
-        if attr.prop & Prop.read:
-            btp.gattc_read(bd_addr_type, bd_addr, attr.value_handle)
-            btp.gattc_read_rsp()
-            return True
-
-    return False
+    btp.gattc_read(bd_addr_type, bd_addr, handle)
+    btp.gattc_read_rsp()
+    return True
 
 
 def hdl_wid_114(params: WIDParams):
@@ -1039,20 +1036,17 @@ def hdl_wid_226(_: WIDParams):
     return True
 
 
-def hdl_wid_227(_: WIDParams):
+def hdl_wid_227(params: WIDParams):
     bd_addr = btp.pts_addr_get()
     bd_addr_type = btp.pts_addr_type_get()
 
-    btp.gattc_disc_all_chrc(bd_addr_type, bd_addr, 0x0001, 0xffff)
-    attrs = btp.gattc_disc_all_chrc_rsp()
+    handle = btp.parse_handle_description(params.description)
+    if not handle:
+        return False
 
-    for attr in attrs:
-        if attr.prop & Prop.read:
-            btp.gattc_read(bd_addr_type, bd_addr, attr.value_handle)
-            btp.gattc_read_rsp()
-            return True
-
-    return False
+    btp.gattc_read(bd_addr_type, bd_addr, handle)
+    btp.gattc_read_rsp()
+    return True
 
 
 def hdl_wid_232(_: WIDParams):


### PR DESCRIPTION
Make all tests related to security elevation rely on explicit actions instead of IUT starting pairing autonomously. This makes tests more reliable by removing some races related to WID handling and implicit security actions by IUT.

Depends on https://github.com/zephyrproject-rtos/zephyr/pull/55502