### PR TITLE
zephyr: Remove PACS overlays

### DIFF
--- a/autopts/bot/iut_config/zephyr.py
+++ b/autopts/bot/iut_config/zephyr.py
@@ -163,17 +163,6 @@ iut_config = {
             'GATT/CL/GAR/BI-42-C',
         ]
     },
-
-    "le_audio.conf": {
-        "overlay": {
-            'CONFIG_BT_AUDIO_UNICAST_SERVER': 'y',
-            'CONFIG_BT_ATT_ENFORCE_FLOW': 'n',
-            'CONFIG_BT_HCI_VS_EXT': 'n',
-        },
-        "test_cases": [
-            'PACS',
-        ]
-    },
 }
 
 retry_config = {


### PR DESCRIPTION
Since unicast server is enabled in bttester by default and NETCORE uses zephyrs controller, the overlays are not needed.