### PR TITLE
mesh: Add missing GATT service register

### DIFF
--- a/autopts/ptsprojects/zephyr/mesh.py
+++ b/autopts/ptsprojects/zephyr/mesh.py
@@ -186,6 +186,7 @@ def test_cases(ptses):
 
     common_pre_conditions = [
         TestFunc(btp.core_reg_svc_gap),
+        TestFunc(btp.core_reg_svc_gatt),
         TestFunc(btp.core_reg_svc_mesh),
         TestFunc(btp.gap_read_ctrl_info),
         TestFunc(lambda: pts.update_pixit_param(


### PR DESCRIPTION
Some tests are using GATT service to verify GATT database. Make sure it is initialized before using it.