### PR TITLE
cron: Set minimal run time for PR job to zero

### DIFF
--- a/tools/cron/common.py
+++ b/tools/cron/common.py
@@ -299,7 +299,7 @@ class GithubCron(Thread):
 
 def pr_choose_start_time():
     start_time = datetime.today()
-    run_time = 10.0
+    run_time = 0.0  # TODO run time estimation and prioritising
     all_jobs = schedule.jobs[:]
 
     while True:


### PR DESCRIPTION
The hardcoreded previous value 10h occured to be pretty annoying, because it delayed significantly every test requested with a PR comment, if in the nearest 10h happened to be scheduled any cyclical job. The issue should be handled by time estimation and prioritization of the jobs.