### PR TITLE
zephyr: Simplify GAP tests configurations

### DIFF
--- a/autopts/bot/iut_config/zephyr.py
+++ b/autopts/bot/iut_config/zephyr.py
@@ -45,9 +45,6 @@ iut_config = {
             'SM/CEN/OOB/BI-01-C',
             'SM/PER/OOB/BV-04-C',
             'SM/PER/OOB/BI-02-C',
-            'GAP/SEC/AUT/BV-11-C',
-            'GAP/SEC/AUT/BV-12-C',
-            'GAP/SEC/AUT/BV-13-C',
         ]
     },
 

--- a/autopts/ptsprojects/zephyr/gap.py
+++ b/autopts/ptsprojects/zephyr/gap.py
@@ -21,7 +21,7 @@ from autopts.client import get_unique_name
 from autopts.ptsprojects.stack import get_stack
 from autopts.ptsprojects.testcase import TestFunc
 from autopts.ptsprojects.zephyr.ztestcase import ZTestCase
-from autopts.ptsprojects.zephyr.gap_wid import gap_wid_hdl, gap_wid_hdl_mode1_lvl2, gap_wid_hdl_mode1_lvl4
+from autopts.ptsprojects.zephyr.gap_wid import gap_wid_hdl
 
 
 class SVC:
@@ -30,7 +30,6 @@ class SVC:
 
 class CHAR:
     name = (None, None, None, UUID.device_name)
-
 
 init_gatt_db = [TestFunc(btp.gatts_add_svc, 0, UUID.VND16_1),
                 TestFunc(btp.gatts_add_char, 0, Prop.read,
@@ -44,15 +43,22 @@ init_gatt_db = [TestFunc(btp.gatts_add_svc, 0, UUID.VND16_1),
                 TestFunc(btp.gatts_add_char, 0,
                          Prop.read | Prop.auth_swrite,
                          Perm.read | Perm.write,
-                         UUID.VND16_3),
+                         UUID.VND16_4),
                 TestFunc(btp.gatts_set_val, 0, '03'),
                 TestFunc(btp.gatts_add_char, 0,
-                         Prop.read | Prop.auth_swrite,
+                         Prop.read | Prop.write,
                          Perm.read_authn | Perm.write_authn,
-                         UUID.VND16_4),
+                         UUID.VND16_5),
                 TestFunc(btp.gatts_set_val, 0, '04'),
                 TestFunc(btp.gatts_start_server)]
 
+init_gatt_db2 = [TestFunc(btp.gatts_add_svc, 0, UUID.VND16_1),
+                 TestFunc(btp.gatts_add_char, 0,
+                         Prop.read | Prop.auth_swrite,
+                         Perm.read | Perm.write_authn,
+                         UUID.VND16_4),
+                TestFunc(btp.gatts_set_val, 0, '03'),
+                TestFunc(btp.gatts_start_server)]
 
 iut_manufacturer_data = 'ABCD'
 iut_appearance = '1111'
@@ -199,6 +205,7 @@ def test_cases(ptses):
 
         TestFunc(btp.core_reg_svc_gatt),
         TestFunc(stack.gatt_init),
+        TestFunc(btp.gap_set_io_cap, IOCap.keyboard_display),
 
         # We do this on test case, because previous one could update
         # this if RPA was used by PTS
@@ -206,220 +213,8 @@ def test_cases(ptses):
         TestFunc(btp.set_pts_addr, pts_bd_addr, Addr.le_public)]
 
     custom_test_cases = [
-        ZTestCase("GAP", "GAP/BROB/BCST/BV-03-C",
-                  cmds=pre_conditions +
-                  [TestFunc(btp.gap_set_io_cap, IOCap.display_only)],
-                  generic_wid_hdl=gap_wid_hdl),
-        ZTestCase("GAP", "GAP/BROB/OBSV/BV-06-C",
-                  cmds=pre_conditions +
-                  [TestFunc(btp.gap_set_io_cap, IOCap.display_only)],
-                  generic_wid_hdl=gap_wid_hdl),
-        ZTestCase("GAP", "GAP/IDLE/NAMP/BV-01-C",
-                  cmds=pre_conditions,
-                  generic_wid_hdl=gap_wid_hdl),
-        ZTestCase("GAP", "GAP/CONN/UCON/BV-06-C",
-                  cmds=pre_conditions +
-                  [TestFunc(btp.gap_set_io_cap, IOCap.display_only)],
-                  generic_wid_hdl=gap_wid_hdl),
-        ZTestCase("GAP", "GAP/BOND/BON/BV-01-C",
-                  cmds=pre_conditions + init_gatt_db +
-                  [TestFunc(btp.gap_set_io_cap, IOCap.display_only)],
-                  generic_wid_hdl=gap_wid_hdl),
-        ZTestCase("GAP", "GAP/BOND/BON/BV-03-C",
-                  cmds=pre_conditions + init_gatt_db +
-                  [TestFunc(btp.gap_set_io_cap, IOCap.display_only)],
-                  generic_wid_hdl=gap_wid_hdl),
-        ZTestCase("GAP", "GAP/BOND/BON/BV-04-C",
-                  cmds=pre_conditions + init_gatt_db +
-                  [TestFunc(btp.gap_set_io_cap, IOCap.display_only)],
-                  generic_wid_hdl=gap_wid_hdl),
-        ZTestCase("GAP", "GAP/CONN/PRDA/BV-02-C",
-                  cmds=pre_conditions +
-                  [TestFunc(btp.gap_pair, post_wid=108)],
-                  generic_wid_hdl=gap_wid_hdl),
-        ZTestCase("GAP", "GAP/SEC/AUT/BV-11-C",
-                  cmds=pre_conditions + init_gatt_db +
-                  [TestFunc(btp.gap_set_io_cap, IOCap.display_only)],
-                  generic_wid_hdl=gap_wid_hdl),
-        ZTestCase("GAP", "GAP/SEC/AUT/BV-12-C",
-                  cmds=pre_conditions + init_gatt_db +
-                  [TestFunc(btp.gap_set_io_cap, IOCap.display_only)],
-                  generic_wid_hdl=gap_wid_hdl),
-        ZTestCase("GAP", "GAP/SEC/AUT/BV-13-C",
-                  cmds=pre_conditions + init_gatt_db +
-                  [TestFunc(btp.gap_set_io_cap, IOCap.display_only)],
-                  generic_wid_hdl=gap_wid_hdl),
-        ZTestCase("GAP", "GAP/SEC/AUT/BV-14-C",
-                  cmds=pre_conditions + init_gatt_db +
-                  [TestFunc(btp.gap_set_io_cap, IOCap.display_only)],
-                  generic_wid_hdl=gap_wid_hdl),
-        ZTestCase("GAP", "GAP/SEC/AUT/BV-18-C",
-                  cmds=pre_conditions + init_gatt_db +
-                  [TestFunc(btp.gap_set_io_cap, IOCap.no_input_output)],
-                  generic_wid_hdl=gap_wid_hdl),
-        ZTestCase("GAP", "GAP/SEC/AUT/BV-19-C",
-                  cmds=pre_conditions +
-                  [TestFunc(lambda: pts.update_pixit_param(
-                   "GAP", "TSPX_encryption_before_service_request", "TRUE"))],
-                  generic_wid_hdl=gap_wid_hdl),
-        ZTestCase("GAP", "GAP/SEC/AUT/BV-21-C",
-                  cmds=pre_conditions +
-                  [TestFunc(btp.gap_set_io_cap, IOCap.display_only),
-                   TestFunc(btp.gap_pair, post_wid=108)],
-                  generic_wid_hdl=gap_wid_hdl),
-        # TODO: Inform about lost bond
-        ZTestCase("GAP", "GAP/SEC/AUT/BV-22-C",
-                  cmds=pre_conditions,
-                  generic_wid_hdl=gap_wid_hdl),
-        ZTestCase("GAP", "GAP/SEC/AUT/BV-23-C",
-                  cmds=pre_conditions + init_gatt_db +
-                  [TestFunc(btp.gap_set_io_cap, IOCap.display_only)],
-                  generic_wid_hdl=gap_wid_hdl),
-        ZTestCase("GAP", "GAP/SEC/AUT/BV-24-C",
-                  cmds=pre_conditions + init_gatt_db +
-                  [TestFunc(btp.gap_set_io_cap, IOCap.display_only)],
-                  generic_wid_hdl=gap_wid_hdl),
-        ZTestCase("GAP", "GAP/SEC/CSIGN/BV-01-C",
-                  cmds=pre_conditions + init_gatt_db +
-                  [TestFunc(btp.gap_set_io_cap, IOCap.display_only)],
-                  generic_wid_hdl=gap_wid_hdl),
-        ZTestCase("GAP", "GAP/SEC/CSIGN/BV-02-C",
-                  cmds=pre_conditions + init_gatt_db +
-                  [TestFunc(btp.gap_set_io_cap, IOCap.no_input_output)],
-                  generic_wid_hdl=gap_wid_hdl),
-        ZTestCase("GAP", "GAP/SEC/CSIGN/BI-01-C",
-                  cmds=pre_conditions + init_gatt_db +
-                  [TestFunc(btp.gap_set_io_cap, IOCap.no_input_output)],
-                  generic_wid_hdl=gap_wid_hdl),
-        ZTestCase("GAP", "GAP/SEC/CSIGN/BI-02-C",
-                  cmds=pre_conditions + init_gatt_db +
-                  [TestFunc(btp.gap_set_io_cap, IOCap.no_input_output)],
-                  generic_wid_hdl=gap_wid_hdl),
-        ZTestCase("GAP", "GAP/SEC/CSIGN/BI-03-C",
-                  cmds=pre_conditions + init_gatt_db +
-                  [TestFunc(btp.gap_set_io_cap, IOCap.no_input_output)],
-                  generic_wid_hdl=gap_wid_hdl),
         ZTestCase("GAP", "GAP/SEC/CSIGN/BI-04-C",
-                  cmds=pre_conditions +
-                  [TestFunc(btp.gap_set_io_cap, IOCap.no_input_output)],
-                  generic_wid_hdl=gap_wid_hdl),
-        ZTestCase("GAP", "GAP/SEC/SEM/BV-21-C",
-                  cmds=pre_conditions +
-                  [TestFunc(btp.gap_set_io_cap, IOCap.display_only)],
-                  generic_wid_hdl=gap_wid_hdl),
-        ZTestCase("GAP", "GAP/SEC/SEM/BV-22-C",
-                  cmds=pre_conditions +
-                  [TestFunc(btp.gap_set_io_cap, IOCap.display_only)],
-                  generic_wid_hdl=gap_wid_hdl_mode1_lvl2),
-        ZTestCase("GAP", "GAP/SEC/SEM/BV-23-C",
-                  cmds=pre_conditions + init_gatt_db +
-                  [TestFunc(btp.gap_set_io_cap, IOCap.display_only)],
-                  generic_wid_hdl=gap_wid_hdl),
-        ZTestCase("GAP", "GAP/SEC/SEM/BV-24-C",
-                  cmds=pre_conditions + init_gatt_db +
-                  [TestFunc(btp.gap_set_io_cap, IOCap.display_only)],
-                  generic_wid_hdl=gap_wid_hdl_mode1_lvl2),
-        ZTestCase("GAP", "GAP/SEC/SEM/BV-26-C",
-                  cmds=pre_conditions +
-                  [TestFunc(btp.gap_set_io_cap, IOCap.display_only)],
-                  generic_wid_hdl=gap_wid_hdl),
-        ZTestCase("GAP", "GAP/SEC/SEM/BV-27-C",
-                  cmds=pre_conditions + init_gatt_db +
-                  [TestFunc(btp.gap_set_io_cap, IOCap.display_only)],
-                  generic_wid_hdl=gap_wid_hdl_mode1_lvl4),
-        ZTestCase("GAP", "GAP/SEC/SEM/BV-28-C",
-                  cmds=pre_conditions + init_gatt_db +
-                  [TestFunc(btp.gap_set_io_cap, IOCap.display_only)],
-                  generic_wid_hdl=gap_wid_hdl),
-        ZTestCase("GAP", "GAP/SEC/SEM/BV-29-C",
-                  cmds=pre_conditions + init_gatt_db +
-                  [TestFunc(btp.gap_set_io_cap, IOCap.display_only)],
-                  generic_wid_hdl=gap_wid_hdl_mode1_lvl4),
-        ZTestCase("GAP", "GAP/SEC/SEM/BV-37-C",
-                  cmds=pre_conditions +
-                  [TestFunc(btp.gap_set_io_cap, IOCap.display_only)],
-                  generic_wid_hdl=gap_wid_hdl),
-        ZTestCase("GAP", "GAP/SEC/SEM/BV-38-C",
-                  cmds=pre_conditions +
-                  [TestFunc(btp.gap_set_io_cap, IOCap.display_only)],
-                  generic_wid_hdl=gap_wid_hdl),
-        ZTestCase("GAP", "GAP/SEC/SEM/BV-39-C",
-                  cmds=pre_conditions +
-                  [TestFunc(btp.gap_set_io_cap, IOCap.display_only)],
-                  generic_wid_hdl=gap_wid_hdl_mode1_lvl2),
-        ZTestCase("GAP", "GAP/SEC/SEM/BV-40-C",
-                  cmds=pre_conditions + init_gatt_db +
-                  [TestFunc(btp.gap_set_io_cap, IOCap.display_only)],
-                  generic_wid_hdl=gap_wid_hdl_mode1_lvl4),
-        ZTestCase("GAP", "GAP/SEC/SEM/BV-41-C",
-                  cmds=pre_conditions + init_gatt_db +
-                  [TestFunc(btp.gap_set_io_cap, IOCap.display_only)],
-                  generic_wid_hdl=gap_wid_hdl),
-        ZTestCase("GAP", "GAP/SEC/SEM/BV-42-C",
-                  cmds=pre_conditions +
-                  [TestFunc(btp.gap_set_io_cap, IOCap.display_only)],
-                  generic_wid_hdl=gap_wid_hdl),
-        ZTestCase("GAP", "GAP/SEC/SEM/BV-43-C",
-                  cmds=pre_conditions + init_gatt_db +
-                  [TestFunc(btp.gap_set_io_cap, IOCap.display_only)],
-                  generic_wid_hdl=gap_wid_hdl_mode1_lvl2),
-        ZTestCase("GAP", "GAP/SEC/SEM/BV-44-C",
-                  cmds=pre_conditions + init_gatt_db +
-                  [TestFunc(btp.gap_set_io_cap, IOCap.display_only)],
-                  generic_wid_hdl=gap_wid_hdl_mode1_lvl4),
-        ZTestCase("GAP", "GAP/SEC/SEM/BV-58-C",
-                  cmds=pre_conditions +
-                  [TestFunc(btp.gap_set_io_cap, IOCap.display_only)],
-                  generic_wid_hdl=gap_wid_hdl),
-        ZTestCase("GAP", "GAP/SEC/SEM/BV-61-C",
-                  cmds=pre_conditions +
-                  [TestFunc(btp.gap_set_io_cap, IOCap.display_only)],
-                  generic_wid_hdl=gap_wid_hdl),
-        ZTestCase("GAP", "GAP/SEC/SEM/BI-09-C",
-                  cmds=pre_conditions +
-                  [TestFunc(btp.gap_set_io_cap, IOCap.display_only)],
-                  generic_wid_hdl=gap_wid_hdl),
-        ZTestCase("GAP", "GAP/SEC/SEM/BI-10-C",
-                  cmds=pre_conditions +
-                  [TestFunc(btp.gap_set_io_cap, IOCap.display_only)],
-                  generic_wid_hdl=gap_wid_hdl),
-        ZTestCase("GAP", "GAP/SEC/SEM/BI-20-C",
-                  cmds=pre_conditions +
-                  [TestFunc(btp.gap_set_io_cap, IOCap.display_only)],
-                  generic_wid_hdl=gap_wid_hdl),
-        ZTestCase("GAP", "GAP/SEC/SEM/BI-21-C",
-                  cmds=pre_conditions +
-                  [TestFunc(btp.gap_set_io_cap, IOCap.display_only)],
-                  generic_wid_hdl=gap_wid_hdl),
-        ZTestCase("GAP", "GAP/SEC/SEM/BI-22-C",
-                  cmds=pre_conditions +
-                  [TestFunc(btp.gap_set_io_cap, IOCap.display_only)],
-                  generic_wid_hdl=gap_wid_hdl),
-        ZTestCase("GAP", "GAP/SEC/SEM/BI-23-C",
-                  cmds=pre_conditions +
-                  [TestFunc(btp.gap_set_io_cap, IOCap.display_only)],
-                  generic_wid_hdl=gap_wid_hdl),
-        ZTestCase("GAP", "GAP/PRIV/CONN/BV-10-C",
-                  cmds=pre_conditions +
-                  [TestFunc(btp.gap_set_io_cap, IOCap.display_only)],
-                  generic_wid_hdl=gap_wid_hdl),
-        ZTestCase("GAP", "GAP/PRIV/CONN/BI-01-C",
-                  cmds=pre_conditions +
-                  [TestFunc(btp.gap_set_io_cap, IOCap.display_only)],
-                  generic_wid_hdl=gap_wid_hdl),
-        # GAP/GAT/BV-01-C
-        # wid: 158 description: IUT support both Central and Peripheral roles.
-        # Click Yes if IUT act as Central role to execute this test otherwise
-        # click No to act as Peripheral role.
-        #
-        # Testing central role.
-        ZTestCase("GAP", "GAP/GAT/BV-01-C",
-                  cmds=pre_conditions + init_gatt_db,
-                  generic_wid_hdl=gap_wid_hdl),
-        # Testing peripheral role.
-        ZTestCase("GAP", "GAP/GAT/BV-01-C",
-                  #   no_wid=158,
-                  cmds=pre_conditions + init_gatt_db,
+                  cmds=pre_conditions + init_gatt_db2,
                   generic_wid_hdl=gap_wid_hdl),
     ]
 
@@ -428,7 +223,7 @@ def test_cases(ptses):
 
     for tc_name in test_case_name_list:
         instance = ZTestCase('GAP', tc_name,
-                             cmds=pre_conditions,
+                             cmds=pre_conditions + init_gatt_db,
                              generic_wid_hdl=gap_wid_hdl)
 
         for custom_tc in custom_test_cases:

--- a/autopts/ptsprojects/zephyr/gap_wid.py
+++ b/autopts/ptsprojects/zephyr/gap_wid.py
@@ -16,8 +16,7 @@
 import logging
 import sys
 
-from autopts.pybtp import btp
-from autopts.wid.gap import gap_wid_hdl as gen_wid_hdl, hdl_wid_139_mode1_lvl2, hdl_wid_139_mode1_lvl4
+from autopts.wid.gap import gap_wid_hdl as gen_wid_hdl
 
 log = logging.debug
 
@@ -34,34 +33,11 @@ def gap_wid_hdl(wid, description, test_case_name):
         return gen_wid_hdl(wid, description, test_case_name, False)
 
 
-# For tests in SC only, mode 1 level 3
-def gap_wid_hdl_mode1_lvl2(wid, description, test_case_name):
-    if wid == 139:
-        log("%s, %r, %r, %s", gap_wid_hdl_mode1_lvl2.__name__, wid, description,
-            test_case_name)
-        return hdl_wid_139_mode1_lvl2(description)
-    return gap_wid_hdl(wid, description, test_case_name)
-
-
-def gap_wid_hdl_mode1_lvl4(wid, description, test_case_name):
-    if wid == 139:
-        log("%s, %r, %r, %s", gap_wid_hdl.__name__, wid, description,
-            test_case_name)
-        return hdl_wid_139_mode1_lvl4(description)
-    return gap_wid_hdl(wid, description, test_case_name)
-
-
 def hdl_wid_104(desc):
     return True
 
 
 def hdl_wid_114(desc):
-    return True
-
-
-def hdl_wid_127(desc):
-    btp.gap_conn_param_update(btp.pts_addr_get(), btp.pts_addr_type_get(),
-                              720, 864, 0, 400)
     return True
 
 

--- a/autopts/pybtp/types.py
+++ b/autopts/pybtp/types.py
@@ -273,6 +273,7 @@ att_rsp_str = {0: "",
                12: "encryption key size error",
                13: "Invalid attribute value length error",
                14: "unlikely error",
+               15: "insufficient encryption",
                128: "Application error",
                }
 


### PR DESCRIPTION
Use common settings reducing number of custom test cases and WIDs. Update generic WIDs handlers to PTS 8.4 requirements and make them more generic.