### PR TITLE
zephyr: Update overlays for LE Audio and MESH

### DIFF
--- a/autopts/bot/iut_config/zephyr.py
+++ b/autopts/bot/iut_config/zephyr.py
@@ -144,6 +144,24 @@ iut_config = {
             'L2CAP/TIM/BV-03-C',
         ]
     },
+
+    "overlay-le-audio.conf": {
+        "overlay": {
+            # The overlay file exists in zephyr repo. Leave this empty.
+        },
+        "test_cases": [
+            'VOCS', 'VCS', 'AICS', 'IAS', 'PACS',
+        ]
+    },
+
+    "overlay-mesh.conf": {
+        "overlay": {
+            # The overlay file exists in zephyr repo. Leave this empty.
+        },
+        "test_cases": [
+            'MESH'
+        ]
+    },
 }
 
 retry_config = {

--- a/autopts/bot/zephyr.py
+++ b/autopts/bot/zephyr.py
@@ -175,7 +175,7 @@ class ZephyrBotClient(BotClient):
         self.config_default = "prj.conf"
 
     def apply_config(self, args, config, value):
-        if 'overlay' in value:
+        if 'overlay' in value and len(value['overlay']):
             apply_overlay(args.project_path, config,
                           value['overlay'])
 


### PR DESCRIPTION
Overlays for LE Audio and MESH were moved out of prj.conf into separate files merged to Zephyr repo.