### PR TITLE
zephyr: Fix L2CAP/COS/ECFC/BV-04-C

### DIFF
--- a/autopts/ptsprojects/zephyr/l2cap.py
+++ b/autopts/ptsprojects/zephyr/l2cap.py
@@ -27,8 +27,7 @@ from autopts.ptsprojects.zephyr.ztestcase import ZTestCase
 le_psm = 128
 psm_unsupported = 241
 le_initial_mtu = 120
-le_initial_mtu_equal_mps = 69
-l2cap_mps = 69
+le_initial_mtu_equal_mps = 96
 
 
 def set_pixits(ptses):


### PR DESCRIPTION
This test requires sending connection request with MTU==MPS. On zephyr this value depend on configured buffer sizes. Since those depends on selected option we just use same fixed value that is configured in IUT.