### PR TITLE
bot: common: Handle existing "test_cases" in default config

### DIFF
--- a/autopts/bot/common.py
+++ b/autopts/bot/common.py
@@ -137,6 +137,10 @@ class BotClient(Client):
 
         # Distribute test cases among .conf files
         for config, value in list(self.iut_config.items()):
+            # Ignore default config here, it will receive all remaining test cases
+            if config == self.config_default:
+                continue
+
             # Merge .confs without 'test_cases' into the default one
             if 'test_cases' not in value:
                 # Rename default config


### PR DESCRIPTION
when generating the test case list. Use case used in iut_config/mynewt.py.