### PR TITLE
boards: nrf53: Remove leftover debug-overlay.conf

### DIFF
--- a/autopts/ptsprojects/boards/nrf53.py
+++ b/autopts/ptsprojects/boards/nrf53.py
@@ -35,7 +35,7 @@ def build_and_flash(zephyr_wd, board, debugger_snr, conf_file=None, *args):
     check_call('rm -rf build/'.split(), cwd=tester_dir)
     check_call('rm -rf build/'.split(), cwd=controller_dir)
 
-    bttester_overlay = 'nrf5340_hci_rpmsg.conf;./overlay-debug.conf'
+    bttester_overlay = 'nrf5340_hci_rpmsg.conf'
 
     if conf_file and conf_file != 'default' and conf_file != 'prj.conf':
         bttester_overlay += f';{conf_file}'


### PR DESCRIPTION
This overlay is not a part of Zephyr's repo.