### PR TITLE
iutctl_common.py: Fix encoding error

### DIFF
--- a/autopts/pybtp/iutctl_common.py
+++ b/autopts/pybtp/iutctl_common.py
@@ -19,6 +19,8 @@ import queue
 import socket
 import sys
 import threading
+import binascii
+
 
 from abc import abstractmethod
 
@@ -87,9 +89,10 @@ class BTPSocket:
             data_memview = data_memview[nbytes:]
             toread_data_len -= nbytes
 
-        tuple_data = bytes(str(dec_data(data)), 'utf-8').decode("unicode_escape").replace("b'", "'")
+        data_string = binascii.hexlify(data).decode('utf-8')
+        data_string = ' '.join(f'{data_string[i:i+2]}' for i in range(0, len(data_string), 2))
+        log(f"Received data: { {data_string} }, {data}")
 
-        log("Received data: %r, %r", tuple_data, data)
         self.conn.settimeout(None)
         return tuple_hdr, dec_data(data)
 


### PR DESCRIPTION
Error was occuring on machines with encoding cp1250:
 File "Python\Python310\lib\encodings\cp1250.py", line 19, in encode
     return codecs.charmap_encode(input,self.errors,encoding_table)[0]
     UnicodeEncodeError: 'charmap' codec can't encode character '\xf5'
     in position 16
     1: character maps to <undefined>