### PR TITLE
bot: Fix startup logging

### DIFF
--- a/autopts/client.py
+++ b/autopts/client.py
@@ -334,7 +334,8 @@ def init_logging(tag=""):
     logging.basicConfig(format=format_template,
                         filename=log_filename,
                         filemode='w',
-                        level=logging.DEBUG)
+                        level=logging.DEBUG,
+                        force=True)
 
 
 class FakeProxy:

--- a/autopts/ptsprojects/bluez/gap_wid.py
+++ b/autopts/ptsprojects/bluez/gap_wid.py
@@ -29,11 +29,12 @@ def gap_wid_hdl(wid, description, test_case_name):
     log("%s, %r, %r, %s", gap_wid_hdl.__name__, wid, description,
         test_case_name)
     module = sys.modules[__name__]
+    wid_str = f'hdl_wid_{wid}'
 
-    try:
-        handler = getattr(module, "hdl_wid_%d" % wid)
+    if hasattr(module, wid_str):
+        handler = getattr(module, wid_str)
         return handler(description)
-    except AttributeError:
+    else:
         return gen_wid_hdl(wid, description, test_case_name, False)
 
 

--- a/autopts/ptsprojects/bluez/sm_wid.py
+++ b/autopts/ptsprojects/bluez/sm_wid.py
@@ -26,11 +26,12 @@ def sm_wid_hdl(wid, description, test_case_name):
     log("%s, %r, %r, %s", sm_wid_hdl.__name__, wid, description,
         test_case_name)
     module = sys.modules[__name__]
+    wid_str = f'hdl_wid_{wid}'
 
-    try:
-        handler = getattr(module, "hdl_wid_%d" % wid)
+    if hasattr(module, wid_str):
+        handler = getattr(module, wid_str)
         return handler(description)
-    except AttributeError:
+    else:
         return gen_wid_hdl(wid, description, test_case_name, False)
 
 

--- a/autopts/ptsprojects/mynewt/gap_wid.py
+++ b/autopts/ptsprojects/mynewt/gap_wid.py
@@ -29,11 +29,12 @@ def gap_wid_hdl(wid, description, test_case_name):
     log("%s, %r, %r, %s", gap_wid_hdl.__name__, wid, description,
         test_case_name)
     module = sys.modules[__name__]
+    wid_str = f'hdl_wid_{wid}'
 
-    try:
-        handler = getattr(module, "hdl_wid_%d" % wid)
+    if hasattr(module, wid_str):
+        handler = getattr(module, wid_str)
         return handler(description)
-    except AttributeError:
+    else:
         return gen_wid_hdl(wid, description, test_case_name, False)
 
 

--- a/autopts/ptsprojects/mynewt/gatt_wid.py
+++ b/autopts/ptsprojects/mynewt/gatt_wid.py
@@ -36,11 +36,12 @@ def gatt_wid_hdl(wid, description, test_case_name):
     log("%s, %r, %r, %s", gatt_wid_hdl.__name__, wid, description,
         test_case_name)
     module = sys.modules[__name__]
+    wid_str = f'hdl_wid_{wid}'
 
-    try:
-        handler = getattr(module, "hdl_wid_%d" % wid)
+    if hasattr(module, wid_str):
+        handler = getattr(module, wid_str)
         return handler(description)
-    except AttributeError:
+    else:
         return gen_wid_hdl(wid, description, test_case_name, False)
 
 

--- a/autopts/ptsprojects/mynewt/gattc_wid.py
+++ b/autopts/ptsprojects/mynewt/gattc_wid.py
@@ -28,12 +28,13 @@ def gattc_wid_hdl(wid, description, test_case_name):
     log("%s, %r, %r, %s", gattc_wid_hdl.__name__, wid, description,
         test_case_name)
     module = sys.modules[__name__]
+    wid_str = f'hdl_wid_{wid}'
 
-    try:
-        handler = getattr(module, "hdl_wid_%d" % wid)
+    if hasattr(module, wid_str):
+        handler = getattr(module, wid_str)
         return handler(description)
-    except AttributeError:
-        return gatt_wid_hdl(wid, description, test_case_name)
+    else:
+        return gatt_wid_hdl(wid, description, test_case_name, False)
 
 
 def gattc_wid_hdl_no_read_long(wid, description, test_case_name):

--- a/autopts/ptsprojects/mynewt/sm_wid.py
+++ b/autopts/ptsprojects/mynewt/sm_wid.py
@@ -29,11 +29,12 @@ def sm_wid_hdl(wid, description, test_case_name):
     log("%s, %r, %r, %s", sm_wid_hdl.__name__, wid, description,
         test_case_name)
     module = sys.modules[__name__]
+    wid_str = f'hdl_wid_{wid}'
 
-    try:
-        handler = getattr(module, "hdl_wid_%d" % wid)
+    if hasattr(module, wid_str):
+        handler = getattr(module, wid_str)
         return handler(description)
-    except AttributeError:
+    else:
         return gen_wid_hdl(wid, description, test_case_name, False)
 
 

--- a/autopts/ptsprojects/zephyr/aics_wid.py
+++ b/autopts/ptsprojects/zephyr/aics_wid.py
@@ -22,14 +22,15 @@ from autopts.wid.aics import aics_wid_hdl as gen_wid_hdl
 
 log = logging.debug
 
+
 def aics_wid_hdl(wid, description, test_case_name):
     log("%s, %r, %r, %s", aics_wid_hdl.__name__, wid, description,
         test_case_name)
     module = sys.modules[__name__]
+    wid_str = f'hdl_wid_{wid}'
 
-    try:
-        handler = getattr(module, "hdl_wid_%d" % wid)
+    if hasattr(module, wid_str):
+        handler = getattr(module, wid_str)
         return handler(description)
-    except AttributeError:
+    else:
         return gen_wid_hdl(wid, description, test_case_name, False)
-

--- a/autopts/ptsprojects/zephyr/ascs_wid.py
+++ b/autopts/ptsprojects/zephyr/ascs_wid.py
@@ -25,9 +25,10 @@ def ascs_wid_hdl(wid, description, test_case_name):
     log("%s, %r, %r, %s", ascs_wid_hdl.__name__, wid, description,
         test_case_name)
     module = sys.modules[__name__]
+    wid_str = f'hdl_wid_{wid}'
 
-    try:
-        handler = getattr(module, "hdl_wid_%d" % wid)
+    if hasattr(module, wid_str):
+        handler = getattr(module, wid_str)
         return handler(description)
-    except AttributeError:
+    else:
         return gen_wid_hdl(wid, description, test_case_name, False)

--- a/autopts/ptsprojects/zephyr/bap_wid.py
+++ b/autopts/ptsprojects/zephyr/bap_wid.py
@@ -26,12 +26,10 @@ def bap_wid_hdl(wid, description, test_case_name):
     log("%s, %r, %r, %s", bap_wid_hdl.__name__, wid, description,
         test_case_name)
     module = sys.modules[__name__]
+    wid_str = f'hdl_wid_{wid}'
 
-    try:
-        handler = getattr(module, "hdl_wid_%d" % wid)
+    if hasattr(module, wid_str):
+        handler = getattr(module, wid_str)
         return handler(description)
-    except AttributeError:
+    else:
         return gen_wid_hdl(wid, description, test_case_name, False)
-
-
-

--- a/autopts/ptsprojects/zephyr/dis_wid.py
+++ b/autopts/ptsprojects/zephyr/dis_wid.py
@@ -26,9 +26,10 @@ def dis_wid_hdl(wid, description, test_case_name):
     log("%s, %r, %r, %s", dis_wid_hdl.__name__, wid, description,
         test_case_name)
     module = sys.modules[__name__]
+    wid_str = f'hdl_wid_{wid}'
 
-    try:
-        handler = getattr(module, "hdl_wid_%d" % wid)
+    if hasattr(module, wid_str):
+        handler = getattr(module, wid_str)
         return handler(description)
-    except AttributeError:
+    else:
         return gen_wid_hdl(wid, description, test_case_name, False)

--- a/autopts/ptsprojects/zephyr/gap_wid.py
+++ b/autopts/ptsprojects/zephyr/gap_wid.py
@@ -25,11 +25,12 @@ def gap_wid_hdl(wid, description, test_case_name):
     log("%s, %r, %r, %s", gap_wid_hdl.__name__, wid, description,
         test_case_name)
     module = sys.modules[__name__]
+    wid_str = f'hdl_wid_{wid}'
 
-    try:
-        handler = getattr(module, "hdl_wid_%d" % wid)
+    if hasattr(module, wid_str):
+        handler = getattr(module, wid_str)
         return handler(description)
-    except AttributeError:
+    else:
         return gen_wid_hdl(wid, description, test_case_name, False)
 
 

--- a/autopts/ptsprojects/zephyr/gatt_wid.py
+++ b/autopts/ptsprojects/zephyr/gatt_wid.py
@@ -18,13 +18,15 @@ import sys
 
 from autopts.wid.gatt import gatt_wid_hdl as gen_wid_hdl
 
+
 def gatt_wid_hdl(wid, description, test_case_name):
     logging.debug("%s, %r, %r, %s", gatt_wid_hdl.__name__, wid, description,
                   test_case_name)
     module = sys.modules[__name__]
+    wid_str = f'hdl_wid_{wid}'
 
-    try:
-        handler = getattr(module, "hdl_wid_%d" % wid)
+    if hasattr(module, wid_str):
+        handler = getattr(module, wid_str)
         return handler(description)
-    except AttributeError:
+    else:
         return gen_wid_hdl(wid, description, test_case_name, False)

--- a/autopts/ptsprojects/zephyr/ias_wid.py
+++ b/autopts/ptsprojects/zephyr/ias_wid.py
@@ -16,20 +16,21 @@
 import logging
 import sys
 
-log = logging.debug
-
 from autopts.pybtp import btp
 from autopts.pybtp.types import UUID
 from autopts.wid.ias import ias_wid_hdl as gen_wid_hdl
+
+log = logging.debug
+
 
 def ias_wid_hdl(wid, description, test_case_name):
     log("%s, %r, %r, %s", ias_wid_hdl.__name__, wid, description,
         test_case_name)
     module = sys.modules[__name__]
+    wid_str = f'hdl_wid_{wid}'
 
-    try:
-        handler = getattr(module, "hdl_wid_%d" % wid)
+    if hasattr(module, wid_str):
+        handler = getattr(module, wid_str)
         return handler(description)
-    except AttributeError:
+    else:
         return gen_wid_hdl(wid, description, test_case_name, False)
-

--- a/autopts/ptsprojects/zephyr/pacs_wid.py
+++ b/autopts/ptsprojects/zephyr/pacs_wid.py
@@ -25,9 +25,10 @@ def pacs_wid_hdl(wid, description, test_case_name):
     log("%s, %r, %r, %s", pacs_wid_hdl.__name__, wid, description,
         test_case_name)
     module = sys.modules[__name__]
+    wid_str = f'hdl_wid_{wid}'
 
-    try:
-        handler = getattr(module, "hdl_wid_%d" % wid)
+    if hasattr(module, wid_str):
+        handler = getattr(module, wid_str)
         return handler(description)
-    except AttributeError:
+    else:
         return gen_wid_hdl(wid, description, test_case_name, False)

--- a/autopts/ptsprojects/zephyr/sm_wid.py
+++ b/autopts/ptsprojects/zephyr/sm_wid.py
@@ -27,11 +27,12 @@ def sm_wid_hdl(wid, description, test_case_name):
     log("%s, %r, %r, %s", sm_wid_hdl.__name__, wid, description,
         test_case_name)
     module = sys.modules[__name__]
+    wid_str = f'hdl_wid_{wid}'
 
-    try:
-        handler = getattr(module, "hdl_wid_%d" % wid)
+    if hasattr(module, wid_str):
+        handler = getattr(module, wid_str)
         return handler(description)
-    except AttributeError:
+    else:
         return gen_wid_hdl(wid, description, test_case_name, False)
 
 

--- a/autopts/ptsprojects/zephyr/vcs_wid.py
+++ b/autopts/ptsprojects/zephyr/vcs_wid.py
@@ -22,13 +22,15 @@ from autopts.wid.vcs import vcs_wid_hdl as gen_wid_hdl
 
 log = logging.debug
 
+
 def vcs_wid_hdl(wid, description, test_case_name):
     log("%s, %r, %r, %s", vcs_wid_hdl.__name__, wid, description,
         test_case_name)
     module = sys.modules[__name__]
+    wid_str = f'hdl_wid_{wid}'
 
-    try:
-        handler = getattr(module, "hdl_wid_%d" % wid)
+    if hasattr(module, wid_str):
+        handler = getattr(module, wid_str)
         return handler(description)
-    except AttributeError:
+    else:
         return gen_wid_hdl(wid, description, test_case_name, False)

--- a/autopts/ptsprojects/zephyr/vocs_wid.py
+++ b/autopts/ptsprojects/zephyr/vocs_wid.py
@@ -22,13 +22,15 @@ from autopts.wid.vocs import vocs_wid_hdl as gen_wid_hdl
 
 log = logging.debug
 
+
 def vocs_wid_hdl(wid, description, test_case_name):
     log("%s, %r, %r, %s", vocs_wid_hdl.__name__, wid, description,
         test_case_name)
     module = sys.modules[__name__]
+    wid_str = f'hdl_wid_{wid}'
 
-    try:
-        handler = getattr(module, "hdl_wid_%d" % wid)
+    if hasattr(module, wid_str):
+        handler = getattr(module, wid_str)
         return handler(description)
-    except AttributeError:
+    else:
         return gen_wid_hdl(wid, description, test_case_name, False)

--- a/autoptsclient_bot.py
+++ b/autoptsclient_bot.py
@@ -25,11 +25,13 @@ import schedule
 import importlib
 from argparse import ArgumentParser, RawTextHelpFormatter, SUPPRESS
 
-from autopts.client import set_end
+from autopts.client import set_end, init_logging
 from autopts.bot.config import BotProjects
 from autopts.bot.zephyr import main as zephyr
 from autopts.bot.mynewt import main as mynewt
 from autopts.winutils import have_admin_rights
+
+log = logging.debug
 
 # TODO Find more sophisticated way
 weekdays2schedule = {
@@ -88,6 +90,8 @@ def main():
     # which occurs under Windows with default encoding other than cp1252
     # each time log() is called.
     _locale._getdefaultlocale = (lambda *arg: ['en_US', 'utf8'])
+
+    init_logging('_startup')
 
     bot_projects = []
     parents = []


### PR DESCRIPTION
First init_loggingi() was not called unitl a process reached init_pts() in client.py. Any debug log before the call was skipped. If any error log was called, then all error logs was printed into console output, even after init_logging() call.