### PR TITLE
bot: server: Add swap_ets option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@
 */client_secret.json
 */credentials.json
 autopts/bot/config.py
+*.ets

--- a/autopts/bot/common.py
+++ b/autopts/bot/common.py
@@ -103,6 +103,7 @@ class BotConfigArgs(Namespace):
         self.superguard = float(args.get('superguard', 0))
         self.cron_optim = args.get('cron_optim', False)
         self.project_repos = args.get('repos', None)
+        self.swap_ets = args.get('swap_ets', False)
 
 
 class BotClient(Client):

--- a/autopts/utils.py
+++ b/autopts/utils.py
@@ -16,10 +16,12 @@
 
 """Utilities"""
 import ctypes
+import multiprocessing
 import os
 import subprocess
 import sys
 import threading
+from ctypes import wintypes
 
 PTS_WORKSPACE_FILE_EXT = ".pqw6"
 
@@ -89,3 +91,128 @@ def get_own_workspaces():
                 workspaces[name] = path
 
     return workspaces
+
+
+# ****************************************************************************
+# .ets swapper
+# ****************************************************************************
+def swap_etses(ptses, test_cases, revert):
+    """
+    Swap original .ets files with the ones from local ets/ folder,
+    i.e. GAP.ets, GATT.ets. The ets/GAP_CONN_ACEP_BV_01_C.ets will
+    be swapped with original GAP.ets
+
+    Set revert=True to undo the swap.
+
+    For the swap to work, the autoptsserver.py has to be run with the
+    admin rights.
+    """
+    result = False
+
+    if type(test_cases) == str:
+        # Test case level swap
+        result = ptses[0].swap_ets(test_cases, revert)
+    else:
+        # Project level swap
+        stack_parts = {}
+        for tc in test_cases:
+            key, *_ = tc.split('/')
+            stack_parts[key] = 1
+
+        stack_parts = stack_parts.keys()
+
+        # For GAP, GATT, etc. ...
+        for p in stack_parts:
+            result = result or ptses[0].swap_ets(p, revert)
+
+    return result
+
+
+def win32_is_file_in_use(filepath):
+    ntdll = ctypes.WinDLL('ntdll')
+    kernel32 = ctypes.WinDLL('kernel32', use_last_error=True)
+
+    NTSTATUS = wintypes.LONG
+    INVALID_HANDLE_VALUE = wintypes.HANDLE(-1).value
+    FILE_READ_ATTRIBUTES = 0x80
+    FILE_SHARE_READ = 1
+    OPEN_EXISTING = 3
+    FILE_FLAG_BACKUP_SEMANTICS = 0x02000000
+    FILE_INFORMATION_CLASS = wintypes.ULONG
+    FileProcessIdsUsingFileInformation = 47
+    LPSECURITY_ATTRIBUTES = wintypes.LPVOID
+    ULONG_PTR = wintypes.WPARAM
+
+    # -----------------------------------------------------------------------------
+    # create handle on concerned file with dwDesiredAccess == FILE_READ_ATTRIBUTES
+    # -----------------------------------------------------------------------------
+
+    kernel32.CreateFileW.restype = wintypes.HANDLE
+    kernel32.CreateFileW.argtypes = (
+        wintypes.LPCWSTR,  # In     lpFileName
+        wintypes.DWORD,  # In     dwDesiredAccess
+        wintypes.DWORD,  # In     dwShareMode
+        LPSECURITY_ATTRIBUTES,  # In_opt lpSecurityAttributes
+        wintypes.DWORD,  # In     dwCreationDisposition
+        wintypes.DWORD,  # In     dwFlagsAndAttributes
+        wintypes.HANDLE)  # In_opt hTemplateFile
+    hFile = kernel32.CreateFileW(
+        filepath, FILE_READ_ATTRIBUTES, FILE_SHARE_READ, None, OPEN_EXISTING,
+        FILE_FLAG_BACKUP_SEMANTICS, None)
+    if hFile == INVALID_HANDLE_VALUE:
+        raise ctypes.WinError(ctypes.get_last_error())
+
+    # -----------------------------------------------------------------------------
+    # prepare data types for system call
+    # -----------------------------------------------------------------------------
+
+    class IO_STATUS_BLOCK(ctypes.Structure):
+        class _STATUS(ctypes.Union):
+            _fields_ = (('Status', NTSTATUS),
+                        ('Pointer', wintypes.LPVOID))
+
+        _anonymous_ = '_Status',
+        _fields_ = (('_Status', _STATUS),
+                    ('Information', ULONG_PTR))
+
+    iosb = IO_STATUS_BLOCK()
+
+    class FILE_PROCESS_IDS_USING_FILE_INFORMATION(ctypes.Structure):
+        _fields_ = (('NumberOfProcessIdsInList', wintypes.LARGE_INTEGER),
+                    ('ProcessIdList', wintypes.LARGE_INTEGER * 64))
+
+    info = FILE_PROCESS_IDS_USING_FILE_INFORMATION()
+
+    PIO_STATUS_BLOCK = ctypes.POINTER(IO_STATUS_BLOCK)
+    ntdll.NtQueryInformationFile.restype = NTSTATUS
+    ntdll.NtQueryInformationFile.argtypes = (
+        wintypes.HANDLE,  # In  FileHandle
+        PIO_STATUS_BLOCK,  # Out IoStatusBlock
+        wintypes.LPVOID,  # Out FileInformation
+        wintypes.ULONG,  # In  Length
+        FILE_INFORMATION_CLASS)  # In  FileInformationClass
+
+    # -----------------------------------------------------------------------------
+    # system call to retrieve list of PIDs currently using the file
+    # -----------------------------------------------------------------------------
+    status = ntdll.NtQueryInformationFile(hFile, ctypes.byref(iosb),
+                                          ctypes.byref(info),
+                                          ctypes.sizeof(info),
+                                          FileProcessIdsUsingFileInformation)
+    pidList = info.ProcessIdList[0:info.NumberOfProcessIdsInList]
+    process_pid = multiprocessing.current_process().pid
+    if process_pid in pidList:
+        pidList.remove(process_pid)
+
+    return len(pidList) > 0
+
+
+# 10x faster than win32_is_file_in_use, but less secure when interrupted
+def is_file_in_use(filepath):
+    try:
+        os.rename(filepath, filepath + "_")
+        os.rename(filepath + "_", filepath)
+    except:
+        return True
+
+    return False

--- a/autoptsserver.py
+++ b/autoptsserver.py
@@ -424,7 +424,6 @@ def multi_main(_args, _superguard):
 
 
 if __name__ == "__main__":
-    winutils.exit_if_admin()
     _args = SvrArgumentParser("PTS automation server").parse_args()
 
     script_name = os.path.basename(sys.argv[0])  # in case it is full path


### PR DESCRIPTION
Experimental feature for swapping original .ets files with those received in PTS errata requests.
Ready for testing, but let's keep it draft for a while.

To use, enable the option in config.py in 
z['auto_pts']  = {
...
    'swap_ets': True,
}

Then put inside the ets/ folder your errata .ets files, i.e.:
ets
├── BAP.ets
├── BAP_UCL_SCC_BV_033_C.ets
└── GAP.ets