### PR TITLE
zephyr: Fix GATT/SR/GAW/BI-33-C

### DIFF
--- a/autopts/ptsprojects/zephyr/gatt.py
+++ b/autopts/ptsprojects/zephyr/gatt.py
@@ -36,8 +36,8 @@ class Value:
     long_2 = eight_bytes_2 * 4
     long_3 = eight_bytes_2 * 7
     long_4 = one_byte_1 * 64
-    long_5 = one_byte_2 * 512
-    long_6 = eight_bytes_1 * 10
+    long_5 = eight_bytes_1 * 10
+    long_6 = one_byte_2 * 512
 
 
 def update_service_gatt_sr_gas_bv_01_c():


### PR DESCRIPTION
GATT/SR/GAW/BI-33-C is using first available long write characteristic andrequires <512 bytes of value data. While GATT/SR/GAW/BV-12-C and GATT/SR/GAW/BV-14-C require exactly 512 value data, in those tests PTS is first looking for valid characteristic (via long reads). So to make all tests happy just declare <512 value characteristic first.