### PR TITLE
Path error for format specifier in gatt.py.

### DIFF
--- a/autopts/pybtp/btp/gatt.py
+++ b/autopts/pybtp/btp/gatt.py
@@ -1578,7 +1578,7 @@ def gattc_disc_all_desc_rsp(store_rsp=False):
         clear_verify_values()
 
         for desc in descs:
-            handle = f'{desc.handle:%04X}'
+            handle = f'{desc.handle:04X}'
             uuid = desc.uuid
             add_to_verify_values(handle)
             add_to_verify_values(uuid)


### PR DESCRIPTION
Fix error for format specifier in autopts/pybtp/gatt.py. GATT/CL/GAD/BV-06-C is failing because of this.