### PR TITLE
wids: Fix wid import in generic wid

### DIFF
--- a/autopts/wid/wid.py
+++ b/autopts/wid/wid.py
@@ -1,3 +1,4 @@
+import importlib
 import logging
 import sys
 from ..ptsprojects.stack import get_stack
@@ -11,7 +12,7 @@ def _generic_wid_hdl(wid, description, test_case_name, module_names):
     wid_str = f'hdl_wid_{wid}'
 
     for module_name in module_names:
-        module = sys.modules[module_name]
+        module = importlib.import_module(module_name)
         if hasattr(module, wid_str):
             wid_hdl = getattr(module, wid_str)
             break


### PR DESCRIPTION
sys.modules contains already imported modules, but will not import a new one.