### PR TITLE
boards: nrf53: Use fixed value for BT_BUF_ACL_RX_SIZE in overlay

### DIFF
--- a/autopts/ptsprojects/boards/nrf53.py
+++ b/autopts/ptsprojects/boards/nrf53.py
@@ -44,11 +44,8 @@ def build_and_flash(zephyr_wd, board, debugger_snr, conf_file=None, *args):
     check_call(cmd, cwd=tester_dir)
     check_call(['west', 'flash', '--skip-rebuild', '--recover', '-i', debugger_snr], cwd=tester_dir)
 
-    controller_overlay = 'bttester_hci_rpmsg_overlay.conf'
-    check_call(f'echo CONFIG_BT_CTLR_CONN_ISO_LOW_LATENCY_POLICY=y > {controller_overlay}'.split(),
-               cwd=controller_dir)
-
     cmd = ['west', 'build', '-b', 'nrf5340dk_nrf5340_cpunet', '--',
-           f'-DOVERLAY_CONFIG=\'nrf5340_cpunet_iso-bt_ll_sw_split.conf;{controller_overlay}\'']
+           f'-DOVERLAY_CONFIG=\'nrf5340_cpunet_iso-bt_ll_sw_split.conf;'
+           f'../../../tests/bluetooth/tester/nrf5340_hci_rpmsg_cpunet.conf\'']
     check_call(cmd, cwd=controller_dir)
     check_call(['west', 'flash', '--skip-rebuild', '-i', debugger_snr], cwd=controller_dir)


### PR DESCRIPTION
To meet common PTS configuration requirements, the default value of BT_BUF_ACL_RX_SIZE is assigned a fixed value 100. However, it is overwritten as 255 in bttester nrf53 overlay config. Since Zephyr L2CAP COC MPS depends on this config value, several L2CAP qualification test cases are affected, incl. L2CAP/COS/CFC/BV-03-C, L2CAP/COS/ECFC/BV-02-C, L2CAP/COS/ECFC/BV-04-C, L2CAP/ECFC/BV-22-C.

To fix the above failed tests on nrf53, reset the value of BT_BUF_ACL_RX_SIZE to 100 in building.