### PR TITLE
iutctl: Fix infinite loop when reading frame data from socket

### DIFF
--- a/autopts/pybtp/iutctl_common.py
+++ b/autopts/pybtp/iutctl_common.py
@@ -86,6 +86,9 @@ class BTPSocket:
         # Gather optional frame data
         while toread_data_len:
             nbytes = self.conn.recv_into(data_memview, toread_data_len)
+            logging.debug("Read %d bytes data", nbytes)
+            if nbytes == 0 and toread_data_len != 0:
+                raise socket.error
             data_memview = data_memview[nbytes:]
             toread_data_len -= nbytes
 


### PR DESCRIPTION
Sometimes the socket reading task would get stuck in an infinite loop. This issue has been handled for the frame header reading but not for the frame data, which may affect GATT/SR/GAW/BV-14-C on nRF53.