### PR TITLE
bot: mynewt: Fix setting privacy for GAP/CONN/ACEP/BV-03-C

### DIFF
--- a/autopts/bot/iut_config/mynewt.py
+++ b/autopts/bot/iut_config/mynewt.py
@@ -26,7 +26,7 @@ iut_config = {
         "overlay": {'BTTESTER_PRIVACY_MODE': '1'},
         "test_cases": [
             'GAP/BROB/BCST/BV-03-C',
-            'GAP/BROB/BCST/BV-05-C'
+            'GAP/BROB/BCST/BV-05-C',
             'GAP/CONN/ACEP/BV-03-C',
             'GAP/CONN/ACEP/BV-04-C',
             'GAP/CONN/DCEP/BV-05-C',


### PR DESCRIPTION
Privacy was not set for this test because of lacking coma in the preceding line.