### PR TITLE
SM: fix SM/CEN/PKE/BI-02-C

### DIFF
--- a/autopts/wid/sm.py
+++ b/autopts/wid/sm.py
@@ -187,7 +187,10 @@ def hdl_wid_149(params: WIDParams):
 
 
 def hdl_wid_152(_: WIDParams):
-    return True
+    """
+    Lower tester expects IUT aborts pairing process. Click Yes to confirm pairing aborted.
+    """
+    return btp.gap_wait_for_pairing_fail()
 
 
 def hdl_wid_154(_: WIDParams):


### PR DESCRIPTION
In TS there is no disconnection requirement here. We should confirm that pairing aborted (failed).