### PR TITLE
boards: Strict a serial number to be only numeric

### DIFF
--- a/autopts/ptsprojects/boards/__init__.py
+++ b/autopts/ptsprojects/boards/__init__.py
@@ -150,7 +150,7 @@ def get_free_device(board=None):
     devices = get_device_list()
 
     for tty, snr in devices.items():
-        if tty not in devices_in_use:
+        if tty not in devices_in_use and len(snr) >= 9 and snr.isnumeric():
             devices_in_use.append(tty)
             return tty, snr
 


### PR DESCRIPTION
The implementation of get_free_device is pretty naive and takes a first found COM serial device if only it has any serial number. Because the JLink serial numbers as far were only numeric and recently supported boards has serial numbers with length >=9, we can improve the function a little.