### PR TITLE
autoptsserver: Fix recovery request

### DIFF
--- a/autoptsserver_requirements.txt
+++ b/autoptsserver_requirements.txt
@@ -1,3 +1,4 @@
 wmi
 pywin32
 utils
+psutil


### PR DESCRIPTION
After a PTS recovery request sent by a client, the recovery flag was not cleared. After a server recovery request, the dongle selected during initialization was forgotten, causing the YKUSH to reattach the wrong dongle.