### PR TITLE
pixits: Remove the TSPX_tester_database_file setting

### DIFF
--- a/autopts/ptsprojects/mynewt/gatt.py
+++ b/autopts/ptsprojects/mynewt/gatt.py
@@ -124,10 +124,6 @@ def set_pixits(ptses):
     pts.set_pixit("GATT", "TSPX_secure_simple_pairing_pass_key_confirmation", "FALSE")
     pts.set_pixit("GATT", "TSPX_iut_use_dynamic_bd_addr", "FALSE")
     pts.set_pixit("GATT", "TSPX_iut_setup_att_over_br_edr", "FALSE")
-    pts.set_pixit(
-        "GATT",
-        "TSPX_tester_database_file",
-        r"C:\Program Files\Bluetooth SIG\Bluetooth PTS\Data\SIGDatabase\GATT_Qualification_Test_Databases.xml")
     pts.set_pixit("GATT", "TSPX_iut_is_client_periphral", "FALSE")
     pts.set_pixit("GATT", "TSPX_iut_is_server_central", "FALSE")
     pts.set_pixit("GATT", "TSPX_mtu_size", "23")

--- a/autopts/ptsprojects/mynewt/mesh.py
+++ b/autopts/ptsprojects/mynewt/mesh.py
@@ -43,8 +43,6 @@ def set_pixits(ptses):
     pts.set_pixit("MESH", "TSPX_bd_addr_additional_filter_accept_list", "")
     pts.set_pixit("MESH", "TSPX_time_guard", "300000")
     pts.set_pixit("MESH", "TSPX_use_implicit_send", "TRUE")
-    pts.set_pixit("MESH", "TSPX_tester_database_file",
-                  r"C:\Program Files\Bluetooth SIG\Bluetooth PTS\Data\SIGDatabase\PTS_SMPP_db.xml")
     pts.set_pixit("MESH", "TSPX_mtu_size", "23")
     pts.set_pixit("MESH", "TSPX_delete_link_key", "TRUE")
     pts.set_pixit("MESH", "TSPX_delete_ltk", "TRUE")
@@ -92,8 +90,6 @@ def set_pixits(ptses):
     pts2.set_pixit("MESH", "TSPX_bd_addr_additional_filter_accept_list", "")
     pts2.set_pixit("MESH", "TSPX_time_guard", "300000")
     pts2.set_pixit("MESH", "TSPX_use_implicit_send", "TRUE")
-    pts2.set_pixit("MESH", "TSPX_tester_database_file",
-                   r"C:\Program Files\Bluetooth SIG\Bluetooth PTS\Data\SIGDatabase\PTS_SMPP_db.xml")
     pts2.set_pixit("MESH", "TSPX_mtu_size", "23")
     pts2.set_pixit("MESH", "TSPX_delete_link_key", "TRUE")
     pts2.set_pixit("MESH", "TSPX_delete_ltk", "TRUE")

--- a/autopts/ptsprojects/zephyr/aics.py
+++ b/autopts/ptsprojects/zephyr/aics.py
@@ -39,10 +39,6 @@ def set_pixits(ptses):
     pts.set_pixit("AICS", "TSPX_iut_device_name_in_adv_packet_for_random_address", "")
     pts.set_pixit("AICS", "TSPX_time_guard", "180000")
     pts.set_pixit("AICS", "TSPX_use_implicit_send", "TRUE")
-    pts.set_pixit(
-        "VCS",
-        "TSPX_tester_database_file",
-        r"C:\Program Files\Bluetooth SIG\Bluetooth PTS\Data\SIGDatabase\PTS_PXP_db")
     pts.set_pixit("AICS", "TSPX_mtu_size", "23")
     pts.set_pixit("AICS", "TSPX_secure_simple_pairing_pass_key_confirmation", "FALSE")
     pts.set_pixit("AICS", "TSPX_delete_link_key", "FALSE")

--- a/autopts/ptsprojects/zephyr/ascs.py
+++ b/autopts/ptsprojects/zephyr/ascs.py
@@ -39,10 +39,6 @@ def set_pixits(ptses):
     pts.set_pixit("ASCS", "TSPX_iut_device_name_in_adv_packet_for_random_address", "")
     pts.set_pixit("ASCS", "TSPX_time_guard", "180000")
     pts.set_pixit("ASCS", "TSPX_use_implicit_send", "TRUE")
-    pts.set_pixit(
-        "ASCS",
-        "TSPX_tester_database_file",
-        r"C:\Program Files\Bluetooth SIG\Bluetooth PTS\Data\SIGDatabase\PTS_PXP_db")
     pts.set_pixit("ASCS", "TSPX_secure_simple_pairing_pass_key_confirmation", "FALSE")
     pts.set_pixit("ASCS", "TSPX_delete_link_key", "FALSE")
     pts.set_pixit("ASCS", "TSPX_pin_code", "0000")

--- a/autopts/ptsprojects/zephyr/bap.py
+++ b/autopts/ptsprojects/zephyr/bap.py
@@ -39,10 +39,6 @@ def set_pixits(ptses):
     pts.set_pixit("BAP", "TSPX_iut_device_name_in_adv_packet_for_random_address", "")
     pts.set_pixit("BAP", "TSPX_time_guard", "180000")
     pts.set_pixit("BAP", "TSPX_use_implicit_send", "TRUE")
-    pts.set_pixit(
-        "BAP",
-        "TSPX_tester_database_file",
-        r"C:\Program Files\Bluetooth SIG\Bluetooth PTS\Data\SIGDatabase\PTS_PXP_db")
     pts.set_pixit("BAP", "TSPX_mtu_size", "64")
     pts.set_pixit("BAP", "TSPX_secure_simple_pairing_pass_key_confirmation", "FALSE")
     pts.set_pixit("BAP", "TSPX_delete_link_key", "FALSE")

--- a/autopts/ptsprojects/zephyr/dis.py
+++ b/autopts/ptsprojects/zephyr/dis.py
@@ -75,8 +75,6 @@ def set_pixits(ptses):
     pts.set_pixit("DIS", "TSPX_iut_device_name_in_adv_packet_for_random_address", "")
     pts.set_pixit("DIS", "TSPX_time_guard", "180000")
     pts.set_pixit("DIS", "TSPX_use_implicit_send", "TRUE")
-    pts.set_pixit("DIS", "TSPX_tester_database_file",
-                  r"C:\Program Files\Bluetooth SIG\Bluetooth PTS\Data\SIGDatabase\PS_DIS.xml")
     pts.set_pixit("DIS", "TSPX_mtu_size", "23")
     pts.set_pixit("DIS", "TSPX_secure_simple_pairing_pass_key_confirmation", "FALSE")
     pts.set_pixit("DIS", "TSPX_delete_link_key", "TRUE")

--- a/autopts/ptsprojects/zephyr/gatt.py
+++ b/autopts/ptsprojects/zephyr/gatt.py
@@ -110,10 +110,6 @@ def set_pixits(ptses):
     pts.set_pixit("GATT", "TSPX_use_implicit_send", "TRUE")
     pts.set_pixit("GATT", "TSPX_iut_use_dynamic_bd_addr", "FALSE")
     pts.set_pixit("GATT", "TSPX_iut_setup_att_over_br_edr", "FALSE")
-    pts.set_pixit(
-        "GATT",
-        "TSPX_tester_database_file",
-        r"C:\Program Files\Bluetooth SIG\Bluetooth PTS\Data\SIGDatabase\GATT_Qualification_Test_Databases.xml")
     pts.set_pixit("GATT", "TSPX_iut_is_client_periphral", "TRUE")
     pts.set_pixit("GATT", "TSPX_iut_is_server_central", "FALSE")
     pts.set_pixit("GATT", "TSPX_mtu_size", "23")
@@ -136,10 +132,6 @@ def set_pixits(ptses):
     pts2.set_pixit("GATT", "TSPX_use_implicit_send", "TRUE")
     pts2.set_pixit("GATT", "TSPX_iut_use_dynamic_bd_addr", "FALSE")
     pts2.set_pixit("GATT", "TSPX_iut_setup_att_over_br_edr", "FALSE")
-    pts2.set_pixit(
-        "GATT",
-        "TSPX_tester_database_file",
-        r"C:\Program Files\Bluetooth SIG\Bluetooth PTS\Data\SIGDatabase\GATT_Qualification_Test_Databases.xml")
     pts2.set_pixit("GATT", "TSPX_iut_is_client_periphral", "TRUE")
     pts2.set_pixit("GATT", "TSPX_iut_is_server_central", "FALSE")
     pts2.set_pixit("GATT", "TSPX_mtu_size", "23")

--- a/autopts/ptsprojects/zephyr/has.py
+++ b/autopts/ptsprojects/zephyr/has.py
@@ -40,8 +40,6 @@ def set_pixits(ptses):
     pts.set_pixit("HAS", "TSPX_iut_device_name_in_adv_packet_for_random_address", "")
     pts.set_pixit("HAS", "TSPX_time_guard", "180000")
     pts.set_pixit("HAS", "TSPX_use_implicit_send", "TRUE")
-    pts.set_pixit("HAS", "TSPX_tester_database_file",
-        r"C:\Program Files\Bluetooth SIG\Bluetooth PTS\Data\SIGDatabase\PTS_PXP_db")
     pts.set_pixit("HAS", "TSPX_mtu_size", "49")
     pts.set_pixit("HAS", "TSPX_secure_simple_pairing_pass_key_confirmation", "FALSE")
     pts.set_pixit("HAS", "TSPX_delete_link_key", "FALSE")

--- a/autopts/ptsprojects/zephyr/ias.py
+++ b/autopts/ptsprojects/zephyr/ias.py
@@ -38,10 +38,6 @@ def set_pixits(ptses):
     pts.set_pixit("IAS", "TSPX_iut_device_name_in_adv_packet_for_random_address", "")
     pts.set_pixit("IAS", "TSPX_time_guard", "180000")
     pts.set_pixit("IAS", "TSPX_use_implicit_send", "TRUE")
-    pts.set_pixit(
-        "VCS",
-        "TSPX_tester_database_file",
-        r"C:\Program Files\Bluetooth SIG\Bluetooth PTS\Data\SIGDatabase\PTS_PXP_db")
     pts.set_pixit("IAS", "TSPX_mtu_size", "23")
     pts.set_pixit("IAS", "TSPX_secure_simple_pairing_pass_key_confirmation", "FALSE")
     pts.set_pixit("IAS", "TSPX_delete_link_key", "FALSE")

--- a/autopts/ptsprojects/zephyr/mesh.py
+++ b/autopts/ptsprojects/zephyr/mesh.py
@@ -43,8 +43,6 @@ def set_pixits(ptses):
     pts.set_pixit("MESH", "TSPX_bd_addr_additional_filter_accept_list", "")
     pts.set_pixit("MESH", "TSPX_time_guard", "300000")
     pts.set_pixit("MESH", "TSPX_use_implicit_send", "TRUE")
-    pts.set_pixit("MESH", "TSPX_tester_database_file",
-                  r"C:\Program Files\Bluetooth SIG\Bluetooth PTS\Data\SIGDatabase\PTS_SMPP_db.xml")
     pts.set_pixit("MESH", "TSPX_mtu_size", "23")
     pts.set_pixit("MESH", "TSPX_delete_link_key", "TRUE")
     pts.set_pixit("MESH", "TSPX_delete_ltk", "TRUE")
@@ -101,8 +99,6 @@ def set_pixits(ptses):
     pts2.set_pixit("MESH", "TSPX_bd_addr_additional_filter_accept_list", "")
     pts2.set_pixit("MESH", "TSPX_time_guard", "300000")
     pts2.set_pixit("MESH", "TSPX_use_implicit_send", "TRUE")
-    pts2.set_pixit("MESH", "TSPX_tester_database_file",
-                   r"C:\Program Files\Bluetooth SIG\Bluetooth PTS\Data\SIGDatabase\PTS_SMPP_db.xml")
     pts2.set_pixit("MESH", "TSPX_mtu_size", "23")
     pts2.set_pixit("MESH", "TSPX_delete_link_key", "TRUE")
     pts2.set_pixit("MESH", "TSPX_delete_ltk", "TRUE")

--- a/autopts/ptsprojects/zephyr/mmdl.py
+++ b/autopts/ptsprojects/zephyr/mmdl.py
@@ -42,8 +42,6 @@ def set_pixits(ptses):
     pts.set_pixit("MMDL", "TSPX_bd_addr_iut", "DEADBEEFDEAD")
     pts.set_pixit("MMDL", "TSPX_time_guard", "300000")
     pts.set_pixit("MMDL", "TSPX_use_implicit_send", "TRUE")
-    pts.set_pixit("MMDL", "TSPX_tester_database_file",
-                  r"C:\Program Files\Bluetooth SIG\Bluetooth PTS\Data\SIGDatabase\PTS_SMPP_db.xml")
     pts.set_pixit("MMDL", "TSPX_mtu_size", "23")
     pts.set_pixit("MMDL", "TSPX_delete_link_key", "TRUE")
     pts.set_pixit("MMDL", "TSPX_delete_ltk", "TRUE")

--- a/autopts/ptsprojects/zephyr/pacs.py
+++ b/autopts/ptsprojects/zephyr/pacs.py
@@ -38,10 +38,6 @@ def set_pixits(ptses):
     pts.set_pixit("PACS", "TSPX_iut_device_name_in_adv_packet_for_random_address", "")
     pts.set_pixit("PACS", "TSPX_time_guard", "180000")
     pts.set_pixit("PACS", "TSPX_use_implicit_send", "TRUE")
-    pts.set_pixit(
-        "PACS",
-        "TSPX_tester_database_file",
-        r"C:\Program Files\Bluetooth SIG\Bluetooth PTS\Data\SIGDatabase\PTS_PXP_db")
     pts.set_pixit("PACS", "TSPX_mtu_size", "60")
     pts.set_pixit("PACS", "TSPX_secure_simple_pairing_pass_key_confirmation", "FALSE")
     pts.set_pixit("PACS", "TSPX_delete_link_key", "FALSE")

--- a/autopts/ptsprojects/zephyr/vcs.py
+++ b/autopts/ptsprojects/zephyr/vcs.py
@@ -39,10 +39,6 @@ def set_pixits(ptses):
     pts.set_pixit("VCS", "TSPX_iut_device_name_in_adv_packet_for_random_address", "")
     pts.set_pixit("VCS", "TSPX_time_guard", "180000")
     pts.set_pixit("VCS", "TSPX_use_implicit_send", "TRUE")
-    pts.set_pixit(
-        "VCS",
-        "TSPX_tester_database_file",
-        r"C:\Program Files\Bluetooth SIG\Bluetooth PTS\Data\SIGDatabase\PTS_PXP_db")
     pts.set_pixit("VCS", "TSPX_mtu_size", "23")
     pts.set_pixit("VCS", "TSPX_secure_simple_pairing_pass_key_confirmation", "FALSE")
     pts.set_pixit("VCS", "TSPX_delete_link_key", "FALSE")

--- a/autopts/ptsprojects/zephyr/vocs.py
+++ b/autopts/ptsprojects/zephyr/vocs.py
@@ -38,10 +38,6 @@ def set_pixits(ptses):
     pts.set_pixit("VOCS", "TSPX_iut_device_name_in_adv_packet_for_random_address", "")
     pts.set_pixit("VOCS", "TSPX_time_guard", "180000")
     pts.set_pixit("VOCS", "TSPX_use_implicit_send", "TRUE")
-    pts.set_pixit(
-        "VCS",
-        "TSPX_tester_database_file",
-        r"C:\Program Files\Bluetooth SIG\Bluetooth PTS\Data\SIGDatabase\PTS_PXP_db")
     pts.set_pixit("VOCS", "TSPX_mtu_size", "23")
     pts.set_pixit("VOCS", "TSPX_secure_simple_pairing_pass_key_confirmation", "FALSE")
     pts.set_pixit("VOCS", "TSPX_delete_link_key", "FALSE")


### PR DESCRIPTION
Since the auto-pts supports only 64-bit python 3, it can be run only under 64-bit Windows. In that case the default installation directory of the PTS is "C:\Program Files (x86)\Bluetooth SIG", not "C:\Program Files\Bluetooth SIG". Hence the databases set with TSPX_tester_database_file were not loaded and the PTS used its default databases. This did not affect test cases so far, but let's remove those settings to avoid confusion in the future.