### PR TITLE
bot: mynewt: Set proper secutiry for GAP/CONN/ACEP tests

### DIFF
--- a/autopts/bot/iut_config/mynewt.py
+++ b/autopts/bot/iut_config/mynewt.py
@@ -48,6 +48,7 @@ iut_config = {
             'BLE_SM_SC': '1',
             'BLE_SM_SC_ONLY': '0',
             'BLE_SM_LVL': '4',
+            'BLE_SM_MITM': '1',
         },
         "test_cases": [
             'GAP/SEC/SEM/BV-21-C',
@@ -55,7 +56,9 @@ iut_config = {
             'GAP/SEC/SEM/BV-24-C',
             'GAP/SEC/SEM/BV-26-C',
             'GAP/SEC/SEM/BV-27-C',
-            'GAP/SEC/SEM/BV-45-C'
+            'GAP/SEC/SEM/BV-45-C',
+            'GAP/SEC/SEM/BV-58-C',
+            'GAP/SEC/SEM/BV-61-C',
         ]
     },
 


### PR DESCRIPTION
This PR fixes privacy setting for:
GAP/CONN/ACEP/BV-58-C
GAP/CONN/ACEP/BV-61-C

Also, this enables MITM setting in mynewt overlay,
which is required for both of those tests to pass.