### PR TITLE
zephyr: Fix handling of IUT ready event

### DIFF
--- a/autopts/ptsprojects/boards/__init__.py
+++ b/autopts/ptsprojects/boards/__init__.py
@@ -49,7 +49,7 @@ class Board:
 
         reset_process = subprocess.Popen(shlex.split(self.reset_cmd),
                                          shell=False,
-                                         stdout=self.iutctl.iut_log_file,
+                                         stdout=subprocess.DEVNULL,
                                          stderr=self.iutctl.iut_log_file)
 
         if reset_process.wait(20):

--- a/autopts/ptsprojects/stack.py
+++ b/autopts/ptsprojects/stack.py
@@ -666,7 +666,6 @@ class ASCS:
 
 
 class CORE:
-
     def __init__(self):
         self.event_queues = {
             defs.CORE_EV_IUT_READY: [],
@@ -675,10 +674,19 @@ class CORE:
     def event_received(self, event_type, event_data_tuple):
         self.event_queues[event_type].append(event_data_tuple)
 
-    def wait_iut_ready_ev(self, timeout, remove=False):
+    def wait_iut_ready_ev(self, timeout, remove=True):
         return wait_for_event_iut(
             self.event_queues[defs.CORE_EV_IUT_READY],
             timeout, remove)
+
+    def cleanup(self):
+        for key in self.event_queues:
+            if key == defs.CORE_EV_IUT_READY:
+                # To pass IUT ready event between test cases
+                continue
+
+            self.event_queues[key].clear()
+
 
 class BAP:
     def __init__(self):
@@ -1354,7 +1362,10 @@ class Stack:
         self.bap = BAP()
 
     def core_init(self):
-        self.core = CORE()
+        if self.core:
+            self.core.cleanup()
+        else:
+            self.core = CORE()
 
     def gatt_cl_init(self):
         self.gatt_cl = GattCl()


### PR DESCRIPTION
There are tests that restart IUT in the middle which means that event needs to be removed from queue. Otherwise second call returns immediatelly due to old event being present. Since leaving event on queue is unlikely scenario, just change default to always remove it.