### PR TITLE
stack: Restore accidentally removed return statement

### DIFF
--- a/autopts/ptsprojects/stack.py
+++ b/autopts/ptsprojects/stack.py
@@ -259,6 +259,8 @@ class Gap:
                 return len(self.connected.data) >= conn_count
             return False
 
+        return self.connected.data
+
     def wait_periodic_report(self, timeout):
         if self.periodic_report_rxed:
             return True


### PR DESCRIPTION
Caused BTP ERROR in some test cases for mynewt e.g. GAP/SEC/SEM/BV-26-C.