### PR TITLE
zephyr: bot: iut_config: Apply overlay-le-audio.conf for CSIS

### DIFF
--- a/autopts/bot/iut_config/zephyr.py
+++ b/autopts/bot/iut_config/zephyr.py
@@ -133,7 +133,7 @@ iut_config = {
             # The overlay file exists in zephyr repo. Leave this empty.
         },
         "test_cases": [
-            'VOCS', 'VCS', 'AICS', 'IAS', 'PACS', 'ASCS', 'BAP', 'HAS'
+            'VOCS', 'VCS', 'AICS', 'IAS', 'PACS', 'ASCS', 'BAP', 'HAS', 'CSIS'
         ]
     },
 


### PR DESCRIPTION
Bot has to apply the overlay-le-audio.conf during build to enable audio features.