### PR TITLE
bot: common: Add report txt without tag to githubdrive

### DIFF
--- a/autopts/bot/mynewt.py
+++ b/autopts/bot/mynewt.py
@@ -1,6 +1,4 @@
 #!/usr/bin/env python
-
-import datetime
 #
 # auto-pts - The Bluetooth PTS Automation Framework
 #
@@ -15,6 +13,8 @@ import datetime
 # FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
 # more details.
 #
+import collections
+import datetime
 import importlib
 import os
 import subprocess
@@ -202,10 +202,19 @@ def main(bot_client):
         repo_status = ''
 
     try:
-        summary, results, descriptions, regressions, progresses, \
-            args['pts_ver'], args['platform'] = bot_client.run_tests()
+        stats = bot_client.run_tests()
     finally:
         release_device(bot_client.args.tty_file)
+
+    summary = stats.get_status_count()
+    results = stats.get_results()
+    descriptions = stats.get_descriptions()
+    regressions = stats.get_regressions()
+    progresses = stats.get_progresses()
+    args['pts_ver'] = stats.pts_ver
+    args['platform'] = stats.platform
+
+    results = collections.OrderedDict(sorted(results.items()))
 
     pts_logs, xmls = bot.common.pull_server_logs(bot_client.args)
 

--- a/test/unittests.py
+++ b/test/unittests.py
@@ -3,11 +3,18 @@ import shutil
 import sys
 import unittest
 from os.path import dirname, abspath
+from pathlib import Path
 from unittest.mock import patch
 
-from autopts.client import FakeProxy
+from autopts import bot
+from autopts.bot.zephyr import make_readme_md
+from autopts.client import FakeProxy, TestCaseRunStats
+from autopts.ptsprojects.testcase_db import TestCaseTable
 from autoptsclient_bot import import_bot_projects, import_bot_module
 from test.mocks.mocked_test_cases import mock_workspace_test_cases, test_case_list_generation_samples
+
+
+DATABASE_FILE = 'test/mocks/zephyr_database.db'
 
 
 class TestCaseRunStatsMock:
@@ -32,6 +39,20 @@ class TestCaseRunStatsMock:
     def print_summary(self):
         pass
 
+    @staticmethod
+    def merge(stats1, stats2):
+        return stats1
+
+
+def delete_file(file_path):
+    try:
+        if os.path.isfile(file_path):
+            os.remove(file_path)
+        elif os.path.isdir(file_path):
+            shutil.rmtree(file_path, ignore_errors=True)
+    except:
+        pass
+
 
 class MyTestCase(unittest.TestCase):
     def setUp(self):
@@ -41,7 +62,7 @@ class MyTestCase(unittest.TestCase):
 
     def tearDown(self):
         os.remove('ttyUSB')
-        os.remove('autopts/bot/config.py')
+        delete_file('autopts/bot/config.py')
 
     def test_bot_startup_import_bot_projects(self):
         """Check that all supported methods of passing a config file
@@ -129,7 +150,6 @@ class MyTestCase(unittest.TestCase):
 
                 # Use monkey patching and mocking
                 bot_module.autoptsclient.run_test_cases = mock_run_test_cases
-                bot_module.autoptsclient.print = mock_run_test_cases
 
                 bot_client_class = getattr(bot_module, 'BotClient', None)
 
@@ -148,6 +168,132 @@ class MyTestCase(unittest.TestCase):
                         self.assertTrue(set(_args.test_cases) == set(expected[config_name]),
                                         f'mock_iut_config_{i} use case failed')
                     bot_client.run_test_cases()
+
+    def generate_stats(self, files):
+        # Test useful for debugging stats and reports generation
+
+        database_file = DATABASE_FILE
+        TEST_CASE_DB = TestCaseTable('zephyr', database_file)
+        start_time = 1693378197  # result of time.time()
+        duration = 30  # seconds
+        end_time = start_time + duration
+
+        test_cases = []
+        for project in mock_workspace_test_cases:
+            for tc in mock_workspace_test_cases[project]:
+                test_cases.append(tc)
+
+        regressions_id = [5, 6, 7, 8]
+        progresses_id = [9, 10, 11, 12]
+        new_cases_id = [13, 14, 15]
+
+        stats1 = TestCaseRunStats(mock_workspace_test_cases.keys(),
+                                  test_cases, 0, None)
+        # Mock results from a first bot run, to generate regressions,
+        # progresses, new cases in a second one.
+        for i, tc in enumerate(test_cases):
+            status = 'PASS'
+            if i in progresses_id:
+                status = 'FAIL'
+            if i in new_cases_id:
+                continue
+
+            stats1.update(tc, end_time, status)
+            TEST_CASE_DB.update_statistics(tc, duration, status)
+            end_time = start_time + duration
+
+        results = stats1.get_results()
+        regressions = stats1.get_regressions()
+        progresses = stats1.get_progresses()
+
+        githubdrive = {
+            'path': 'test/mocks/bluetooth-qualification',
+            'subdir': 'host/',
+        }
+
+        report_txt = bot.common.make_report_txt(
+            results, regressions, progresses, '', 'zephyr')
+        files['first_report_txt'] = report_txt
+        assert os.path.exists(report_txt)
+
+        first_report_txt = os.path.join(
+            githubdrive['path'], githubdrive['subdir'], 'autopts_report',
+            os.path.basename(report_txt))
+
+        Path(os.path.dirname(first_report_txt)).mkdir(parents=True, exist_ok=True)
+        shutil.move(report_txt, first_report_txt)
+        files['first_report_txt'] = first_report_txt
+
+        stats = TestCaseRunStats(mock_workspace_test_cases.keys(),
+                                 test_cases, 0, TEST_CASE_DB)
+
+        # Mock results from a second bot run.
+        # Note one deleted test case.
+        for i, tc in enumerate(test_cases[:-1]):
+            status = 'PASS'
+            if i in regressions_id:
+                status = 'FAIL'
+
+            stats.update(tc, end_time, status)
+            TEST_CASE_DB.update_statistics(tc, duration, status)
+            end_time = start_time + duration
+
+        summary = stats.get_status_count()
+        results = stats.get_results()
+        descriptions = stats.get_descriptions()
+        regressions = stats.get_regressions()
+        progresses = stats.get_progresses()
+        new_cases = stats.get_new_cases()
+
+        start_timestamp = '30_08_2023_08_50_01'
+        end_time = '30_08_2023_11_30_23'
+        repos_info = {'zephyr': {'commit': '123456', 'desc': 'zephyr'}}
+        pts_ver = '8_5_0'
+
+        iut_logs = 'logs/'
+        pts_logs = 'tmp/zephyr-master'
+        xmls = 'tmp/XMLs'
+        Path(iut_logs).mkdir(parents=True, exist_ok=True)
+        Path(pts_logs).mkdir(parents=True, exist_ok=True)
+        Path(xmls).mkdir(parents=True, exist_ok=True)
+        files['iut_logs'] = iut_logs
+        files['pts_logs'] = pts_logs
+        files['xmls'] = xmls
+
+        report_file = bot.common.make_report_xlsx(
+            results, summary, regressions, progresses, descriptions,
+            xmls, 'zephyr')
+        files['report_file'] = report_file
+        assert os.path.exists(report_file)
+
+        report_txt = bot.common.make_report_txt(
+            results, regressions, progresses, '', 'zephyr')
+        files['report_txt'] = report_txt
+        assert os.path.exists(report_txt)
+
+        readme_file = make_readme_md(
+            start_timestamp, end_time, repos_info, pts_ver)
+        files['readme_file'] = readme_file
+        assert os.path.exists(readme_file)
+
+        report_diff_txt, deleted_cases = bot.common.make_report_diff(
+            githubdrive, results, regressions, progresses, new_cases)
+        files['report_diff_txt'] = report_diff_txt
+        assert os.path.exists(report_diff_txt)
+
+        report_folder = bot.common.make_report_folder(
+            iut_logs, pts_logs, xmls, report_file, report_txt, report_diff_txt,
+            readme_file, database_file, '_iut_zephyr_' + start_timestamp)
+        files['report_folder'] = report_folder
+        assert os.path.exists(report_folder)
+
+    def test_generate_stats(self):
+        files = {}
+        try:
+            self.generate_stats(files)
+        finally:
+            for key in files:
+                delete_file(files[key])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
A datetime tag in report txt file name prevents diff view in GitHub, but it is still sometimes useful. To compromise, just add a second same report file, but without a tag.