### PR TITLE
zephyr: iutctl: Fix misguiding exception

### DIFF
--- a/autopts/ptsprojects/zephyr/iutctl.py
+++ b/autopts/ptsprojects/zephyr/iutctl.py
@@ -247,8 +247,8 @@ class ZephyrCtl:
         self.rtt_logger_stop()
         self.btmon_stop()
 
-        if not self.gdb and self.board:
-            stack = get_stack()
+        stack = get_stack()
+        if not self.gdb and self.board and stack.core:
             stack.core.event_queues[defs.CORE_EV_IUT_READY].clear()
             self.board.reset()
 


### PR DESCRIPTION
This exception was thrown when no test case prefix was matched, resulting in stack.core not being initialized.

  File "C:\Users\magda\auto-pts\autopts\client.py", line 1102, in start
    self.cleanup()
  File "C:\Users\magda\auto-pts\autopts\client.py", line 1170, in cleanup
    autoprojects.iutctl.cleanup()
  File "C:\Users\magda\auto-pts\autopts\ptsprojects\zephyr\iutctl.py", line 326, in cleanup
    ZEPHYR.stop()
  File "C:\Users\magda\auto-pts\autopts\ptsprojects\zephyr\iutctl.py", line 252, in stop
    stack.core.event_queues[defs.CORE_EV_IUT_READY].clear()
    ^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'event_queues'