### PR TITLE
cron: bot: Post a comment under PR in case of bot failure

### DIFF
--- a/autopts/bot/common.py
+++ b/autopts/bot/common.py
@@ -53,6 +53,7 @@ CLIENT_SECRET_FILE = 'client_secret.json'
 REPORT_XLSX = "report.xlsx"
 REPORT_TXT = "report.txt"
 REPORT_DIFF_TXT = "report-diff.txt"
+ERROR_TXT = 'error.txt'
 COMMASPACE = ', '
 
 PROJECT_DIR = os.path.dirname(  # auto-pts repo directory
@@ -875,6 +876,12 @@ def make_report_diff(log_git_conf, results, regressions,
     f.close()
 
     return filename, deleted_cases
+
+
+def make_error_txt(msg):
+    filename = os.path.join(os.getcwd(), ERROR_TXT)
+    with open(filename, "w") as f:
+        f.write(msg)
 
 
 def github_push_report(report_folder, log_git_conf, commit_msg):

--- a/autopts/bot/mynewt.py
+++ b/autopts/bot/mynewt.py
@@ -23,9 +23,9 @@ import time
 from pathlib import Path
 
 from autopts import bot
+from autopts.bot.common import make_error_txt
 from autopts.client import Client
-from autopts.ptsprojects.boards import get_free_device, release_device, get_build_and_flash, get_tty, get_debugger_snr, \
-    get_board_type
+from autopts.ptsprojects.boards import release_device, get_build_and_flash, get_board_type
 from autopts.ptsprojects.mynewt.iutctl import get_iut, log
 from autopts.ptsprojects.testcase_db import DATABASE_FILE
 
@@ -156,7 +156,12 @@ class MynewtBotClient(bot.common.BotClient):
         if not args.no_build:
             build_and_flash = get_build_and_flash(args.board_name)
             board_type = get_board_type(args.board_name)
-            build_and_flash(args.project_path, board_type, overlay, args.debugger_snr)
+
+            try:
+                build_and_flash(args.project_path, board_type, overlay, args.debugger_snr)
+            except:
+                make_error_txt('Build and flash step failed')
+                raise
 
             time.sleep(10)
 

--- a/autopts/bot/zephyr.py
+++ b/autopts/bot/zephyr.py
@@ -29,9 +29,9 @@ import serial
 from autopts import bot
 from autopts.ptsprojects.zephyr import ZEPHYR_PROJECT_URL
 from autopts import client as autoptsclient
-from autopts.bot.common import BotConfigArgs, BotClient, make_report_diff
-from autopts.ptsprojects.boards import get_free_device, tty_to_com, release_device, get_tty, get_debugger_snr,\
-    get_build_and_flash, get_board_type
+
+from autopts.bot.common import BotConfigArgs, BotClient, make_report_diff, make_error_txt
+from autopts.ptsprojects.boards import tty_to_com, release_device, get_build_and_flash, get_board_type
 from autopts.ptsprojects.testcase_db import DATABASE_FILE
 from autopts.ptsprojects.zephyr.iutctl import get_iut, log
 
@@ -194,10 +194,16 @@ class ZephyrBotClient(BotClient):
         if not args.no_build:
             build_and_flash = get_build_and_flash(args.board_name)
             board_type = get_board_type(args.board_name)
-            build_and_flash(args.project_path, board_type, args.debugger_snr,
-                            overlays, args.project_repos)
 
-            flush_serial(args.tty_file)
+            try:
+                build_and_flash(args.project_path, board_type, args.debugger_snr,
+                                overlays, args.project_repos)
+
+                flush_serial(args.tty_file)
+            except:
+                make_error_txt('Build and flash step failed')
+                raise
+
             time.sleep(10)
 
     def start(self, args=None):


### PR DESCRIPTION
Until now, a message about an error was sent only to the admin e-mail. Let's post a comment under a PR that triggered a failing PR job, indicating that the results will not be delivered due to an error.