### PR TITLE
zephyr: gatt: Fix GATT/SR/GAN/BV-02-C

### DIFF
--- a/autopts/ptsprojects/zephyr/gatt.py
+++ b/autopts/ptsprojects/zephyr/gatt.py
@@ -21,7 +21,7 @@ from autopts.pybtp import btp
 from autopts.pybtp.types import UUID, Addr, IOCap, Prop, Perm
 from autopts.client import get_unique_name
 from autopts.wid.gatt import gattc_wid_hdl_multiple_indications
-from autopts.ptsprojects.stack import get_stack
+from autopts.ptsprojects.stack import get_stack, SynchPoint
 from autopts.ptsprojects.testcase import TestFunc
 from autopts.ptsprojects.zephyr.gatt_wid import gatt_wid_hdl
 from autopts.ptsprojects.zephyr.ztestcase import ZTestCase, ZTestCaseSlave
@@ -307,7 +307,8 @@ def test_cases_server(ptses):
 
     custom_test_cases = [
         ZTestCase("GATT", "GATT/SR/GAN/BV-02-C",
-                  pre_conditions + init_server,
+                  pre_conditions + init_server + [TestFunc(get_stack().synch.add_synch_element,
+                            [SynchPoint("GATT/SR/GAN/BV-02-C", 149)])],
                   generic_wid_hdl=gatt_wid_hdl,
                   lt2="GATT/SR/GAN/BV-02-C_LT2"),
         ZTestCase("GATT", "GATT/SR/GAS/BV-03-C",


### PR DESCRIPTION
LT1 shall wait at hdl_wid_149 until LT2 will connect to IUT, let's ensure this with SynchPoint feature. Moreover, multiple BTP commands at once from two Lower Testers causes BTP ERRORs. Let's just use thread locks as a workaround for now.