### PR TITLE
cron: Ignore Launch Studio project file at cleanup

### DIFF
--- a/tools/cron/common.py
+++ b/tools/cron/common.py
@@ -180,7 +180,7 @@ def clear_workspace(workspace_dir):
                     shutil.rmtree(f, ignore_errors=True)
                 else:
                     try:
-                        if not f.name.endswith(('.pqw6', '.pts', '.gitignore', '.xlsx')):
+                        if not f.name.endswith(('.pqw6', '.pts', '.gitignore', '.xlsx', '.bls')):
                             os.remove(f)
                     except:
                         pass


### PR DESCRIPTION
clear_workspace deletes any file from workspace folder unless its extension is the exceptions list. The .bls file from nimble workspace was deleted at bot run thus making the autopts repo marked as dirty.