### PR TITLE
zephyr: Fix test case preconditions

### DIFF
--- a/autopts/ptsprojects/zephyr/aics.py
+++ b/autopts/ptsprojects/zephyr/aics.py
@@ -75,8 +75,10 @@ def test_cases(ptses):
                       TestFunc(btp.gap_set_conn),
                       TestFunc(btp.gap_set_gendiscov),
                       TestFunc(btp.core_reg_svc_aics),
+                      TestFunc(btp.core_reg_svc_vcs),
                       TestFunc(btp.set_pts_addr, pts_bd_addr, Addr.le_public),
-                      TestFunc(stack.aics_init)]
+                      TestFunc(stack.aics_init),
+                      TestFunc(stack.vcs_init)]
 
     test_case_name_list = pts.get_test_case_list('AICS')
     tc_list = []

--- a/autopts/ptsprojects/zephyr/vocs.py
+++ b/autopts/ptsprojects/zephyr/vocs.py
@@ -73,7 +73,9 @@ def test_cases(ptses):
                       TestFunc(btp.gap_set_conn),
                       TestFunc(btp.gap_set_gendiscov),
                       TestFunc(btp.core_reg_svc_vocs),
-                      TestFunc(stack.vocs_init)]
+                      TestFunc(btp.core_reg_svc_vcs),
+                      TestFunc(stack.vocs_init),
+                      TestFunc(stack.vcs_init)]
 
     test_case_name_list = pts.get_test_case_list('VOCS')
     tc_list = []


### PR DESCRIPTION
Add vcs_init as a precondition for AICS tests and vcs_init for VOCS tests.