### PR TITLE
zephyr: Prefer EATT for GATT tests

### DIFF
--- a/autopts/ptsprojects/zephyr/gatt.py
+++ b/autopts/ptsprojects/zephyr/gatt.py
@@ -117,6 +117,7 @@ def set_pixits(ptses):
     pts.set_pixit("GATT", "TSPX_use_dynamic_pin", "FALSE")
     pts.set_pixit("GATT", "TSPX_delete_ltk", "TRUE")
     pts.set_pixit("GATT", "TSPX_tester_appearance", "0000")
+    pts.set_pixit("GATT", "TSPX_bearer_for_le", "EATT")
 
     if len(ptses) < 2:
         return


### PR DESCRIPTION
Make PTS use EATT for running GATT tests.