### PR TITLE
cron: Use 'database_file' config instead of find_latest_db

### DIFF
--- a/autopts/bot/common_features/report.py
+++ b/autopts/bot/common_features/report.py
@@ -306,16 +306,15 @@ def make_report_diff(log_git_conf, results, regressions,
                                   'autopts_report',
                                   REPORT_TXT)
 
-    if not os.path.exists(old_report_txt):
-        return None
-
     filename = os.path.join(os.getcwd(), REPORT_DIFF_TXT)
     f = open(filename, "w")
 
-    old_test_cases = report_parse_test_cases(old_report_txt)
-
     deleted_cases = []
+    old_test_cases = []
     test_cases = list(results.keys())
+
+    if os.path.exists(old_report_txt):
+        old_test_cases = report_parse_test_cases(old_report_txt)
 
     for tc in old_test_cases:
         if tc not in test_cases:

--- a/autopts/bot/mynewt.py
+++ b/autopts/bot/mynewt.py
@@ -23,6 +23,7 @@ import time
 from pathlib import Path
 
 from autopts import bot
+from autopts.bot.common_features.github import update_sources
 from autopts.client import Client
 from autopts.ptsprojects.boards import release_device, get_build_and_flash, get_board_type
 from autopts.ptsprojects.mynewt.iutctl import get_iut, log
@@ -196,6 +197,11 @@ def main(bot_client):
 
     if 'database_file' not in args:
         args['database_file'] = DATABASE_FILE
+
+    if 'githubdrive' in cfg:
+        update_sources(cfg['githubdrive']['path'],
+                       cfg['githubdrive']['remote'],
+                       cfg['githubdrive']['branch'], True)
 
     if args.get('newt_upgrade', False):
         bot.common.check_call(['newt', 'upgrade', '-f', '--shallow=0'], cwd=args['project_path'])

--- a/autopts/bot/zephyr.py
+++ b/autopts/bot/zephyr.py
@@ -27,6 +27,7 @@ from pathlib import Path
 import serial
 
 from autopts import bot
+from autopts.bot.common_features.github import update_sources
 from autopts.ptsprojects.zephyr import ZEPHYR_PROJECT_URL
 from autopts import client as autoptsclient
 
@@ -229,6 +230,11 @@ def main(bot_client):
 
     if 'database_file' not in args:
         args['database_file'] = DATABASE_FILE
+
+    if 'githubdrive' in cfg:
+        update_sources(cfg['githubdrive']['path'],
+                       cfg['githubdrive']['remote'],
+                       cfg['githubdrive']['branch'], True)
 
     args['kernel_image'] = os.path.join(args['project_path'], 'tests',
                                         'bluetooth', 'tester', 'outdir',


### PR DESCRIPTION
find_latest_db turned out to be not a very good solution. It works fine if githbudrive repo is used only on one machine. Let's just use the .db file configured with 'database_file'. The database still can exist in the githubdrive, so let's update the repo at bot start. The remaining issue with separate .db files will be fixed in the next patches with some merging tool instead.