### PR TITLE
zephyr: pixits: Fix set_pixit() exceptions

### DIFF
--- a/autopts/ptsprojects/zephyr/aics.py
+++ b/autopts/ptsprojects/zephyr/aics.py
@@ -46,10 +46,8 @@ def set_pixits(ptses):
     pts.set_pixit("AICS", "TSPX_use_dynamic_pin", "FALSE")
     pts.set_pixit("AICS", "TSPX_delete_ltk", "TRUE")
     pts.set_pixit("AICS", "TSPX_security_enabled", "FALSE")
-    pts.set_pixit("AICS", "TSPX_iut_setup_att_over_br_edr", "FALSE")
-    pts.set_pixit("AICS", "TSPX_tester_appearance", "0000")
-    pts.set_pixit("AICS", "TSPX_Step_Size", "1")
-    pts.set_pixit("AICS", "TSPX_iut_ATT_trnasport", "ATT Bearer on LE Transport")
+    pts.set_pixit("AICS", "TSPX_iut_ATT_transport", "ATT Bearer on LE Transport")
+
 
 def test_cases(ptses):
     """Returns a list of AICS Server test cases"""

--- a/autopts/ptsprojects/zephyr/ascs.py
+++ b/autopts/ptsprojects/zephyr/ascs.py
@@ -45,9 +45,6 @@ def set_pixits(ptses):
     pts.set_pixit("ASCS", "TSPX_use_dynamic_pin", "FALSE")
     pts.set_pixit("ASCS", "TSPX_delete_ltk", "TRUE")
     pts.set_pixit("ASCS", "TSPX_security_enabled", "FALSE")
-    pts.set_pixit("ASCS", "TSPX_iut_setup_att_over_br_edr", "FALSE")
-    pts.set_pixit("ASCS", "TSPX_tester_appearance", "0000")
-    pts.set_pixit("ASCS", "TSPX_Step_Size", "1")
     pts.set_pixit("ASCS", "TSPX_iut_ATT_transport", "ATT Bearer on LE Transport")
 
 

--- a/autopts/ptsprojects/zephyr/bap.py
+++ b/autopts/ptsprojects/zephyr/bap.py
@@ -48,7 +48,6 @@ def set_pixits(ptses):
     pts.set_pixit("BAP", "TSPX_use_dynamic_pin", "FALSE")
     pts.set_pixit("BAP", "TSPX_delete_ltk", "TRUE")
     pts.set_pixit("BAP", "TSPX_security_enabled", "FALSE")
-    pts.set_pixit("BAP", "TSPX_Step_Size", "1")
     pts.set_pixit("BAP", "TSPX_iut_ATT_transport", "ATT Bearer on LE Transport")
     pts.set_pixit("BAP", "TSPX_VS_Codec_ID", "ffff")
     pts.set_pixit("BAP", "TSPX_VS_Company_ID", "ffff")
@@ -87,10 +86,6 @@ def test_cases(ptses):
                           stack.gap.iut_addr_get_str())),
                       TestFunc(lambda: set_addr(
                           stack.gap.iut_addr_get_str())),
-                      TestFunc(lambda: pts.update_pixit_param(
-                          "BAP", "TSPX_iut_use_dynamic_bd_addr",
-                          "TRUE" if stack.gap.iut_addr_is_random()
-                          else "FALSE")),
                       TestFunc(btp.core_reg_svc_gatt),
                       TestFunc(btp.set_pts_addr, pts_bd_addr, Addr.le_public),
                       TestFunc(stack.gatt_init),

--- a/autopts/ptsprojects/zephyr/gap.py
+++ b/autopts/ptsprojects/zephyr/gap.py
@@ -134,7 +134,6 @@ def set_pixits(ptses):
     pts.set_pixit("GAP", "TSPX_iut_mandates_mitm", "FALSE")
     pts.set_pixit("GAP", "TSPX_encryption_before_service_request", "FALSE")
     pts.set_pixit("GAP", "TSPX_tester_appearance", "0000")
-    pts.set_pixit("GAP", "TSPX_advertising_data", "")
     pts.set_pixit("GAP", "TSPX_iut_device_IRK_for_resolvable_privacy_address_generation_procedure",
                   "00000000000000000000000000000000")
     pts.set_pixit("GAP", "TSPX_tester_device_IRK_for_resolvable_privacy_address_generation_procedure",

--- a/autopts/ptsprojects/zephyr/ias.py
+++ b/autopts/ptsprojects/zephyr/ias.py
@@ -47,8 +47,7 @@ def set_pixits(ptses):
     pts.set_pixit("IAS", "TSPX_security_enabled", "FALSE")
     pts.set_pixit("IAS", "TSPX_iut_setup_att_over_br_edr", "FALSE")
     pts.set_pixit("IAS", "TSPX_tester_appearance", "0000")
-    pts.set_pixit("IAS", "TSPX_Step_Size", "1")
-    pts.set_pixit("IAS", "TSPX_iut_ATT_trnasport", "ATT Bearer on LE Transport")
+
 
 def test_cases(ptses):
     """Returns a list of IAS Server test cases"""

--- a/autopts/ptsprojects/zephyr/l2cap.py
+++ b/autopts/ptsprojects/zephyr/l2cap.py
@@ -95,7 +95,6 @@ def set_pixits(ptses):
     pts.set_pixit("L2CAP", "TSPX_generate_local_busy", "TRUE")
     pts.set_pixit("L2CAP", "TSPX_l2ca_cbmps_min", "0040")
     pts.set_pixit("L2CAP", "TSPX_l2ca_cbmps_max", "0100")
-    pts.set_pixit("L2CAP", "TSPX_eatt_over_br_edr", "FALSE")
 
 
 def test_cases(ptses):

--- a/autopts/ptsprojects/zephyr/micp.py
+++ b/autopts/ptsprojects/zephyr/micp.py
@@ -53,9 +53,6 @@ def set_pixits(ptses):
     pts.set_pixit("MICP", "TSPX_use_dynamic_pin", "FALSE")
     pts.set_pixit("MICP", "TSPX_delete_ltk", "FALSE")
     pts.set_pixit("MICP", "TSPX_security_enabled", "FALSE")
-    pts.set_pixit("MICP", "TSPX_iut_setup_att_over_br_edr", "FALSE")
-    pts.set_pixit("MICP", "TSPX_tester_appearance", "0000")
-    pts.set_pixit("MICP", "TSPX_Step_Size", "1")
 
 
 def test_cases(ptses):

--- a/autopts/ptsprojects/zephyr/pacs.py
+++ b/autopts/ptsprojects/zephyr/pacs.py
@@ -41,13 +41,8 @@ def set_pixits(ptses):
     pts.set_pixit("PACS", "TSPX_mtu_size", "60")
     pts.set_pixit("PACS", "TSPX_secure_simple_pairing_pass_key_confirmation", "FALSE")
     pts.set_pixit("PACS", "TSPX_delete_link_key", "FALSE")
-    pts.set_pixit("PACS", "TSPX_pin_code", "0000")
-    pts.set_pixit("PACS", "TSPX_use_dynamic_pin", "FALSE")
     pts.set_pixit("PACS", "TSPX_delete_ltk", "TRUE")
     pts.set_pixit("PACS", "TSPX_security_enabled", "FALSE")
-    pts.set_pixit("PACS", "TSPX_iut_setup_att_over_br_edr", "FALSE")
-    pts.set_pixit("PACS", "TSPX_tester_appearance", "0000")
-    pts.set_pixit("PACS", "TSPX_Step_Size", "1")
     pts.set_pixit("PACS", "TSPX_iut_ATT_transport", "ATT Bearer on LE Transport")
 
 

--- a/autopts/ptsprojects/zephyr/vcp.py
+++ b/autopts/ptsprojects/zephyr/vcp.py
@@ -53,9 +53,6 @@ def set_pixits(ptses):
     pts.set_pixit("VCP", "TSPX_use_dynamic_pin", "FALSE")
     pts.set_pixit("VCP", "TSPX_delete_ltk", "FALSE")
     pts.set_pixit("VCP", "TSPX_security_enabled", "FALSE")
-    pts.set_pixit("VCP", "TSPX_iut_setup_att_over_br_edr", "FALSE")
-    pts.set_pixit("VCP", "TSPX_tester_appearance", "0000")
-    pts.set_pixit("VCP", "TSPX_Step_Size", "1")
 
 
 def test_cases(ptses):

--- a/autopts/ptsprojects/zephyr/vcs.py
+++ b/autopts/ptsprojects/zephyr/vcs.py
@@ -46,10 +46,7 @@ def set_pixits(ptses):
     pts.set_pixit("VCS", "TSPX_use_dynamic_pin", "FALSE")
     pts.set_pixit("VCS", "TSPX_delete_ltk", "TRUE")
     pts.set_pixit("VCS", "TSPX_security_enabled", "FALSE")
-    pts.set_pixit("VCS", "TSPX_iut_setup_att_over_br_edr", "FALSE")
-    pts.set_pixit("VCS", "TSPX_tester_appearance", "0000")
-    pts.set_pixit("VCS", "TSPX_Step_Size", "1")
-    pts.set_pixit("VCS", "TSPX_iut_ATT_trnasport", "ATT Bearer on LE Transport")
+
 
 def test_cases(ptses):
     """Returns a list of IAS Server test cases"""

--- a/autopts/ptsprojects/zephyr/vocs.py
+++ b/autopts/ptsprojects/zephyr/vocs.py
@@ -45,10 +45,8 @@ def set_pixits(ptses):
     pts.set_pixit("VOCS", "TSPX_use_dynamic_pin", "FALSE")
     pts.set_pixit("VOCS", "TSPX_delete_ltk", "TRUE")
     pts.set_pixit("VOCS", "TSPX_security_enabled", "FALSE")
-    pts.set_pixit("VOCS", "TSPX_iut_setup_att_over_br_edr", "FALSE")
-    pts.set_pixit("VOCS", "TSPX_tester_appearance", "0000")
-    pts.set_pixit("VOCS", "TSPX_Step_Size", "1")
-    pts.set_pixit("VOCS", "TSPX_iut_ATT_trnasport", "ATT Bearer on LE Transport")
+    pts.set_pixit("VOCS", "TSPX_iut_ATT_transport", "ATT Bearer on LE Transport")
+
 
 def test_cases(ptses):
     """Returns a list of VOCS Server test cases"""


### PR DESCRIPTION
PTS profiles contain different sets of pixits and some set_pixit() calls were just copy pasted without checking if a pixit is really available in a profile. This doesn't interrupt a test run, but it clutters the autoptsserver logs a little.