### PR TITLE
mesh: Restore IV Update Test mode after reset

### DIFF
--- a/autopts/pybtp/btp/mesh.py
+++ b/autopts/pybtp/btp/mesh.py
@@ -450,6 +450,8 @@ def mesh_reset():
 
     stack.mesh.is_provisioned.data = False
     stack.mesh.is_initialized = True
+    if stack.mesh.iv_test_mode_autoinit:
+        mesh_iv_update_test_mode(True)
 
 
 def mesh_input_number(number):


### PR DESCRIPTION
IV Update Test mode flag is set in bt_mesh.flags:
https://github.com/zephyrproject-rtos/zephyr/blob/7fb2929e5ba058da82716b6555f75c112c252072/subsys/bluetooth/mesh/net.c#L248-L250 which is reset when bt_mesh_reset() is called:
https://github.com/zephyrproject-rtos/zephyr/blob/7fb2929e5ba058da82716b6555f75c112c252072/subsys/bluetooth/mesh/main.c#L341-L352

If hdl_wid_13 has been called at the start of the test and stack.mesh.is_provisioned.data was set, btp.mesh_reset() will be called, which will reset the flag. Therefore we need to restore it after resetting the stack.