### PR TITLE
cron: github: Do not post repo sha in bot results

### DIFF
--- a/tools/cron/common.py
+++ b/tools/cron/common.py
@@ -109,6 +109,8 @@ def report_to_review_msg(report_path):
     msg = 'AutoPTS Bot results:\n'
 
     with open(report_path, 'r') as f:
+        f.readline()
+
         while True:
             line = f.readline()
 


### PR DESCRIPTION
Skip the first line of report.txt, because it contains repos sha.