### PR TITLE
zephyr: mesh: align sensor client tests with latest PTS

### DIFF
--- a/autopts/pybtp/btp/mmdl.py
+++ b/autopts/pybtp/btp/mmdl.py
@@ -949,7 +949,7 @@ def mmdl_sensor_column_get(sensor_id, raw_value):
 
     hdr_fmt = '<H%ds' % (len(rsp) - 2)
     (prop_id, column_data) = struct.unpack_from(hdr_fmt, rsp)
-    column_data = binascii.hexlify(column_data).decode('UTF-8')
+    column_data = int.from_bytes(column_data, byteorder='big')
     stack = get_stack()
     stack.mesh.recv_status_data_set('Status', [prop_id, column_data])
     logging.debug('Status: Property ID = 0x%x Column data = %r',
@@ -968,12 +968,12 @@ def mmdl_sensor_series_get(sensor_id, raw_values):
 
     (rsp,) = iutctl.btp_socket.send_wait_rsp(
         *MMDL['sensor_series_get'], data=data)
-    hdr_fmt = '<9sH'
+    hdr_fmt = '<%dsH' % (len(rsp) - 2)
     (column_data, prop_id) = struct.unpack_from(hdr_fmt, rsp)
-    column_data = int(binascii.hexlify(column_data), 16)
+    column_data = int.from_bytes(column_data, byteorder='big')
     stack = get_stack()
     stack.mesh.recv_status_data_set('Status', [prop_id, column_data])
-    logging.debug('Status: Property ID = 0x%x Column data = 0x%x',
+    logging.debug('Status: Property ID = 0x%x Column data = 0x%r',
                   prop_id, column_data)
 
 

--- a/autopts/wid/mmdl.py
+++ b/autopts/wid/mmdl.py
@@ -770,7 +770,7 @@ def sensor_setting_status(_):
 
 
 def sensor_column_get(_):
-    sensor_id = 0x0069
+    sensor_id = 0x0042
     raw_value = '10'
     btp.mmdl_sensor_column_get(sensor_id, raw_value)
     return True
@@ -778,23 +778,26 @@ def sensor_column_get(_):
 
 def sensor_column_status(params):
     sensor_id = params['PropertyId']
-    column_data = hex(params['ColumnData'])[2:]
+    column_data = 0
+    if 'ColumnData' in params:
+        column_data = params['ColumnData']
 
     stack = get_stack()
-    return [sensor_id, column_data] == stack.mesh.recv_status_data_get('Status')
+    status = stack.mesh.recv_status_data_get('Status')
+    return [sensor_id, column_data] == status
 
 
 def sensor_series_get(params):
     sensor_id = params['PropertyId']
-    if params['RawValueX1'] is None:
+    if params['RawValueA1'] is None:
         raw_value_x1 = '10'
     else:
-        raw_value_x1 = hex(params['RawValueX1'])[2:]
+        raw_value_x1 = hex(params['RawValueA1'])[2:]
 
-    if params['RawValueX2'] is None:
+    if params['RawValueA2'] is None:
         raw_value_x2 = '20'
     else:
-        raw_value_x2 = hex(params['RawValueX2'])[2:]
+        raw_value_x2 = hex(params['RawValueA2'])[2:]
 
     btp.mmdl_sensor_series_get(sensor_id, raw_value_x1 + raw_value_x2)
     return True
@@ -805,7 +808,8 @@ def sensor_series_status(params):
     column_data = params['ColumnData']
 
     stack = get_stack()
-    return [sensor_id, column_data] == stack.mesh.recv_status_data_get('Status')
+    status = stack.mesh.recv_status_data_get('Status')
+    return [sensor_id, column_data] == status
 
 
 ZONE_CHANGE_ZERO_POINT = 0x40


### PR DESCRIPTION
Update MMI parameter formats according to latest
PTS version. Update the sensor id with a one supported by PTS.
Fixes:
MMDL/CL/SNR/BV-12-C and MMDL/CL/SNR/BV-13-C