### PR TITLE
mesh: Add handlers for MMIs 303, 304 and 346 needed for MBT tests with Pull mode

### DIFF
--- a/autopts/wid/mmdl.py
+++ b/autopts/wid/mmdl.py
@@ -65,6 +65,35 @@ def hdl_wid_13(_: WIDParams):
     return True
 
 
+def hdl_wid_303(_: WIDParams):
+    """
+    Implements:
+    description: Please send Friend Request to initiate the Friendship Establishment procedure.
+    """
+
+    btp.mesh_lpn(True)
+    return True
+
+
+def hdl_wid_304(_: WIDParams):
+    """
+    Implements:
+    description: Please click OK to send Friend Poll message.
+    """
+
+    btp.mesh_lpn_poll()
+    return True
+
+
+def hdl_wid_346(_: WIDParams):
+    """
+    Implements:
+    description: Please send Friend Subscription List Add message to Lower Tester.
+    """
+
+    return True
+
+
 def hdl_wid_515(_: WIDParams):
     """
     MMDL/SR/SCH/BV-01-C


### PR DESCRIPTION
This PR enables support for Pull mode MBT tests:
- MBT/SR/BT/BV-05-C
- MBT/SR/BT/BV-07-C
- MBT/SR/BT/BV-08-C
- MBT/SR/BT/BV-10-C

This PR also allows to run them with friendship, but currently disables LPN on the node as the tests fail.