### PR TITLE
ptscontrol: Do not close PTSSender on Cancel response

### DIFF
--- a/autopts/ptscontrol.py
+++ b/autopts/ptscontrol.py
@@ -269,18 +269,23 @@ class PTSSender(win32com.server.connect.ConnectableServer):
                 if result is not None:
                     rsp = result
 
+                if rsp == "END_TEST_CASE":
+                    # Client failed, skip next MMIs
+                    self.close()
+                    rsp = "Cancel"
+
                 logger.info(f"Response for on_implicit_send (wid {wid}): {rsp}")
         except xmlrpc.client.Fault as err:
             logger.info("A fault occurred, code = %d, string = %s",
                         err.faultCode, err.faultString)
+            self.close()
 
         except Exception as e:
             logger.exception(e)
+            self.close()
 
         finally:
             self._response.clear()
-            if rsp == 'Cancel':
-                self.close()
 
         # Stringify response
         rsp = str(rsp)

--- a/autopts/ptsprojects/testcase.py
+++ b/autopts/ptsprojects/testcase.py
@@ -605,7 +605,7 @@ class TestCase(PTSCallback):
             for step in next_steps:
                 self.add_next_step(*step)
 
-        if response == "WAIT":
+        if response in ["WAIT", "END_TEST_CASE"]:
             return response
 
         if style in (ptstypes.MMI_Style_Edit1, ptstypes.MMI_Style_Edit2):


### PR DESCRIPTION
Some WIDs return a Cancel response to select a different test variant. Let's use a different key word, END_TEST_CASE, to block sending next MMIs to the autopts client.