### PR TITLE
cleanup: Wait for LT threads to finish after interrupt

### DIFF
--- a/autopts/bot/common.py
+++ b/autopts/bot/common.py
@@ -143,6 +143,8 @@ class BotClient(Client):
         self.args.retry_config = bot_config_dict.get('retry_config', None)
 
         if not errmsg:
+            # Remove default root handler that was created at first logging.debug
+            logging.getLogger().handlers.clear()
             init_logging('_' + '_'.join(str(x) for x in self.args.cli_port))
 
         return errmsg

--- a/autopts/bot/zephyr.py
+++ b/autopts/bot/zephyr.py
@@ -36,7 +36,6 @@ from autopts.ptsprojects.boards import tty_to_com, release_device, get_build_and
 from autopts.ptsprojects.testcase_db import DATABASE_FILE
 from autopts.ptsprojects.zephyr.iutctl import get_iut, log
 from autopts.bot.common_features import github, report, mail, google_drive
-from autopts.utils import usb_power
 
 PROJECT_NAME = Path(__file__).stem
 
@@ -248,10 +247,6 @@ def main(bot_client):
     else:
         repos_info = {}
         repo_status = ''
-
-    if 'ykush' in args:
-        usb_power(args['ykush'], True)
-        time.sleep(1)
 
     try:
         stats = bot_client.run_tests()

--- a/autopts/ptscontrol.py
+++ b/autopts/ptscontrol.py
@@ -453,6 +453,7 @@ class PyPTS:
         func(*args, **kwds)
 
     def _replug_dongle(self):
+        log(f"{self._replug_dongle.__name__} not implemented")
         pass
 
     @pts_lock_wrapper(PTS_START_LOCK)
@@ -609,7 +610,8 @@ class PyPTS:
         self._init_attributes()
 
     def set_wid_response(self, response):
-        self._pts_sender.set_wid_response(response)
+        if self._pts_sender:
+            self._pts_sender.set_wid_response(response)
 
     def create_workspace(self, bd_addr, pts_file_path, workspace_name,
                          workspace_path):
@@ -787,7 +789,8 @@ class PyPTS:
             test_case_name)
 
         # After close, the sender will send 'Cancel' as WID response
-        self._pts_sender.close()
+        if self._pts_sender:
+            self._pts_sender.close()
 
         # NOTE: According to documentation 'StopTestCase() is not
         # currently implemented'. If by any chance this changes in

--- a/autopts/ptsprojects/mynewt/gatt.py
+++ b/autopts/ptsprojects/mynewt/gatt.py
@@ -15,7 +15,6 @@
 
 """GATT test cases"""
 
-from queue import Queue
 from autopts.pybtp import btp
 from autopts.pybtp.types import Addr
 from autopts.client import get_unique_name
@@ -24,6 +23,7 @@ from autopts.ptsprojects.testcase import TestFunc
 from autopts.ptsprojects.mynewt.ztestcase import ZTestCase, ZTestCaseSlave
 from autopts.ptsprojects.mynewt.gatt_wid import gatt_wid_hdl
 from autopts.ptsprojects.mynewt.gatt_client_wid import gattc_wid_hdl
+from autopts.utils import ResultWithFlag
 
 
 class Value:
@@ -140,10 +140,10 @@ def test_cases_server(ptses):
 
     stack = get_stack()
 
-    queue = Queue()
+    iut_addr = ResultWithFlag()
 
     def set_addr(addr):
-        queue.put(addr)
+        iut_addr.set(addr)
 
     pts = ptses[0]
 
@@ -221,7 +221,7 @@ def test_cases_server(ptses):
 
     pre_conditions_lt2 = [
                         TestFunc(lambda: pts2.update_pixit_param(
-                                "GATT", "TSPX_bd_addr_iut", queue.get())),
+                                "GATT", "TSPX_bd_addr_iut", iut_addr.get(timeout=90, clear=True))),
                         TestFunc(lambda: pts2.update_pixit_param(
                                 "GATT", "TSPX_iut_use_dynamic_bd_addr",
                                 "TRUE" if stack.gap.iut_addr_is_random() else "FALSE"))

--- a/autopts/ptsprojects/zephyr/bap.py
+++ b/autopts/ptsprojects/zephyr/bap.py
@@ -15,8 +15,6 @@
 
 """BAP test cases"""
 
-from queue import Queue
-
 from autopts.pybtp import btp
 from autopts.client import get_unique_name
 from autopts.ptsprojects.stack import get_stack
@@ -24,6 +22,7 @@ from autopts.ptsprojects.testcase import TestFunc
 from autopts.ptsprojects.zephyr.bap_wid import bap_wid_hdl
 from autopts.ptsprojects.zephyr.ztestcase import ZTestCase, ZTestCaseSlave
 from autopts.pybtp.types import Addr, AdType, UUID, AdFlags
+from autopts.utils import ResultWithFlag
 
 
 def set_pixits(ptses):
@@ -73,10 +72,10 @@ def test_cases(ptses):
         AdType.uuid16_svc_data: '4e1801ff0fff0f00',
     }
 
-    queue = Queue()
+    iut_addr = ResultWithFlag()
 
     def set_addr(addr):
-        queue.put(addr)
+        iut_addr.set(addr)
 
     pre_conditions = [TestFunc(btp.core_reg_svc_gap),
                       TestFunc(stack.gap_init, iut_device_name),
@@ -178,7 +177,7 @@ def test_cases(ptses):
 
     pre_conditions_lt2 = [
                         TestFunc(lambda: pts2.update_pixit_param(
-                                "BAP", "TSPX_bd_addr_iut", queue.get())),
+                                "BAP", "TSPX_bd_addr_iut", iut_addr.get(timeout=90, clear=True))),
     ]
 
     test_cases_lt2 = [

--- a/autopts/ptsprojects/zephyr/gatt.py
+++ b/autopts/ptsprojects/zephyr/gatt.py
@@ -16,10 +16,10 @@
 """GATT test cases"""
 import logging
 
-from queue import Queue
 from autopts.pybtp import btp
 from autopts.pybtp.types import UUID, Addr, IOCap, Prop, Perm
 from autopts.client import get_unique_name
+from autopts.utils import ResultWithFlag
 from autopts.wid.gatt import gattc_wid_hdl_multiple_indications
 from autopts.ptsprojects.stack import get_stack, SynchPoint
 from autopts.ptsprojects.testcase import TestFunc
@@ -149,10 +149,10 @@ def test_cases_server(ptses):
     iut_device_name = get_unique_name(pts)
     stack = get_stack()
 
-    queue = Queue()
+    iut_addr = ResultWithFlag()
 
     def set_addr(addr):
-        queue.put(addr)
+        iut_addr.set(addr)
 
     pre_conditions = [
                     TestFunc(btp.core_reg_svc_gap),
@@ -350,7 +350,7 @@ def test_cases_server(ptses):
 
     pre_conditions_lt2 = [
                         TestFunc(lambda: pts2.update_pixit_param(
-                                "GATT", "TSPX_bd_addr_iut", queue.get())),
+                                "GATT", "TSPX_bd_addr_iut", iut_addr.get(timeout=90, clear=True))),
                         TestFunc(lambda: pts2.update_pixit_param(
                                 "GATT", "TSPX_iut_use_dynamic_bd_addr",
                                 "TRUE" if stack.gap.iut_addr_is_random() else "FALSE"))

--- a/autopts/ptsprojects/zephyr/micp.py
+++ b/autopts/ptsprojects/zephyr/micp.py
@@ -22,13 +22,7 @@ from autopts.ptsprojects.testcase import TestFunc
 from autopts.ptsprojects.zephyr.micp_wid import micp_wid_hdl
 from autopts.ptsprojects.zephyr.ztestcase import ZTestCase
 from autopts.pybtp.types import IOCap, Addr
-from queue import Queue
-
-queue = Queue()
-
-
-def set_addr(addr):
-    queue.put(addr)
+from autopts.utils import ResultWithFlag
 
 
 def set_pixits(ptses):
@@ -63,6 +57,11 @@ def test_cases(ptses):
     pts_bd_addr = pts.q_bd_addr
     iut_device_name = get_unique_name(pts)
     stack = get_stack()
+
+    iut_addr = ResultWithFlag()
+
+    def set_addr(addr):
+        iut_addr.set(addr)
 
     pre_conditions = [
         TestFunc(btp.core_reg_svc_gap),

--- a/autopts/ptsprojects/zephyr/mics.py
+++ b/autopts/ptsprojects/zephyr/mics.py
@@ -22,13 +22,7 @@ from autopts.ptsprojects.testcase import TestFunc
 from autopts.ptsprojects.zephyr.mics_wid import mics_wid_hdl
 from autopts.ptsprojects.zephyr.ztestcase import ZTestCase
 from autopts.pybtp.types import IOCap, Addr
-from queue import Queue
-
-queue = Queue()
-
-
-def set_addr(addr):
-    queue.put(addr)
+from autopts.utils import ResultWithFlag
 
 
 def set_pixits(ptses):
@@ -63,6 +57,11 @@ def test_cases(ptses):
     pts_bd_addr = pts.q_bd_addr
     iut_device_name = get_unique_name(pts)
     stack = get_stack()
+
+    iut_addr = ResultWithFlag()
+
+    def set_addr(addr):
+        iut_addr.set(addr)
 
     pre_conditions = [
         TestFunc(btp.core_reg_svc_gap),

--- a/autopts/ptsprojects/zephyr/vcp.py
+++ b/autopts/ptsprojects/zephyr/vcp.py
@@ -22,13 +22,7 @@ from autopts.ptsprojects.testcase import TestFunc
 from autopts.ptsprojects.zephyr.vcp_wid import vcp_wid_hdl
 from autopts.ptsprojects.zephyr.ztestcase import ZTestCase
 from autopts.pybtp.types import IOCap, Addr
-from queue import Queue
-
-queue = Queue()
-
-
-def set_addr(addr):
-    queue.put(addr)
+from autopts.utils import ResultWithFlag
 
 
 def set_pixits(ptses):
@@ -63,6 +57,11 @@ def test_cases(ptses):
     pts_bd_addr = pts.q_bd_addr
     iut_device_name = get_unique_name(pts)
     stack = get_stack()
+
+    iut_addr = ResultWithFlag()
+
+    def set_addr(addr):
+        iut_addr.set(addr)
 
     pre_conditions = [
         TestFunc(btp.core_reg_svc_gap),

--- a/autopts/utils.py
+++ b/autopts/utils.py
@@ -73,16 +73,21 @@ class ResultWithFlag:
             self.result = value
             self.event.set()
 
-    def get(self, timeout=None, predicate=None):
+    def get(self, timeout=None, predicate=None, clear=False):
         """
         Args:
             timeout: timeout in seconds
             predicate: a function that will check other additional
              waiting conditions
+            clear: clear result and flag so the result will not be reused
         """
         self.wait(timeout=timeout, predicate=predicate)
         with self.lock:
-            return self.result
+            result = self.result
+            if clear:
+                self.result = None
+                self.event.clear()
+            return result
 
     def wait(self, timeout=None, predicate=lambda: True):
         """

--- a/autopts/wid/bap.py
+++ b/autopts/wid/bap.py
@@ -24,7 +24,7 @@ from autopts.ptsprojects.stack import get_stack
 from autopts.ptsprojects.testcase import MMI
 from autopts.pybtp import btp, defs
 from autopts.pybtp.btp import pts_addr_get, pts_addr_type_get, ascs_add_ase_to_cis
-from autopts.pybtp.types import WIDParams, UUID, gap_settings_btp2txt, AdType, AdFlags
+from autopts.pybtp.types import WIDParams, UUID, gap_settings_btp2txt, AdType, AdFlags, BTPError
 from autopts.wid import generic_wid_hdl
 
 log = logging.debug
@@ -1363,7 +1363,8 @@ def hdl_wid_311(params: WIDParams):
         for config in sinks:
             try:
                 btp.bap_send(config.ase_id, stream_data[config.ase_id])
-            except:
+            except BTPError:
+                # Buffer full
                 pass
 
     return True
@@ -1608,7 +1609,8 @@ def hdl_wid_377(_: WIDParams):
         for ase_id in sources:
             try:
                 btp.bap_send(ase_id, data)
-            except:
+            except BTPError:
+                # Buffer full
                 pass
 
     return True

--- a/autoptsserver.py
+++ b/autoptsserver.py
@@ -152,6 +152,7 @@ class PyPTSWithCallback(ptscontrol.PyPTS, threading.Thread):
         self.client_callback = None
 
     def _replug_dongle(self):
+        log(f"{self._replug_dongle.__name__}")
         ykush_port = self.args.ykush
         if not ykush_port:
             return

--- a/cliparser.py
+++ b/cliparser.py
@@ -22,7 +22,7 @@ from distutils.spawn import find_executable
 from autopts.config import SERVER_PORT, CLIENT_PORT
 from autopts.ptsprojects.boards import tty_exists, com_to_tty
 from autopts.ptsprojects.testcase_db import DATABASE_FILE
-from autopts.utils import usb_power
+from autopts.utils import ykush_replug_usb
 
 
 class CliParser(argparse.ArgumentParser):
@@ -166,8 +166,7 @@ class CliParser(argparse.ArgumentParser):
     def check_args_tty(self, args):
         if args.ykush:
             # If ykush is used, the board could be unplugged right now
-            usb_power(args.ykush, True)
-            time.sleep(1)
+            ykush_replug_usb(args.ykush, device_id=args.tty_file, delay=2)
 
         if not tty_exists(args.tty_file):
             return 'TTY mode: {} serial port does not exist!\n'.format(repr(args.tty_file))


### PR DESCRIPTION
If interrupt was sent after Superguard timeout and a wid was badly implemented, e.g. in a blocking way, it was possible to end up with multiple BTPWorker threads.