### PR TITLE
mynewt: add Mesh init to preconditions

### DIFF
--- a/autopts/ptsprojects/mynewt/mesh.py
+++ b/autopts/ptsprojects/mynewt/mesh.py
@@ -165,6 +165,7 @@ def test_cases(ptses):
         TestFunc(btp.core_reg_svc_gap),
         TestFunc(btp.core_reg_svc_mesh),
         TestFunc(btp.gap_read_ctrl_info),
+        TestFunc(btp.mesh_init),
         TestFunc(lambda: pts.update_pixit_param(
             "MESH", "TSPX_bd_addr_iut",
             stack.gap.iut_addr_get_str())),


### PR DESCRIPTION
This is needed because advertising is now enabled via mesh_start. Mesh init only initialises stack now.