### PR TITLE
client: Clear the wid queue before retrying a test case

### DIFF
--- a/autopts/client.py
+++ b/autopts/client.py
@@ -889,6 +889,10 @@ class LTThread(InterruptableThread):
         finally:
             finish_count.add(1)
 
+    def interrupt(self):
+        stack.get_stack().synch.cancel_synch()
+        super().interrupt()
+
     def _run_test_case(self, pts, test_case, exceptions, finish_count):
         """Runs the test case specified by a TestCase instance."""
         log("Starting TestCase %s %s", self._run_test_case.__name__,

--- a/autopts/ptsprojects/stack.py
+++ b/autopts/ptsprojects/stack.py
@@ -21,7 +21,7 @@ from time import sleep
 
 from autopts.pybtp import defs
 from autopts.pybtp.types import AdType, Addr, IOCap
-from autopts.utils import raise_on_global_end
+from autopts.utils import raise_on_global_end, ResultWithFlag
 
 STACK = None
 log = logging.debug
@@ -1606,10 +1606,10 @@ class SynchPoint:
         self.test_case = test_case
         self.wid = wid
         self.delay = delay
-        self.done = threading.Event()
+        self.done = None
 
     def set_done(self):
-        self.done.set()
+        self.done.set(True)
 
     def clear(self):
         self.done.clear()
@@ -1681,6 +1681,11 @@ class Synch:
         self._synch_table.clear()
 
     def add_synch_element(self, elem):
+        for sync_point in elem:
+            # If a test case has to be repeated, its SyncPoints will be reused.
+            # Reinit done-flags to renew potentially broken locks.
+            sync_point.done = ResultWithFlag()
+
         self._synch_table.append(SynchElem(elem))
 
     def wait_for_start(self, wid, tc_name):

--- a/autopts/ptsprojects/testcase.py
+++ b/autopts/ptsprojects/testcase.py
@@ -409,8 +409,8 @@ class TestCase(PTSCallback):
         self.verify_wids = verify_wids
         self.ok_cancel_wids = ok_cancel_wids
         self.generic_wid_hdl = generic_wid_hdl
-        self.steps_queue = queue.Queue()
-        self.post_wid_queue = []
+        self.steps_queue = None
+        self.post_wid_queue = None
         self.ptsproject_name = ptsproject_name
         self.tc_subproc = None
         self.lf_subproc = None
@@ -418,8 +418,11 @@ class TestCase(PTSCallback):
         self.log_dir = log_dir
 
     def reset(self):
+        # Fields that have to be reinit before retrying a test case
         self.status = "init"
         self.state = None
+        self.steps_queue = queue.Queue()
+        self.post_wid_queue = []
 
     def __str__(self):
         """Returns string representation"""


### PR DESCRIPTION
and break LT thread barrier in case there was a Superguard timeout. Fixes a case where at retrying a test case the LT threads were waiting at two different SynchPoints, because there was an old wid in step queue.