### PR TITLE
zephyr: tester: MCP tests

### DIFF
--- a/autopts/ptsprojects/zephyr/mcp.py
+++ b/autopts/ptsprojects/zephyr/mcp.py
@@ -89,10 +89,19 @@ def test_cases(ptses):
     test_case_name_list = pts.get_test_case_list('MCP')
     tc_list = []
 
+    pre_conditions_server = pre_conditions.copy()
+    pre_conditions_server[11] = TestFunc(btp.core_reg_svc_gmcs)
+    pre_conditions_server[13] = TestFunc(stack.gmcs_init)
+
     for tc_name in test_case_name_list:
-        instance = ZTestCase("MCP", tc_name,
-                             cmds=pre_conditions,
-                             generic_wid_hdl=mcp_wid_hdl)
+        if tc_name == 'MCP/SR/SP/BV-01-C':
+            instance = ZTestCase("MCP", tc_name,
+                                 cmds=pre_conditions_server,
+                                 generic_wid_hdl=mcp_wid_hdl)
+        else:
+            instance = ZTestCase("MCP", tc_name,
+                                 cmds=pre_conditions,
+                                 generic_wid_hdl=mcp_wid_hdl)
         tc_list.append(instance)
 
     return tc_list

--- a/autopts/pybtp/btp/mcp.py
+++ b/autopts/pybtp/btp/mcp.py
@@ -507,8 +507,6 @@ def mcp_icon_obj_id_ev(mcp, data, data_len):
     obj_id_bytes = data[-6:]
     obj_id = int.from_bytes(obj_id_bytes, byteorder='little', signed=False)
 
-    addr = binascii.hexlify(addr[::-1]).lower().decode('utf-8')
-
     logging.debug(f'MCP Icon Object ID: addr {addr} addr_type {addr_type},'
                   f' Status {status}, Icon Object ID {obj_id}')
 
@@ -547,8 +545,6 @@ def mcp_parent_group_obj_id_ev(mcp, data, data_len):
     obj_id_bytes = data[-6:]
     obj_id = int.from_bytes(obj_id_bytes, byteorder='little', signed=False)
 
-    addr = binascii.hexlify(addr[::-1]).lower().decode('utf-8')
-
     logging.debug(f'MCP Parent Group Object ID: addr {addr} addr_type {addr_type},'
                   f' Status {status}, Parent Group Object ID {obj_id}')
 
@@ -568,10 +564,8 @@ def mcp_current_group_obj_id_ev(mcp, data, data_len):
     obj_id_bytes = data[-6:]
     obj_id = int.from_bytes(obj_id_bytes, byteorder='little', signed=False)
 
-    addr = binascii.hexlify(addr[::-1]).lower().decode('utf-8')
-
     logging.debug(f'MCP Current Group Object ID: addr {addr} addr_type {addr_type},'
-                  f' Status {status}, Parent Group Object ID {obj_id}')
+                  f' Status {status}, Current Group Object ID {obj_id}')
 
     mcp.event_received(defs.MCP_CURRENT_GROUP_OBJ_ID_EV, (addr_type, addr, status,
                                                           obj_id))
@@ -678,8 +672,6 @@ def mcp_segments_obj_id_ev(mcp, data, data_len):
     addr = binascii.hexlify(addr[::-1]).lower().decode('utf-8')
     obj_id_bytes = data[-6:]
     obj_id = int.from_bytes(obj_id_bytes, byteorder='little', signed=False)
-
-    addr = binascii.hexlify(addr[::-1]).lower().decode('utf-8')
 
     logging.debug(f'MCP Track Segments Object ID: addr {addr} addr_type {addr_type},'
                   f' Status {status}, Track Segments Object ID {obj_id}')

--- a/autopts/wid/mcp.py
+++ b/autopts/wid/mcp.py
@@ -201,6 +201,15 @@ def hdl_wid_41(params: WIDParams):
     return True
 
 
+def hdl_wid_20001(_: WIDParams):
+    """Please prepare IUT into a connectable mode. Verify that the
+    Implementation Under Test (IUT) can accept GATT connect request from PTS."""
+    stack = get_stack()
+    btp.gap_set_conn()
+    btp.gap_adv_ind_on(ad=stack.gap.ad)
+    return True
+
+
 def hdl_wid_20100(params: WIDParams):
     """
     Please initiate a GATT connection to the PTS. Verify that the Implementation
@@ -331,9 +340,24 @@ def hdl_wid_20110(params: WIDParams):
     addr_type = btp.pts_addr_type_get()
     addr = btp.pts_addr_get()
 
-    if "0x0101" in params.description:
-        btp.mcp_next_track_obj_id_set(100, addr_type, addr)
+    if "0x00F3" in params.description:
+        btp.mcp_track_position_set(100, addr_type, addr)
+        ev = stack.mcp.wait_track_position_ev(addr_type, addr, 10)
+    elif "0x00F6" in params.description:
+        btp.mcp_playback_speed_set(64, addr_type, addr)
+        ev = stack.mcp.wait_playback_speed_ev(addr_type, addr, 10)
+    elif "0x0101" in params.description:
+        btp.mcp_next_track_obj_id_set(16777477, addr_type, addr)
         ev = stack.mcp.wait_next_track_obj_id_ev(addr_type, addr, 10)
+    elif "0x0104" in params.description:
+        btp.mcp_current_group_obj_id_set(16777498, addr_type, addr)
+        ev = stack.mcp.wait_current_group_obj_id_ev(addr_type, addr, 10)
+    elif "0x0107" in params.description:
+        btp.mcp_playing_order_set(2, addr_type, addr)
+        ev = stack.mcp.wait_playing_order_ev(addr_type, addr, 10)
+    elif "0x00FE" in params.description:
+        btp.mcp_current_track_obj_id_set(16777499, addr_type, addr)
+        ev = stack.mcp.wait_current_track_obj_id_ev(addr_type, addr, 10)
 
     if ev is None:
         return False


### PR DESCRIPTION
Adding missing handler for MCP/SR/SP/BV-01-C testcase. Although this is MCP testcase, it uses Generic Media Control Service - merge after [PR#1054](https://github.com/auto-pts/auto-pts/pull/1054)