### PR TITLE
Fix Exception: unknown encoding: idna

### DIFF
--- a/autoptsclient-zephyr.py
+++ b/autoptsclient-zephyr.py
@@ -16,6 +16,11 @@
 #
 
 """Zephyr auto PTS client"""
+
+# Workaround for Exception: unknown encoding: idna
+# that appears randomly in embedded Python distribution.
+# Issue #1021.
+import encodings.idna
 import importlib
 
 from autopts import client as autoptsclient


### PR DESCRIPTION
Workaround for Exception: unknown encoding: idna that appears randomly in embedded Python distribution.
Fixes #1021.