### PR TITLE
zephyr: Add CCP to overlay-le-audio.conf

### DIFF
--- a/autopts/bot/iut_config/zephyr.py
+++ b/autopts/bot/iut_config/zephyr.py
@@ -142,7 +142,7 @@ iut_config = {
         },
         "test_cases": [
             'VOCS', 'VCS', 'AICS', 'IAS', 'PACS', 'ASCS', 'BAP', 'HAS', 'CSIS', 'MICP',
-            'MICS', 'VCP', 'MCP', 'CAP', 'BASS', 'GMCS'
+            'MICS', 'VCP', 'MCP', 'CAP', 'BASS', 'GMCS', 'CCP'
         ]
     },
 


### PR DESCRIPTION
To enable CCP tests in the bot runs.