### PR TITLE
zephyr: Update workspace to turn off the BAP/BA/BASS/BV-08-C

### DIFF
--- a/autopts/workspaces/zephyr/zephyr-master/zephyr-master.pqw6
+++ b/autopts/workspaces/zephyr/zephyr-master/zephyr-master.pqw6
@@ -4589,7 +4589,7 @@
           <Row>
             <Name>TSPC_BAP_88_5</Name>
             <Description>SyncInfo Transfer (O)</Description>
-            <Value>TRUE</Value>
+            <Value>FALSE</Value>
             <Mandatory>FALSE</Mandatory>
           </Row>
           <Row>


### PR DESCRIPTION
Zephyr controller does not support the PAST procedure, so it will not be able to transfer SyncInfo to Scan Delegator.