### PR TITLE
synch: Stop all LTs if one of LTs failed its test case

### DIFF
--- a/autopts/wid/bap.py
+++ b/autopts/wid/bap.py
@@ -55,7 +55,8 @@ def hdl_wid_20100(params: WIDParams):
     stack = get_stack()
 
     btp.gap_conn()
-    stack.gap.gap_wait_for_sec_lvl_change(30)
+    stack.gap.wait_for_connection(timeout=5, addr=addr)
+    stack.gap.gap_wait_for_sec_lvl_change(level=2, timeout=30)
 
     btp.bap_discover(addr_type, addr)
     stack.bap.wait_discovery_completed_ev(addr_type, addr, 30)

--- a/autopts/wid/gap.py
+++ b/autopts/wid/gap.py
@@ -1043,7 +1043,7 @@ def hdl_wid_206(params: WIDParams):
     try:
         btp.gap_passkey_entry_rsp(bd_addr, bd_addr_type, passkey)
     except types.BTPError:
-        if (stack.gap.is_connected(0) == False):
+        if (stack.gap.is_connected() == False):
             logging.debug("Ignoring expected error on disconnected")
         else:
             return False

--- a/autopts/wid/mcp.py
+++ b/autopts/wid/mcp.py
@@ -219,7 +219,8 @@ def hdl_wid_20100(params: WIDParams):
     addr = btp.pts_addr_get()
     stack = get_stack()
     btp.gap_conn()
-    stack.gap.gap_wait_for_sec_lvl_change(30)
+    stack.gap.wait_for_connection(timeout=5, addr=addr)
+    stack.gap.gap_wait_for_sec_lvl_change(level=2, timeout=30)
     btp.mcp_discover(addr_type, addr)
     ev = stack.mcp.wait_discovery_completed_ev(addr_type, addr, 20, remove=False)
     if ev is None:

--- a/autopts/wid/micp.py
+++ b/autopts/wid/micp.py
@@ -156,7 +156,8 @@ def hdl_wid_20100(params: WIDParams):
     addr = btp.pts_addr_get()
     stack = get_stack()
     btp.gap_conn()
-    stack.gap.gap_wait_for_sec_lvl_change(30)
+    stack.gap.wait_for_connection(timeout=5, addr=addr)
+    stack.gap.gap_wait_for_sec_lvl_change(level=2, timeout=30)
     btp.micp_discover(addr_type, addr)
     ev = stack.micp.wait_discovery_completed_ev(addr_type, addr, 30, remove=False)
     if ev is None:

--- a/autopts/wid/sm.py
+++ b/autopts/wid/sm.py
@@ -203,7 +203,7 @@ def hdl_wid_155(_: WIDParams):
 
 def hdl_wid_156(_: WIDParams):
     stack = get_stack()
-    return not stack.gap.is_connected(0)
+    return not stack.gap.is_connected()
 
 
 def hdl_wid_173(_: WIDParams):

--- a/autopts/wid/vcp.py
+++ b/autopts/wid/vcp.py
@@ -138,7 +138,8 @@ def hdl_wid_20100(params: WIDParams):
     addr = btp.pts_addr_get()
     stack = get_stack()
     btp.gap_conn()
-    gap_ev = stack.gap.gap_wait_for_sec_lvl_change(30)
+    stack.gap.wait_for_connection(timeout=5, addr=addr)
+    gap_ev = stack.gap.gap_wait_for_sec_lvl_change(level=2, timeout=30)
     if gap_ev is None:
         return False
     btp.vcp_discover(addr_type, addr)


### PR DESCRIPTION
In a test case with multiple LTs, if one of LTs has ended its test case with a failed status, there is no need for the other one to wait any longer at the barrier or to run the remaining test case steps.