### PR TITLE
cliparser: Fix -b/--board option help printout

### DIFF
--- a/cliparser.py
+++ b/cliparser.py
@@ -115,12 +115,11 @@ class CliParser(argparse.ArgumentParser):
             self.add_argument("-j", "--jlink", dest="debugger_snr", type=str, default=None,
                               help="Specify jlink serial number manually.")
 
-            self.add_argument("-b", "--board", dest='board_name',
+            self.add_argument("-b", "--board", dest='board_name', type=str, choices=board_names,
                               help="Used DUT board. This option is used to "
                                    "select DUT reset command that is run before "
                                    "each test case. If board is not specified DUT "
-                                   "will not be reset. Supported boards: %s. "
-                              .format((", ".join(board_names, ),), choices=board_names))
+                                   "will not be reset.")
 
             self.add_argument("--btmon",
                               help="Capture iut btsnoop logs from device over RTT"


### PR DESCRIPTION
Fixes 'board' option help description:
before:
  -b BOARD_NAME, --board BOARD_NAME
                        Used DUT board. This option is used to select DUT reset command that is run before each test case. If board is not specified DUT will not be reset. Supported boards: {'option_strings': ['-b', '--board'], 'dest': 'board_name',
                        'nargs': None, 'const': None, 'default': None, 'type': None, 'choices': None, 'required': False, 'help': 'Used DUT board. This option is used to select DUT reset command that is run before each test case. If board is not
                        specified DUT will not be reset. Supported boards: %s. ', 'metavar': None, 'container': <argparse._ArgumentGroup object at 0x7f05d86a86b0>, 'prog': 'autoptsclient-mynewt.py'}.

after:
  -b {dialog_da1469x_dk_pro,nordic_pca10056,nordic_pca10095}, --board {dialog_da1469x_dk_pro,nordic_pca10056,nordic_pca10095}
                        Used DUT board. This option is used to select DUT reset command that is run before each test case. If board is not specified DUT will not be reset.