### PR TITLE
zephyr: iut_config: Add HAP to overlay-le-audio.conf

### DIFF
--- a/autopts/bot/iut_config/zephyr.py
+++ b/autopts/bot/iut_config/zephyr.py
@@ -142,7 +142,7 @@ iut_config = {
         },
         "test_cases": [
             'VOCS', 'VCS', 'AICS', 'IAS', 'PACS', 'ASCS', 'BAP', 'HAS', 'CSIS', 'MICP',
-            'MICS', 'VCP', 'MCP', 'CAP', 'BASS', 'GMCS', 'CCP'
+            'MICS', 'VCP', 'MCP', 'CAP', 'BASS', 'GMCS', 'CCP', 'HAP'
         ]
     },
 


### PR DESCRIPTION
HAP test cases require the audio overlays.