### PR TITLE
autoptsserver: Fix Win32 exception

### DIFF
--- a/autoptsserver.py
+++ b/autoptsserver.py
@@ -413,8 +413,10 @@ class Server(threading.Thread):
         same context as its instance was initialized.
         """
 
-        pythoncom.CoInitialize()
-        log(f'pythoncom._GetInterfaceCount(): {pythoncom._GetInterfaceCount()}')
+        if threading.current_thread().name != 'MainThread':
+            # Should be called only in threads other than the main one.
+            pythoncom.CoInitialize()
+            log(f'pythoncom._GetInterfaceCount(): {pythoncom._GetInterfaceCount()}')
 
         c = wmi.WMI()
         for iface in c.Win32_NetworkAdapterConfiguration(IPEnabled=True):
@@ -441,8 +443,9 @@ class Server(threading.Thread):
             except BaseException as e:
                 logging.exception(e)
 
-        pythoncom.CoUninitialize()
-        log(f'pythoncom._GetInterfaceCount(): {pythoncom._GetInterfaceCount()}')
+        if threading.current_thread().name != 'MainThread':
+            pythoncom.CoUninitialize()
+            log(f'pythoncom._GetInterfaceCount(): {pythoncom._GetInterfaceCount()}')
 
     def server_init(self):
         if self.server:


### PR DESCRIPTION
Fix the exception:
"Win32 exception occurred releasing IUnknown"
that occured at close up of the autoptserver.py process. CoInitialize and CoUninitialize should be called only in threads other that the MainThread.