### PR TITLE
Update pts workspace for mesh

### DIFF
--- a/autopts/ptsprojects/zephyr/dfu.py
+++ b/autopts/ptsprojects/zephyr/dfu.py
@@ -59,7 +59,7 @@ def set_pixits(ptses):
     pts.set_pixit("DFU", "TSPX_device_uuid", "00000000000000000000000000000000")
     pts.set_pixit("DFU", "TSPX_device_uuid2", "001BDC0810210B0E0A0C000B0E0A0C00")
     pts.set_pixit("DFU", "TSPX_use_pb_gatt_bearer", "FALSE")
-    pts.set_pixit("DFU", "TSPX_iut_comp_data_page", "0")
+    pts.set_pixit("DFU", "TSPX_iut_comp_data_page", "2")
     pts.set_pixit("DFU", "TSPX_oob_state_change", "FALSE")
     pts.set_pixit("DFU", "TSPX_enable_IUT_provisioner", "FALSE")
     pts.set_pixit("DFU", "TSPX_Procedure_Timeout", "60")

--- a/autopts/ptsprojects/zephyr/mbt.py
+++ b/autopts/ptsprojects/zephyr/mbt.py
@@ -59,7 +59,7 @@ def set_pixits(ptses):
     pts.set_pixit("MBT", "TSPX_device_uuid", "00000000000000000000000000000000")
     pts.set_pixit("MBT", "TSPX_device_uuid2", "001BDC0810210B0E0A0C000B0E0A0C00")
     pts.set_pixit("MBT", "TSPX_use_pb_gatt_bearer", "FALSE")
-    pts.set_pixit("MBT", "TSPX_iut_comp_data_page", "0")
+    pts.set_pixit("MBT", "TSPX_iut_comp_data_page", "2")
     pts.set_pixit("MBT", "TSPX_oob_state_change", "FALSE")
     pts.set_pixit("MBT", "TSPX_enable_IUT_provisioner", "FALSE")
     pts.set_pixit("MBT", "TSPX_Procedure_Timeout", "60")

--- a/autopts/ptsprojects/zephyr/mesh.py
+++ b/autopts/ptsprojects/zephyr/mesh.py
@@ -74,6 +74,7 @@ def set_pixits(ptses):
     pts.set_pixit("MESH", "TSPX_vendor_model_id", "05f11234")
     pts.set_pixit("MESH", "TSPX_maximum_network_message_cache_entries", "2")
     pts.set_pixit("MESH", "TSPX_health_valid_test_ids", "00")
+    pts.set_pixit("MESH", "TSPX_iut_comp_data_page", "130")
     pts.set_pixit("MESH", "TSPX_netkeyindex_value", "0")
     pts.set_pixit("MESH", "TSPX_iut_supports_relay", "FALSE")
     pts.set_pixit("MESH", "TSPX_application_key",

--- a/autopts/ptsprojects/zephyr/mmdl.py
+++ b/autopts/ptsprojects/zephyr/mmdl.py
@@ -60,6 +60,7 @@ def set_pixits(ptses):
     pts.set_pixit("MMDL", "TSPX_sensor_property_ids", "1,0069,0010,FFF0")
     pts.set_pixit("MMDL", "TSPX_enable_IUT_provisioner", "FALSE")
     pts.set_pixit("MMDL", "TSPX_cadence_property_IDs", "1,0069,0010,FFF0")
+    pts-set_pixits("MMDL", "TSPX_iut_comp_data_page", "1")
 
 
 def test_cases(ptses):

--- a/autopts/workspaces/zephyr/zephyr-master/zephyr-master.pqw6
+++ b/autopts/workspaces/zephyr/zephyr-master/zephyr-master.pqw6
@@ -9073,6 +9073,326 @@
         </Rows>
       </PIXIT>
     </PROJECT_INFORMATION>
+    <PROJECT_INFORMATION NAME="DFU" TC_LOG="tc_log.xml" TC_SCRIPT="tc_sqript.xml" USERDLL="" USE_USERDLL="False" RUNTIME_LOGGING="False">
+      <PICS>
+        <Name>DFU</Name>
+        <Version />
+        <Rows>
+          <Row>
+            <Name>TSPC_DFU_ALL</Name>
+            <Description>Enables all test cases when set.</Description>
+            <Value>FALSE</Value>
+            <Mandatory>FALSE</Mandatory>
+          </Row>
+          <Row>
+            <Name>TSPC_DFU_0_1</Name>
+            <Description>Mesh Device Firmware Update Model v1.0 (M)</Description>
+            <Value>TRUE</Value>
+            <Mandatory>TRUE</Mandatory>
+          </Row>
+          <Row>
+            <Name>TSPC_DFU_3_1</Name>
+            <Description>Firmware Update Server model (C.1)</Description>
+            <Value>TRUE</Value>
+            <Mandatory>FALSE</Mandatory>
+          </Row>
+          <Row>
+            <Name>TSPC_DFU_3_2</Name>
+            <Description>Firmware Distribution Server model (C.2)</Description>
+            <Value>TRUE</Value>
+            <Mandatory>FALSE</Mandatory>
+          </Row>
+          <Row>
+            <Name>TSPC_DFU_3_3</Name>
+            <Description>Firmware Update Client model (C.3)</Description>
+            <Value>TRUE</Value>
+            <Mandatory>FALSE</Mandatory>
+          </Row>
+          <Row>
+            <Name>TSPC_DFU_3_4</Name>
+            <Description>Firmware Distribution Client model (C.4)</Description>
+            <Value>FALSE</Value>
+            <Mandatory>FALSE</Mandatory>
+          </Row>
+          <Row>
+            <Name>TSPC_DFU_10_1</Name>
+            <Description>BLOB Transfer Server model (M)</Description>
+            <Value>TRUE</Value>
+            <Mandatory>TRUE</Mandatory>
+          </Row>
+          <Row>
+            <Name>TSPC_DFU_11_1</Name>
+            <Description>Pull BLOB Transfer Mode (C.1)</Description>
+            <Value>TRUE</Value>
+            <Mandatory>FALSE</Mandatory>
+          </Row>
+          <Row>
+            <Name>TSPC_DFU_11_2</Name>
+            <Description>Push BLOB Transfer Mode (C.2)</Description>
+            <Value>TRUE</Value>
+            <Mandatory>FALSE</Mandatory>
+          </Row>
+          <Row>
+            <Name>TSPC_DFU_20_1</Name>
+            <Description>Pull BLOB Transfer Mode (M)</Description>
+            <Value>TRUE</Value>
+            <Mandatory>TRUE</Mandatory>
+          </Row>
+          <Row>
+            <Name>TSPC_DFU_21_1</Name>
+            <Description>Pull BLOB Transfer Mode (C.1)</Description>
+            <Value>TRUE</Value>
+            <Mandatory>FALSE</Mandatory>
+          </Row>
+          <Row>
+            <Name>TSPC_DFU_21_2</Name>
+            <Description>Push BLOB Transfer Mode (C.2)</Description>
+            <Value>TRUE</Value>
+            <Mandatory>FALSE</Mandatory>
+          </Row>
+          <Row>
+            <Name>TSPC_DFU_22_1</Name>
+            <Description>Store Firmware OOB procedure (C.1)</Description>
+            <Value>TRUE</Value>
+            <Mandatory>FALSE</Mandatory>
+          </Row>
+          <Row>
+            <Name>TSPC_DFU_22_2</Name>
+            <Description>Firmware Retrieval Over HTTPS procedure (C.1)</Description>
+            <Value>FALSE</Value>
+            <Mandatory>FALSE</Mandatory>
+          </Row>
+          <Row>
+            <Name>TSPC_DFU_22_3</Name>
+            <Description>Multiple Firmware Image Support (O)</Description>
+            <Value>TRUE</Value>
+            <Mandatory>FALSE</Mandatory>
+          </Row>
+          <Row>
+            <Name>TSPC_DFU_30_1</Name>
+            <Description>BLOB Transfer Client model (M)</Description>
+            <Value>TRUE</Value>
+            <Mandatory>TRUE</Mandatory>
+          </Row>
+          <Row>
+            <Name>TSPC_DFU_40_1</Name>
+            <Description>BLOB Transfer Client model (M)</Description>
+            <Value>FALSE</Value>
+            <Mandatory>TRUE</Mandatory>
+          </Row>
+          <Row>
+            <Name>TSPC_DFU_41_1</Name>
+            <Description>Upload Firmware OOB procedure (O)</Description>
+            <Value>FALSE</Value>
+            <Mandatory>FALSE</Mandatory>
+          </Row>
+          <Row>
+            <Name>TSPC_ALL</Name>
+            <Description>Enables all test cases when set.</Description>
+            <Value>FALSE</Value>
+            <Mandatory>FALSE</Mandatory>
+          </Row>
+        </Rows>
+      </PICS>
+      <PIXIT>
+        <Name>DFU</Name>
+        <Version>1.0</Version>
+        <Rows>
+          <Row>
+            <Name>TSPX_bd_addr_iut</Name>
+            <Description>The unique 48-bit Bluetooth device address (BD_ADDR) of the IUT. This was filled in during workspace creation.</Description>
+            <Type>OCTETSTRING</Type>
+            <Value>DEADBEEFDEAD</Value>
+          </Row>
+          <Row>
+            <Name>TSPX_time_guard</Name>
+            <Description>The time in milliseconds, to break PTS from waiting for a required event, if time guard is used by the test case. (Default: 300000)</Description>
+            <Type>INTEGER</Type>
+            <Value>300000</Value>
+          </Row>
+          <Row>
+            <Name>TSPX_use_implicit_send</Name>
+            <Description>Whether to receive a message via Implicit Send when an action or attention is needed by test operator. (Default: TRUE)</Description>
+            <Type>BOOLEAN</Type>
+            <Value>TRUE</Value>
+          </Row>
+          <Row>
+            <Name>TSPX_tester_database_file</Name>
+            <Description>Location of SIG database file. (Default: C:\Program Files\Bluetooth SIG\Bluetooth PTS\Data\SIGDatabase\PTS_SMPP_db.xml)</Description>
+            <Type>IA5STRING</Type>
+            <Value>C:\Program Files\Bluetooth SIG\Bluetooth PTS\Data\SIGDatabase\PTS_SMPP_db.xml</Value>
+          </Row>
+          <Row>
+            <Name>TSPX_mtu_size</Name>
+            <Description>MTU size. (Default: 23)</Description>
+            <Type>INTEGER</Type>
+            <Value>23</Value>
+          </Row>
+          <Row>
+            <Name>TSPX_delete_link_key</Name>
+            <Description>Whether to delete link key or not. (Default: FALSE)</Description>
+            <Type>BOOLEAN</Type>
+            <Value>FALSE</Value>
+          </Row>
+          <Row>
+            <Name>TSPX_delete_ltk</Name>
+            <Description>Whether to delete Long Term Key or not. (Default: FALSE)</Description>
+            <Type>BOOLEAN</Type>
+            <Value>FALSE</Value>
+          </Row>
+          <Row>
+            <Name>TSPX_security_enabled</Name>
+            <Description>Whether to set security for the test suite. (Default: FALSE)</Description>
+            <Type>BOOLEAN</Type>
+            <Value>FALSE</Value>
+          </Row>
+          <Row>
+            <Name>TSPX_iut_setup_att_over_br_edr</Name>
+            <Description>IUT can optionally test ATT over BR/EDR connection when this flag is set when applicable. (Default: FALSE)</Description>
+            <Type>BOOLEAN</Type>
+            <Value>FALSE</Value>
+          </Row>
+          <Row>
+            <Name>TSPX_scan_interval</Name>
+            <Description>The scan interval value N*0.625ms. Default is setto fast scan interval.(Default: 30)</Description>
+            <Type>INTEGER</Type>
+            <Value>30</Value>
+          </Row>
+          <Row>
+            <Name>TSPX_scan_window</Name>
+            <Description>The scan window value N*0.625ms. Default is set to fast scan window.(Default: 30)</Description>
+            <Type>INTEGER</Type>
+            <Value>30</Value>
+          </Row>
+          <Row>
+            <Name>TSPX_scan_filter</Name>
+            <Description>The scan filter setting to allow accept filter accept list only device.(Default: 0 - Fileter none)</Description>
+            <Type>OCTETSTRING</Type>
+            <Value>00</Value>
+          </Row>
+          <Row>
+            <Name>TSPX_advertising_interval_min</Name>
+            <Description>The minimum advertising interval value N*0.625ms. PTS will using this value to set advertising parameters.(Default: 160)</Description>
+            <Type>INTEGER</Type>
+            <Value>160</Value>
+          </Row>
+          <Row>
+            <Name>TSPX_advertising_interval_max</Name>
+            <Description>The maximum advertising interval value N*0.625ms. PTS will using this value to set advertising parameters.(Default: 160)</Description>
+            <Type>INTEGER</Type>
+            <Value>160</Value>
+          </Row>
+          <Row>
+            <Name>TSPX_tester_OOB_information</Name>
+            <Description>The 16-bit tester OOB information value. PTS will advertise using this value when in peripheral role.(Default: F87F)</Description>
+            <Type>OCTETSTRING</Type>
+            <Value>F87F</Value>
+          </Row>
+          <Row>
+            <Name>TSPX_device_uuid</Name>
+            <Description>used for mesh beacon. (Default: 001BDC0810210B0E0A0C000B0E0A0C00)</Description>
+            <Type>OCTETSTRING</Type>
+            <Value>001BDC0810210B0E0A0C000B0E0A0C00</Value>
+          </Row>
+          <Row>
+            <Name>TSPX_device_uuid2</Name>
+            <Description>used for tester2 mesh beacon. (Default: 00000000000000000000000000000000)</Description>
+            <Type>OCTETSTRING</Type>
+            <Value>00000000000000000000000000000000</Value>
+          </Row>
+          <Row>
+            <Name>TSPX_use_pb_gatt_bearer</Name>
+            <Description>PB ADV or PB GATT bearer for PROT test cases. (Default: TRUE - PB-ADV)</Description>
+            <Type>BOOLEAN</Type>
+            <Value>FALSE</Value>
+          </Row>
+          <Row>
+            <Name>TSPX_iut_comp_data_page</Name>
+            <Description>The page number of the composition data (Default: 0)</Description>
+            <Type>INTEGER</Type>
+            <Value>0</Value>
+          </Row>
+          <Row>
+            <Name>TSPX_oob_state_change</Name>
+            <Description>Indicates if the IUT supports out-of-band triggered state changes. If set to TRUE, then the IUT supports Upper Tester commands to trigger a state change. (Default: FALSE)</Description>
+            <Type>BOOLEAN</Type>
+            <Value>FALSE</Value>
+          </Row>
+          <Row>
+            <Name>TSPX_enable_IUT_provisioner</Name>
+            <Description>Indicates if the IUT performs provisioning for client cases. If set to TRUE, PTS expects to get provisioned by the IUT. (Default: FALSE)</Description>
+            <Type>BOOLEAN</Type>
+            <Value>FALSE</Value>
+          </Row>
+          <Row>
+            <Name>TSPX_Procedure_Timeout</Name>
+            <Description>The time in seconds. (Default: 60)</Description>
+            <Type>INTEGER</Type>
+            <Value>60</Value>
+          </Row>
+          <Row>
+            <Name>TSPX_Client_BLOB_ID</Name>
+            <Description>Unique identifier for the BLOB being transferred by the BLOB Transfer Client IUT. (Default: 1)</Description>
+            <Type>OCTETSTRING</Type>
+            <Value>1100000000000011</Value>
+          </Row>
+          <Row>
+            <Name>TSPX_Client_BLOB_Data</Name>
+            <Description>BLOB being transferred by the IUT.</Description>
+            <Type>IA5STRING</Type>
+            <Value />
+          </Row>
+          <Row>
+            <Name>TSPX_TTL</Name>
+            <Description>TTL. (Default: 2)</Description>
+            <Type>INTEGER</Type>
+            <Value>2</Value>
+          </Row>
+          <Row>
+            <Name>TSPX_Reception_Counter</Name>
+            <Description>Reception Counter for the Pull BLOB Transfer Mode. (Default: 5)</Description>
+            <Type>INTEGER</Type>
+            <Value>5</Value>
+          </Row>
+          <Row>
+            <Name>TSPX_Server_Timeout</Name>
+            <Description>Timer value before Server enters Suspended state. (Default: 60)</Description>
+            <Type>INTEGER</Type>
+            <Value>60</Value>
+          </Row>
+          <Row>
+            <Name>TSPX_Firmware_ID</Name>
+            <Description>Firmware_ID used by device to varify firmware.(Default: 1)</Description>
+            <Type>OCTETSTRING</Type>
+            <Value>11000011</Value>
+          </Row>
+          <Row>
+            <Name>TSPX_Firmware_Metadata</Name>
+            <Description>Firmware metadata for the incoming firmware on the IUT. (Default: )</Description>
+            <Type>OCTETSTRING</Type>
+            <Value>1100000000000011</Value>
+          </Row>
+          <Row>
+            <Name>TSPX_Firmware_Update_URI</Name>
+            <Description>URI used for test case execution. (Default: http://www.dummy.com)</Description>
+            <Type>IA5STRING</Type>
+            <Value>http://www.dummy.com</Value>
+          </Row>
+          <Row>
+            <Name>TSPX_New_Firmware_Image</Name>
+            <Description>Firmware being transferred by the IUT.</Description>
+            <Type>IA5STRING</Type>
+            <Value />
+          </Row>
+          <Row>
+            <Name>TSPX_Update_Firmware_Image_Index</Name>
+            <Description>Firmware Image Index value to identiy firmware used for testing. (Default: 0)</Description>
+            <Type>INTEGER</Type>
+            <Value>0</Value>
+          </Row>
+        </Rows>
+      </PIXIT>
+    </PROJECT_INFORMATION>
     <PROJECT_INFORMATION NAME="DIS" TC_LOG="tc_log.xml" TC_SCRIPT="tc_sqript.xml" USERDLL="" USE_USERDLL="False" RUNTIME_LOGGING="False">
       <PICS>
         <Name>DIS</Name>
@@ -16576,6 +16896,266 @@
         </Rows>
       </PIXIT>
     </PROJECT_INFORMATION>
+    <PROJECT_INFORMATION NAME="MBT" TC_LOG="tc_log.xml" TC_SCRIPT="tc_sqript.xml" USERDLL="" USE_USERDLL="False" RUNTIME_LOGGING="False">
+      <PICS>
+        <Name>MBT</Name>
+        <Version />
+        <Rows>
+          <Row>
+            <Name>TSPC_MBT_ALL</Name>
+            <Description>Enables all test cases when set.</Description>
+            <Value>FALSE</Value>
+            <Mandatory>FALSE</Mandatory>
+          </Row>
+          <Row>
+            <Name>TSPC_MBT_0_1</Name>
+            <Description>Mesh Binary Large Object Transfer Model v1.0 (M)</Description>
+            <Value>TRUE</Value>
+            <Mandatory>TRUE</Mandatory>
+          </Row>
+          <Row>
+            <Name>TSPC_MBT_3_1</Name>
+            <Description>BLOB Transfer Server model (C.1)</Description>
+            <Value>TRUE</Value>
+            <Mandatory>FALSE</Mandatory>
+          </Row>
+          <Row>
+            <Name>TSPC_MBT_3_2</Name>
+            <Description>BLOB Transfer Client model (C.1)</Description>
+            <Value>TRUE</Value>
+            <Mandatory>FALSE</Mandatory>
+          </Row>
+          <Row>
+            <Name>TSPC_MBT_10_1</Name>
+            <Description>Pull BLOB Transfer Mode (C.1)</Description>
+            <Value>TRUE</Value>
+            <Mandatory>FALSE</Mandatory>
+          </Row>
+          <Row>
+            <Name>TSPC_MBT_10_2</Name>
+            <Description>Push BLOB Transfer Mode (C.2)</Description>
+            <Value>TRUE</Value>
+            <Mandatory>FALSE</Mandatory>
+          </Row>
+          <Row>
+            <Name>TSPC_MBT_20_1</Name>
+            <Description>Pull BLOB Transfer Mode (M)</Description>
+            <Value>TRUE</Value>
+            <Mandatory>TRUE</Mandatory>
+          </Row>
+          <Row>
+            <Name>TSPC_MBT_20_2</Name>
+            <Description>Push BLOB Transfer Mode (M)</Description>
+            <Value>TRUE</Value>
+            <Mandatory>TRUE</Mandatory>
+          </Row>
+          <Row>
+            <Name>TSPC_ALL</Name>
+            <Description>Enables all test cases when set.</Description>
+            <Value>FALSE</Value>
+            <Mandatory>FALSE</Mandatory>
+          </Row>
+        </Rows>
+      </PICS>
+      <PIXIT>
+        <Name>MBT</Name>
+        <Version>1.0</Version>
+        <Rows>
+          <Row>
+            <Name>TSPX_bd_addr_iut</Name>
+            <Description>The unique 48-bit Bluetooth device address (BD_ADDR) of the IUT. This was filled in during workspace creation.</Description>
+            <Type>OCTETSTRING</Type>
+            <Value>DEADBEEFDEAD</Value>
+          </Row>
+          <Row>
+            <Name>TSPX_time_guard</Name>
+            <Description>The time in milliseconds, to break PTS from waiting for a required event, if time guard is used by the test case. (Default: 300000)</Description>
+            <Type>INTEGER</Type>
+            <Value>300000</Value>
+          </Row>
+          <Row>
+            <Name>TSPX_use_implicit_send</Name>
+            <Description>Whether to receive a message via Implicit Send when an action or attention is needed by test operator. (Default: TRUE)</Description>
+            <Type>BOOLEAN</Type>
+            <Value>TRUE</Value>
+          </Row>
+          <Row>
+            <Name>TSPX_tester_database_file</Name>
+            <Description>Location of SIG database file. (Default: C:\Program Files\Bluetooth SIG\Bluetooth PTS\Data\SIGDatabase\PTS_SMPP_db.xml)</Description>
+            <Type>IA5STRING</Type>
+            <Value>C:\Program Files\Bluetooth SIG\Bluetooth PTS\Data\SIGDatabase\PTS_SMPP_db.xml</Value>
+          </Row>
+          <Row>
+            <Name>TSPX_mtu_size</Name>
+            <Description>MTU size. (Default: 23)</Description>
+            <Type>INTEGER</Type>
+            <Value>23</Value>
+          </Row>
+          <Row>
+            <Name>TSPX_delete_link_key</Name>
+            <Description>Whether to delete link key or not. (Default: FALSE)</Description>
+            <Type>BOOLEAN</Type>
+            <Value>FALSE</Value>
+          </Row>
+          <Row>
+            <Name>TSPX_delete_ltk</Name>
+            <Description>Whether to delete Long Term Key or not. (Default: FALSE)</Description>
+            <Type>BOOLEAN</Type>
+            <Value>FALSE</Value>
+          </Row>
+          <Row>
+            <Name>TSPX_security_enabled</Name>
+            <Description>Whether to set security for the test suite. (Default: FALSE)</Description>
+            <Type>BOOLEAN</Type>
+            <Value>FALSE</Value>
+          </Row>
+          <Row>
+            <Name>TSPX_iut_setup_att_over_br_edr</Name>
+            <Description>IUT can optionally test ATT over BR/EDR connection when this flag is set when applicable. (Default: FALSE)</Description>
+            <Type>BOOLEAN</Type>
+            <Value>FALSE</Value>
+          </Row>
+          <Row>
+            <Name>TSPX_scan_interval</Name>
+            <Description>The scan interval value N*0.625ms. Default is setto fast scan interval.(Default: 30)</Description>
+            <Type>INTEGER</Type>
+            <Value>30</Value>
+          </Row>
+          <Row>
+            <Name>TSPX_scan_window</Name>
+            <Description>The scan window value N*0.625ms. Default is set to fast scan window.(Default: 30)</Description>
+            <Type>INTEGER</Type>
+            <Value>30</Value>
+          </Row>
+          <Row>
+            <Name>TSPX_scan_filter</Name>
+            <Description>The scan filter setting to allow accept filter accept list only device.(Default: 0 - Fileter none)</Description>
+            <Type>OCTETSTRING</Type>
+            <Value>00</Value>
+          </Row>
+          <Row>
+            <Name>TSPX_advertising_interval_min</Name>
+            <Description>The minimum advertising interval value N*0.625ms. PTS will using this value to set advertising parameters.(Default: 160)</Description>
+            <Type>INTEGER</Type>
+            <Value>160</Value>
+          </Row>
+          <Row>
+            <Name>TSPX_advertising_interval_max</Name>
+            <Description>The maximum advertising interval value N*0.625ms. PTS will using this value to set advertising parameters.(Default: 160)</Description>
+            <Type>INTEGER</Type>
+            <Value>160</Value>
+          </Row>
+          <Row>
+            <Name>TSPX_tester_OOB_information</Name>
+            <Description>The 16-bit tester OOB information value. PTS will advertise using this value when in peripheral role.(Default: F87F)</Description>
+            <Type>OCTETSTRING</Type>
+            <Value>F87F</Value>
+          </Row>
+          <Row>
+            <Name>TSPX_device_uuid</Name>
+            <Description>used for mesh beacon. (Default: 001BDC0810210B0E0A0C000B0E0A0C00)</Description>
+            <Type>OCTETSTRING</Type>
+            <Value>001BDC0810210B0E0A0C000B0E0A0C00</Value>
+          </Row>
+          <Row>
+            <Name>TSPX_device_uuid2</Name>
+            <Description>used for tester2 mesh beacon. (Default: 00000000000000000000000000000000)</Description>
+            <Type>OCTETSTRING</Type>
+            <Value>00000000000000000000000000000000</Value>
+          </Row>
+          <Row>
+            <Name>TSPX_use_pb_gatt_bearer</Name>
+            <Description>PB ADV or PB GATT bearer for PROT test cases. (Default: TRUE - PB-ADV)</Description>
+            <Type>BOOLEAN</Type>
+            <Value>FALSE</Value>
+          </Row>
+          <Row>
+            <Name>TSPX_iut_comp_data_page</Name>
+            <Description>The page number of the composition data (Default: 0)</Description>
+            <Type>INTEGER</Type>
+            <Value>0</Value>
+          </Row>
+          <Row>
+            <Name>TSPX_oob_state_change</Name>
+            <Description>Indicates if the IUT supports out-of-band triggered state changes. If set to TRUE, then the IUT supports Upper Tester commands to trigger a state change. (Default: FALSE)</Description>
+            <Type>BOOLEAN</Type>
+            <Value>FALSE</Value>
+          </Row>
+          <Row>
+            <Name>TSPX_enable_IUT_provisioner</Name>
+            <Description>Indicates if the IUT performs provisioning for client cases. If set to TRUE, PTS expects to get provisioned by the IUT. (Default: FALSE)</Description>
+            <Type>BOOLEAN</Type>
+            <Value>FALSE</Value>
+          </Row>
+          <Row>
+            <Name>TSPX_Procedure_Timeout</Name>
+            <Description>The time in seconds. (Default: 60)</Description>
+            <Type>INTEGER</Type>
+            <Value>60</Value>
+          </Row>
+          <Row>
+            <Name>TSPX_Client_BLOB_ID</Name>
+            <Description>Unique identifier for the BLOB being transferred by the BLOB Transfer Client IUT. (Default: 1)</Description>
+            <Type>OCTETSTRING</Type>
+            <Value>1100000000000011</Value>
+          </Row>
+          <Row>
+            <Name>TSPX_Client_BLOB_Data</Name>
+            <Description>BLOB being transferred by the IUT.</Description>
+            <Type>IA5STRING</Type>
+            <Value />
+          </Row>
+          <Row>
+            <Name>TSPX_Transfer_TTL</Name>
+            <Description>TTL. (Default: 3)</Description>
+            <Type>INTEGER</Type>
+            <Value>3</Value>
+          </Row>
+          <Row>
+            <Name>TSPX_Reception_Counter</Name>
+            <Description>Reception Counter for the Pull BLOB Transfer Mode. (Default: 5)</Description>
+            <Type>INTEGER</Type>
+            <Value>5</Value>
+          </Row>
+          <Row>
+            <Name>TSPX_Server_Timeout</Name>
+            <Description>Timer value before Server enters Suspended state. (Default: 60)</Description>
+            <Type>INTEGER</Type>
+            <Value>60</Value>
+          </Row>
+          <Row>
+            <Name>TSPX_Firmware_ID</Name>
+            <Description>Firmware_ID used by device to varify firmware.(Default: 1)</Description>
+            <Type>OCTETSTRING</Type>
+            <Value>11000011</Value>
+          </Row>
+          <Row>
+            <Name>TSPX_Firmware_Metadata</Name>
+            <Description>Firmware metadata for the incoming firmware on the IUT. (Default: )</Description>
+            <Type>OCTETSTRING</Type>
+            <Value>1100000000000011</Value>
+          </Row>
+          <Row>
+            <Name>TSPX_Firmware_Update_URI</Name>
+            <Description>URI used for test case execution. (Default: http://www.dummy.com)</Description>
+            <Type>IA5STRING</Type>
+            <Value>http://www.dummy.com</Value>
+          </Row>
+          <Row>
+            <Name>TSPX_New_Firmware_Image</Name>
+            <Description>Firmware being transferred by the IUT.</Description>
+            <Type>IA5STRING</Type>
+            <Value />
+          </Row>
+          <Row>
+            <Name>TSPX_Update_Firmware_Image_Index</Name>
+            <Description>Firmware Image Index value to identiy firmware used for testing. (Default: 0)</Description>
+            <Type>INTEGER</Type>
+            <Value>0</Value>
+          </Row>
+        </Rows>
+      </PIXIT>
+    </PROJECT_INFORMATION>
     <PROJECT_INFORMATION NAME="MCP" TC_LOG="tc_log.xml" TC_SCRIPT="tc_sqript.xml" USERDLL="" USE_USERDLL="False" RUNTIME_LOGGING="False">
       <PICS>
         <Name>MCP</Name>
@@ -17521,32 +18101,32 @@
           <Row>
             <Name>TSPC_MESH_0_1</Name>
             <Description>Mesh v1.0 (C.1)</Description>
-            <Value>TRUE</Value>
+            <Value>FALSE</Value>
             <Mandatory>FALSE</Mandatory>
           </Row>
           <Row>
             <Name>TSPC_MESH_0_2</Name>
             <Description>Mesh v1.1 (C.1)</Description>
-            <Value>FALSE</Value>
+            <Value>TRUE</Value>
             <Mandatory>FALSE</Mandatory>
           </Row>
           <!-- Table 0a: X.Y.Z. Versions -->
           <Row>
             <Name>TSPC_MESH_0a_1</Name>
             <Description>Erratum 10395 (C.1)</Description>
-            <Value>TRUE</Value>
+            <Value>FALSE</Value>
             <Mandatory>FALSE</Mandatory>
           </Row>
           <Row>
             <Name>TSPC_MESH_0a_2</Name>
             <Description>Mesh v1.0.1 (C.2)</Description>
-            <Value>TRUE</Value>
+            <Value>FALSE</Value>
             <Mandatory>FALSE</Mandatory>
           </Row>
           <Row>
             <Name>TSPC_MESH_0a_3</Name>
             <Description>Erratum 16350 (C.1)</Description>
-            <Value>TRUE</Value>
+            <Value>FALSE</Value>
             <Mandatory>FALSE</Mandatory>
           </Row>
           <!-- Table 2: Roles -->
@@ -17676,25 +18256,25 @@
           <Row>
             <Name>TSPC_MESH_4_14</Name>
             <Description>Provisioning algorithm: ECDH_P256 + HMAC_SHA256 + CCM_AES128 (C.4)</Description>
-            <Value>FALSE</Value>
+            <Value>TRUE</Value>
             <Mandatory>FALSE</Mandatory>
           </Row>
           <Row>
             <Name>TSPC_MESH_4_15</Name>
             <Description>Node Provisioning Protocol Interface (C.5)</Description>
-            <Value>FALSE</Value>
+            <Value>TRUE</Value>
             <Mandatory>FALSE</Mandatory>
           </Row>
           <Row>
             <Name>TSPC_MESH_4_16</Name>
             <Description>Node Address Refresh Procedure (C.5)</Description>
-            <Value>FALSE</Value>
+            <Value>TRUE</Value>
             <Mandatory>FALSE</Mandatory>
           </Row>
           <Row>
             <Name>TSPC_MESH_4_17</Name>
             <Description>Node Composition Refresh Procedure (C.5)</Description>
-            <Value>FALSE</Value>
+            <Value>TRUE</Value>
             <Mandatory>FALSE</Mandatory>
           </Row>
           <Row>
@@ -17838,7 +18418,7 @@
           <Row>
             <Name>TSPC_MESH_10_5</Name>
             <Description>Private Beacon (C.1)</Description>
-            <Value>FALSE</Value>
+            <Value>TRUE</Value>
             <Mandatory>FALSE</Mandatory>
           </Row>
           <!-- Table 11: Node Capabilities - Foundation Mesh Models -->
@@ -17869,13 +18449,13 @@
           <Row>
             <Name>TSPC_MESH_11_5</Name>
             <Description>Private Beacon Server Model (C.1)</Description>
-            <Value>FALSE</Value>
+            <Value>TRUE</Value>
             <Mandatory>FALSE</Mandatory>
           </Row>
           <Row>
             <Name>TSPC_MESH_11_6</Name>
             <Description>Private Beacon Client Model (C.2)</Description>
-            <Value>FALSE</Value>
+            <Value>TRUE</Value>
             <Mandatory>FALSE</Mandatory>
           </Row>
           <Row>
@@ -17905,85 +18485,85 @@
           <Row>
             <Name>TSPC_MESH_11_11</Name>
             <Description>Remote Provisioning Server Model (C.2)</Description>
-            <Value>FALSE</Value>
+            <Value>TRUE</Value>
             <Mandatory>FALSE</Mandatory>
           </Row>
           <Row>
             <Name>TSPC_MESH_11_12</Name>
             <Description>Remote Provisioning Client Model (C.4)</Description>
-            <Value>FALSE</Value>
+            <Value>TRUE</Value>
             <Mandatory>FALSE</Mandatory>
           </Row>
           <Row>
             <Name>TSPC_MESH_11_13</Name>
             <Description>Composition Data Page 1 (C.2)</Description>
-            <Value>FALSE</Value>
+            <Value>TRUE</Value>
             <Mandatory>FALSE</Mandatory>
           </Row>
           <Row>
             <Name>TSPC_MESH_11_14</Name>
             <Description>On-demand Private Proxy Server Model (C.5)</Description>
-            <Value>FALSE</Value>
+            <Value>TRUE</Value>
             <Mandatory>FALSE</Mandatory>
           </Row>
           <Row>
             <Name>TSPC_MESH_11_15</Name>
             <Description>On-demand Private Proxy Client Model (C.2)</Description>
-            <Value>FALSE</Value>
+            <Value>TRUE</Value>
             <Mandatory>FALSE</Mandatory>
           </Row>
           <Row>
             <Name>TSPC_MESH_11_16</Name>
             <Description>Solicitation PDU RPL Configuration Server Model (C.6)</Description>
-            <Value>FALSE</Value>
+            <Value>TRUE</Value>
             <Mandatory>FALSE</Mandatory>
           </Row>
           <Row>
             <Name>TSPC_MESH_11_17</Name>
             <Description>Solicitation PDU RPL Configuration Client Model (C.2)</Description>
-            <Value>FALSE</Value>
+            <Value>TRUE</Value>
             <Mandatory>FALSE</Mandatory>
           </Row>
           <Row>
             <Name>TSPC_MESH_11_18</Name>
             <Description>SAR Configuration Server Model (C.2)</Description>
-            <Value>FALSE</Value>
+            <Value>TRUE</Value>
             <Mandatory>FALSE</Mandatory>
           </Row>
           <Row>
             <Name>TSPC_MESH_11_19</Name>
             <Description>SAR Configuration Client Model (C.2)</Description>
-            <Value>FALSE</Value>
+            <Value>TRUE</Value>
             <Mandatory>FALSE</Mandatory>
           </Row>
           <Row>
             <Name>TSPC_MESH_11_20</Name>
             <Description>Opcodes Aggregator Server Model (C.2)</Description>
-            <Value>FALSE</Value>
+            <Value>TRUE</Value>
             <Mandatory>FALSE</Mandatory>
           </Row>
           <Row>
             <Name>TSPC_MESH_11_21</Name>
             <Description>Opcodes Aggregator Client Model (C.2)</Description>
-            <Value>FALSE</Value>
+            <Value>TRUE</Value>
             <Mandatory>FALSE</Mandatory>
           </Row>
           <Row>
             <Name>TSPC_MESH_11_22</Name>
             <Description>Large Composition Data Server Model (C.2)</Description>
-            <Value>FALSE</Value>
+            <Value>TRUE</Value>
             <Mandatory>FALSE</Mandatory>
           </Row>
           <Row>
             <Name>TSPC_MESH_11_23</Name>
             <Description>Large Composition Data Client Model (C.2)</Description>
-            <Value>FALSE</Value>
+            <Value>TRUE</Value>
             <Mandatory>FALSE</Mandatory>
           </Row>
           <Row>
             <Name>TSPC_MESH_11_24</Name>
             <Description>Composition Data Page 2 (C.7)</Description>
-            <Value>FALSE</Value>
+            <Value>TRUE</Value>
             <Mandatory>FALSE</Mandatory>
           </Row>
           <!-- Table 12: Node Capabilities - Proxy -->
@@ -18026,13 +18606,13 @@
           <Row>
             <Name>TSPC_MESH_12_7</Name>
             <Description>Advertising with Private Network Identity (C.6)</Description>
-            <Value>FALSE</Value>
+            <Value>TRUE</Value>
             <Mandatory>FALSE</Mandatory>
           </Row>
           <Row>
             <Name>TSPC_MESH_12_8</Name>
             <Description>Advertising with Private Node Identity (C.7)</Description>
-            <Value>FALSE</Value>
+            <Value>TRUE</Value>
             <Mandatory>FALSE</Mandatory>
           </Row>
           <Row>
@@ -18050,7 +18630,7 @@
           <Row>
             <Name>TSPC_MESH_12_11</Name>
             <Description>Sending Proxy Solicitation (C.10)</Description>
-            <Value>FALSE</Value>
+            <Value>TRUE</Value>
             <Mandatory>FALSE</Mandatory>
           </Row>
           <Row>
@@ -18254,7 +18834,7 @@
           <Row>
             <Name>TSPC_MESH_18_13</Name>
             <Description>Provisioning algorithm: ECDH_P256 + HMAC_SHA256 + CCM_AES128 (C.3)</Description>
-            <Value>FALSE</Value>
+            <Value>TRUE</Value>
             <Mandatory>FALSE</Mandatory>
           </Row>
           <Row>
@@ -23666,7 +24246,7 @@
             <Name>TSPX_bd_addr_iut</Name>
             <Description>The unique 48-bit Bluetooth device address (BD_ADDR) of the IUT. This was filled in during workspace creation.</Description>
             <Type>OCTETSTRING</Type>
-            <Value>000000000000</Value>
+            <Value>DEADBEEFDEAD</Value>
           </Row>
           <Row>
             <Name>TSPX_iut_device_name_in_adv_packet_for_random_address</Name>

--- a/errata/zephyr.yaml
+++ b/errata/zephyr.yaml
@@ -103,3 +103,8 @@ OTS/SR/OLE/BI-01-C: https://github.com/zephyrproject-rtos/zephyr/issues/66023
 OTS/SR/OLE/BI-03-C: https://github.com/zephyrproject-rtos/zephyr/issues/66023
 OTS/SR/OLE/BI-04-C: https://github.com/zephyrproject-rtos/zephyr/issues/66023
 OTS/SR/OLE/BI-05-C: https://github.com/zephyrproject-rtos/zephyr/issues/66023
+MESH/NODE/TNPT/BV-11-C: ES-24062
+MESH/CL/DPROX/BV-02-C: ES-24237
+MESH/CL/PROX/BV-11-C: ES-24124
+MESH/CL/PROX/BV-12-C: ES-24124
+MESH/CL/PROX/BV-13-C: ES-24124


### PR DESCRIPTION
Mesh is by default support v1.1 currently. In this regard
this commit updates the workspace to reflect supported
features. Also MBT 1.0 and DFU 1.0 models and features
supported by Mesh stack are enabled.

Adding the errata for mesh

MESH

Mesh v1.0.1 is dropped and Mesh v1.1 is now selected.

Added features and models:
- Provisioning algorithm ECDH_P256 + HMAC_SHA256 + CCM_AES128.
- Node Provisioning Protocol Interface.
- Node address and composition refresh procedures.
- Private beacon server and client models.
- Remote provisioning server and client models.
- Composition data page 1 and 2.
- On-demand proxy server and client models.
- Solicitation PDU RPL configuration server model.
- SAR configuration server and client models.
- Opcodes aggregator server and client models.
- Large composition data server and client models.
- Advertising with private network and node identity.

MBT

Mesh binary large object transfer model is added. Both client and
server models are supported.

DFU

Mesh device firmware update models are added.
- Firmware update server with pull/push mode BLOB transfer.
- Firmware distribution server with pull/push mode BLOB
transfer, store OOB firmware procedure and multiple image
support.
- Firmware update client with BLOB transfer.