### PR TITLE
zephyr: Fix GAP/SEC/AUT/BV-25-C test

### DIFF
--- a/autopts/ptsprojects/zephyr/gap.py
+++ b/autopts/ptsprojects/zephyr/gap.py
@@ -138,7 +138,7 @@ def set_pixits(ptses):
     pts.set_pixit("GAP", "TSPX_conn_update_supervision_timeout", "01F4")
     pts.set_pixit("GAP", "TSPX_pairing_before_service_request", "FALSE")
     pts.set_pixit("GAP", "TSPX_iut_mandates_mitm", "FALSE")
-    pts.set_pixit("GAP", "TSPX_encryption_before_service_request", "FALSE")
+    pts.set_pixit("GAP", "TSPX_encryption_before_service_request", "TRUE")
     pts.set_pixit("GAP", "TSPX_tester_appearance", "0000")
     pts.set_pixit("GAP", "TSPX_iut_device_IRK_for_resolvable_privacy_address_generation_procedure",
                   "00000000000000000000000000000000")

--- a/autopts/wid/gap.py
+++ b/autopts/wid/gap.py
@@ -497,7 +497,7 @@ def hdl_wid_104(_: WIDParams):
 def hdl_wid_106(params: WIDParams):
     # description: Waiting for HCI_ENCRYPTION_CHANGE_EVENT...
     # Depending on test, PTS seems to start pairing on its own here or not
-    if params.test_case_name in ['GAP/SEC/AUT/BV-19-C', 'GAP/SEC/AUT/BV-25-C']:
+    if params.test_case_name in ['GAP/SEC/AUT/BV-19-C']:
         btp.gap_pair()
 
     btp.gap_wait_for_sec_lvl_change(1)


### PR DESCRIPTION
This PTS test is very fragile with this test and any unexpected pairing causes PTS to fail test (via SMP timeout).

This seems to be an issue on PTS side andthis patch is merely a workaround for PTS issue and thus MMI handling should be reworked when PTS fix its implementation.