### PR TITLE
Update `hdl_wid_112` for `GAP/SEC/AUT/BV-19-C`

### DIFF
--- a/autopts/wid/gap.py
+++ b/autopts/wid/gap.py
@@ -528,6 +528,10 @@ def hdl_wid_112(params: WIDParams):
     if params.test_case_name in ['GAP/SEC/AUT/BV-19-C']:
         if (btp.verify_att_error("authentication error")):
             btp.gap_pair()
+        # Allow some time to receive a response before returning because next
+        # order is a disconnect. This will lead create a `BTP ERROR` if receive
+        # a response while being disconnected.
+        sleep(1)
 
     return True
 


### PR DESCRIPTION
In `GAP/SEC/AUT/BV-19-C`, PTS order a service request (GATT read) and order then a disconnection. When returning from the service request, if the service request is not complete, the disconnection will still be executed.

This lead to `BTP ERROR` if we receive the service request answer after the disconnection as been executed.

To resolve the problem, `hdl_wid_112` will now wait 1s before returning (only for `GAP/SEC/AUT/BV-19-C`).