### PR TITLE
zephyr: Fix GAP/SEC/AUT/BV-19-C test

### DIFF
--- a/autopts/ptsprojects/zephyr/gap.py
+++ b/autopts/ptsprojects/zephyr/gap.py
@@ -138,7 +138,7 @@ def set_pixits(ptses):
     pts.set_pixit("GAP", "TSPX_conn_update_supervision_timeout", "01F4")
     pts.set_pixit("GAP", "TSPX_pairing_before_service_request", "FALSE")
     pts.set_pixit("GAP", "TSPX_iut_mandates_mitm", "FALSE")
-    pts.set_pixit("GAP", "TSPX_encryption_before_service_request", "TRUE")
+    pts.set_pixit("GAP", "TSPX_encryption_before_service_request", "FALSE")
     pts.set_pixit("GAP", "TSPX_tester_appearance", "0000")
     pts.set_pixit("GAP", "TSPX_iut_device_IRK_for_resolvable_privacy_address_generation_procedure",
                   "00000000000000000000000000000000")

--- a/autopts/wid/gap.py
+++ b/autopts/wid/gap.py
@@ -525,10 +525,6 @@ def hdl_wid_112(params: WIDParams):
         btp.gattc_read(bd_addr_type, bd_addr, handle)
         btp.gattc_read_rsp(store_rsp=True)
 
-    if params.test_case_name in ['GAP/SEC/AUT/BV-19-C']:
-        if (btp.verify_att_error("authentication error")):
-            btp.gap_pair()
-
     return True
 
 
@@ -1078,6 +1074,12 @@ def hdl_wid_226(_: WIDParams):
 
 
 def hdl_wid_227(params: WIDParams):
+    # There seems to be issue in PTS regarding using WID112 and WID227 in that test
+    # Should be removed if PTS fix this.
+    if params.test_case_name in ['GAP/SEC/AUT/BV-19-C']:
+        btp.gap_pair()
+        return True
+
     stack = get_stack()
 
     bd_addr = btp.pts_addr_get()


### PR DESCRIPTION
Workaround issue in PTS that was affecting this test. In long term this should be reworked when PTS is fixed.