### PR TITLE
Fix GAP/BOND/BON/BV-02-C

### DIFF
--- a/autopts/wid/gap.py
+++ b/autopts/wid/gap.py
@@ -505,6 +505,10 @@ def hdl_wid_106(params: WIDParams):
 
 
 def hdl_wid_108(params: WIDParams):
+    if params.test_case_name in ['GAP/BOND/BON/BV-02-C']:
+        if params.description.startswith('Please configure the IUT into LE Security and start pairing process.'):
+            return True
+
     btp.gap_pair()
     return True
 


### PR DESCRIPTION
PTS seems to send WID 108 twice in a row in this test just with different deciption. This results in calling BTP Pair command twice. On Zephyr second call is just a NOP (since encryption is already enabled), but in NimBLE this results in re-encrypting link with existing LTK which confuses PTS due to unexpected HCI event.