### PR TITLE
iut_config: mynewt

### DIFF
--- a/autopts/bot/iut_config/mynewt.py
+++ b/autopts/bot/iut_config/mynewt.py
@@ -17,6 +17,9 @@
 
 iut_config = {
     "default.conf": {
+        "overlay": {
+            'BLE_SVC_GAP_DEVICE_NAME_MAX_LENGTH': '6',
+        },
         "test_cases": [
             'GAP', 'GATT', 'L2CAP', 'SM', 'MESH',
         ],


### PR DESCRIPTION
Add overlay BLE_SVC_GAP_DEVICE_NAME_MAX_LENGTH = 6. This is needed for GATT/SR/GAW/BI-32-C test case.