### PR TITLE
nimble: update workspace

### DIFF
--- a/autopts/wid/gatt_client.py
+++ b/autopts/wid/gatt_client.py
@@ -1178,7 +1178,7 @@ def hdl_wid_90(_: WIDParams):
     notification send from PTS.
     """
     stack = get_stack()
-    return stack.gatt_cl.wait_for_notifications(expected_count=1)
+    return stack.gatt_cl.wait_for_notifications(expected_count=2)
 
 
 def hdl_wid_91(params: WIDParams):

--- a/autopts/workspaces/nimble-master/nimble-master.pqw6
+++ b/autopts/workspaces/nimble-master/nimble-master.pqw6
@@ -3540,7 +3540,7 @@
             <Name>TSPX_bearer_for_le</Name>
             <Description>When both ATT and EATT bearers are supported, this specifies the bearer the controller creates for the LE transport. Values: ATT or EATT. (Default: "ATT")</Description>
             <Type>IA5STRING</Type>
-            <Value>ATT</Value>
+            <Value>EATT</Value>
             <ValueList>
               <ValueListItem>ATT</ValueListItem>
               <ValueListItem>EATT</ValueListItem>


### PR DESCRIPTION
Enable EATT support for GATT tests
This is needed to pass GATT/CL/GAN/BV-02-C nad GATT/CL/GAR/BV-08-C test case