### PR TITLE
autoptsserver: ykush: Allow ykush board selection

### DIFF
--- a/autopts/utils.py
+++ b/autopts/utils.py
@@ -20,6 +20,7 @@ import logging
 import os
 import sys
 import threading
+import traceback
 from time import sleep
 
 import psutil
@@ -356,6 +357,15 @@ def ykush_replug_usb(ykush_config, device_id=None, delay=0, end_flag=None):
             i += 1
 
         sleep(0.1)
+
+
+def print_thread_stack_trace():
+    logging.debug("Printing stack trace for each thread:")
+    for thread_id, thread_obj in threading._active.items():
+        stack = sys._current_frames().get(thread_id)
+        if stack is not None:
+            logging.debug(f"Thread ID: {thread_id}, Thread Name: {thread_obj.name}")
+            logging.debug(traceback.extract_stack(stack))
 
 
 def exit_if_admin():

--- a/autoptsserver.py
+++ b/autoptsserver.py
@@ -52,7 +52,8 @@ import wmi
 
 from autopts import ptscontrol
 from autopts.config import SERVER_PORT
-from autopts.utils import CounterWithFlag, get_global_end, exit_if_admin, ykush_replug_usb, usb_power
+from autopts.utils import CounterWithFlag, get_global_end, exit_if_admin, ykush_replug_usb, usb_power, \
+    print_thread_stack_trace
 from autopts.winutils import kill_all_processes
 
 logging = root_logging.getLogger('server')
@@ -447,6 +448,7 @@ class Server(threading.Thread):
                 if self._args.superguard and \
                         self._args.superguard < time.time() - self.last_request_time:
                     log('Superguard timeout, reinitializing XMLRPC')
+                    print_thread_stack_trace()
                     self.server_init()
 
                 # Main work

--- a/autoptsserver.py
+++ b/autoptsserver.py
@@ -52,7 +52,7 @@ import wmi
 
 from autopts import ptscontrol
 from autopts.config import SERVER_PORT
-from autopts.utils import CounterWithFlag, get_global_end, exit_if_admin, ykush_replug_usb
+from autopts.utils import CounterWithFlag, get_global_end, exit_if_admin, ykush_replug_usb, usb_power
 from autopts.winutils import kill_all_processes
 
 logging = root_logging.getLogger('server')
@@ -330,6 +330,22 @@ class SvrArgumentParser(argparse.ArgumentParser):
 
         arg.superguard = 60 * arg.superguard
 
+        if arg.ykush:
+            ykush_confs = []
+            for ykush_conf in arg.ykush:
+                config = {}
+                if ':' in ykush_conf:
+                    ykush_srn, port = ykush_conf.split(':')
+                else:
+                    port = ykush_conf
+                    ykush_srn = None
+
+                config['ports'] = port
+                config['ykush_srn'] = ykush_srn
+                ykush_confs.append(config)
+
+            arg.ykush = ykush_confs
+
     def parse_args(self, args=None, namespace=None):
         arg = super().parse_args(args, namespace)
         self.check_args(arg)
@@ -558,7 +574,7 @@ if __name__ == "__main__":
 
     if _args.ykush:
         for ykush_config in _args.ykush:
-            ykush_replug_usb(ykush_config, device_id=None, delay=3)
+            usb_power(ykush_config['ports'], False, ykush_config['ykush_srn'])
 
     autoptsservers = []
     server_count = len(_args.srv_port)


### PR DESCRIPTION
If multiple YKUSH boards are plugged in, we need to provide the serial number of the board to be able to reppluged the right PTS dongle. Let's extend the --ykush command so it allowed usage like
--ykush YKUSH_SRN:YKUSH_PORT

Example:
python ./autoptsserver.py -S 65000 65002 --ykush YK12345:1 YK12345:2