### PR TITLE
Mynewt: fix writing EATT supported bit

### DIFF
--- a/autopts/ptsprojects/mynewt/gatt_client_wid.py
+++ b/autopts/ptsprojects/mynewt/gatt_client_wid.py
@@ -42,17 +42,20 @@ def hdl_wid_142(desc):
 
     Discover all characteristics if needed.
     """
-    log("Mynewt sends EATT supported bit")
+    log("Mynewt sends EATT supported bit on encryption changed")
+    btp.gap_pair()
 
     # No response expected
     return True
 
 
 def hdl_wid_400(desc):
-    log("Mynewt sends EATT supported bit")
+    log("Mynewt sends EATT supported bit on encryption changed")
+    btp.gap_pair()
     return '0000'
 
 
 def hdl_wid_402(desc):
-    log("Mynewt sends EATT supported bit")
+    log("Mynewt sends EATT supported bit on encryption changed")
+    btp.gap_pair()
     return '0000'

--- a/autopts/ptsprojects/stack/layers/gattcl.py
+++ b/autopts/ptsprojects/stack/layers/gattcl.py
@@ -100,3 +100,12 @@ class GattCl:
 
     def wait_for_write_rsp(self, timeout=30):
         return wait_for_event(timeout, self.is_write_completed)
+
+
+    def is_verified_val_rxed(self, expected_count):
+        if expected_count > 0:
+            return len(self.verify_values) == expected_count
+        return len(self.verify_values) > 0
+
+    def wait_for_verify_values(self, timeout=30, expected_count=0):
+        return wait_for_event(timeout, self.is_verified_val_rxed, expected_count)

--- a/autopts/wid/gatt_client.py
+++ b/autopts/wid/gatt_client.py
@@ -755,7 +755,8 @@ def hdl_wid_55(params: WIDParams):
     MMI.parse_description(params.description)
 
     stack = get_stack()
-    stack.gatt_cl.wait_for_read()
+
+    stack.gatt_cl.wait_for_verify_values(expected_count=2)
 
     for saved_val in btp.get_verify_values():
         logging.debug("received value: %s", saved_val[1].decode().upper())


### PR DESCRIPTION
Mynewt now writes EATT supported wid on encryption changed, not connection event.