### PR TITLE
zephyr: csip: fix CSIP/SR test

### DIFF
--- a/autopts/ptsprojects/zephyr/csip.py
+++ b/autopts/ptsprojects/zephyr/csip.py
@@ -47,7 +47,7 @@ def set_pixits(ptses):
     pts.set_pixit("CSIP", "TSPX_delete_link_key", "FALSE")
     pts.set_pixit("CSIP", "TSPX_pin_code", "0000")
     pts.set_pixit("CSIP", "TSPX_use_dynamic_pin", "FALSE")
-    pts.set_pixit("CSIP", "TSPX_delete_ltk", "FALSE")
+    pts.set_pixit("CSIP", "TSPX_delete_ltk", "TRUE")
     pts.set_pixit("CSIP", "TSPX_security_enabled", "FALSE")
     pts.set_pixit("CSIP", "TSPX_target_service", "5F03")
     pts.set_pixit("CSIP", "TSPX_set_size", "3")
@@ -127,6 +127,7 @@ def test_cases(ptses):
         TestFunc(btp.gap_set_conn),
         TestFunc(btp.gap_set_gendiscov),
         TestFunc(btp.core_reg_svc_csip),
+        TestFunc(btp.core_reg_svc_csis),
         TestFunc(stack.csip_init),
         TestFunc(lambda: set_addr(
             stack.gap.iut_addr_get_str())),

--- a/autopts/wid/csip.py
+++ b/autopts/wid/csip.py
@@ -47,10 +47,18 @@ def hdl_wid_4(_: WIDParams):
     return True
 
 
-def hdl_wid_5(_: WIDParams):
+def hdl_wid_5(params: WIDParams):
     """
         Please have IUT enter GAP Discoverable Mode and generate Advertising Packets.
     """
+
+    if params.test_case_name == "CSIP/SR/SP/BV-03-C":
+        # Encrypted SIRK
+        btp.csis_set_sirk_type(1)
+    else:
+        # Plain Text SIRK
+        btp.csis_set_sirk_type(0)
+
     rsi = btp.csis_get_member_rsi()
     if not rsi:
         return False


### PR DESCRIPTION
Add csis register to CSIP preconditions. This is needed to generate adv packets with correct SIRK type. 
Fixes CSIP/SR/SP/BV-01-C, CSIP/SR/SP/BV-03-C
Note: requires https://github.com/zephyrproject-rtos/zephyr/pull/70783 to be merged
