### PR TITLE
zephyr: csip: set member lock/release command refactor

### DIFF
--- a/autopts/ptsprojects/zephyr/csip.py
+++ b/autopts/ptsprojects/zephyr/csip.py
@@ -70,7 +70,7 @@ def set_pixits(ptses):
     pts2.set_pixit("CSIP", "TSPX_delete_link_key", "FALSE")
     pts2.set_pixit("CSIP", "TSPX_pin_code", "0000")
     pts2.set_pixit("CSIP", "TSPX_use_dynamic_pin", "FALSE")
-    pts2.set_pixit("CSIP", "TSPX_delete_ltk", "FALSE")
+    pts2.set_pixit("CSIP", "TSPX_delete_ltk", "TRUE")
     pts2.set_pixit("CSIP", "TSPX_security_enabled", "FALSE")
     pts2.set_pixit("CSIP", "TSPX_target_service", "5F03")
     pts2.set_pixit("CSIP", "TSPX_set_size", "3")
@@ -93,7 +93,7 @@ def set_pixits(ptses):
     pts3.set_pixit("CSIP", "TSPX_delete_link_key", "FALSE")
     pts3.set_pixit("CSIP", "TSPX_pin_code", "0000")
     pts3.set_pixit("CSIP", "TSPX_use_dynamic_pin", "FALSE")
-    pts3.set_pixit("CSIP", "TSPX_delete_ltk", "FALSE")
+    pts3.set_pixit("CSIP", "TSPX_delete_ltk", "TRUE")
     pts3.set_pixit("CSIP", "TSPX_security_enabled", "FALSE")
     pts3.set_pixit("CSIP", "TSPX_target_service", "5F03")
     pts3.set_pixit("CSIP", "TSPX_set_size", "3")
@@ -197,8 +197,7 @@ def test_cases(ptses):
                                 SynchPoint("CSIP/CL/SPE/BI-01-C_LT3", 20100)]),
                       TestFunc(get_stack().synch.add_synch_element,
                                [SynchPoint("CSIP/CL/SPE/BI-01-C", 20110),
-                                SynchPoint("CSIP/CL/SPE/BI-01-C_LT2", 20110),
-                                SynchPoint("CSIP/CL/SPE/BI-01-C_LT3", 20110)]),
+                                SynchPoint("CSIP/CL/SPE/BI-01-C_LT2", 20110)]),
                   ],
                   generic_wid_hdl=csip_wid_hdl,
                   lt2="CSIP/CL/SPE/BI-01-C_LT2",

--- a/autopts/pybtp/btp/csip.py
+++ b/autopts/pybtp/btp/csip.py
@@ -75,25 +75,45 @@ def csip_discover(bd_addr_type=None, bd_addr=None):
     csip_command_rsp_succ()
 
 
-def csip_set_coordinator_lock(count):
+def csip_set_coordinator_lock(addr_list=None):
     logging.debug(f"{csip_set_coordinator_lock.__name__}")
 
-    data = bytearray()
-    data.extend(struct.pack('b', count))
-
     iutctl = get_iut()
+    data = bytearray()
+    addr_cnt = len(addr_list) if addr_list else 0
+
+    data.extend(struct.pack('b', addr_cnt))
+
+    if addr_cnt != 0:
+        # Perform lock request procedure on subset of set members
+        for addr_type, addr in addr_list:
+            bd_addr_type_ba = chr(addr_type).encode('utf-8')
+            bd_addr_ba = addr2btp_ba(addr)
+            data.extend(bd_addr_type_ba)
+            data.extend(bd_addr_ba)
+
     iutctl.btp_socket.send(*CSIP['set_coordinator_lock'], data=data)
 
     csip_command_rsp_succ()
 
 
-def csip_set_coordinator_release(count):
+def csip_set_coordinator_release(addr_list=None):
     logging.debug(f"{csip_set_coordinator_release.__name__}")
 
-    data = bytearray()
-    data.extend(struct.pack('b', count))
-
     iutctl = get_iut()
+    data = bytearray()
+    addr_cnt = len(addr_list) if addr_list else 0
+
+    data.extend(struct.pack('b', addr_cnt))
+
+    if addr_cnt != 0:
+        # Perform lock release procedure on subset of set members
+        for addr_type, addr in addr_list:
+            bd_addr_type_ba = chr(addr_type).encode('utf-8')
+            bd_addr_ba = addr2btp_ba(addr)
+            data.extend(bd_addr_type_ba)
+            data.extend(bd_addr_ba)
+
     iutctl.btp_socket.send(*CSIP['set_coordinator_release'], data=data)
 
     csip_command_rsp_succ()

--- a/doc/btp_csip.txt
+++ b/doc/btp_csip.txt
@@ -47,21 +47,29 @@ Commands and responses:
 	Opcode 0x04 - Set Coordinator Lock
 
 		Controller Index:	<controller id>
-		Command parameters:     Members count (1 octet)
+		Command parameters:     Address count (1 octet)
+					Address list (varies)
 		Response parameters:    <none>
 
-		This command is used to lock an array of set members.
-		During operation, the IUT may send event:
+		This command is used to perform lock request on set members.
+		Address list parameter should contain tuple(s) of address type
+		and address: ([(0, 'DB:F5:72:56:C9:EF'), (0, 'DB:F5:72:56:C9:EF')].
+		When Address list is not provided, lock procedure will be performed
+		on all set members. During operation, the IUT may send event:
 				CSIP Lock event
 
 	Opcode 0x05 - Set Coordinator Lock Release
 
 		Controller Index:	<controller id>
-		Command parameters:     Members count (1 octet)
+		Command parameters:     Address count (1 octet)
+					Address list (varies)
 		Response parameters:    <none>
 
-		This command is used to release an array of set members.
-		During operation, the IUT may send event:
+		This command is used to perform lock release on set members.
+		Address list parameter should contain tuple(s) of address type
+		and address: ([(0, 'DB:F5:72:56:C9:EF'), (0, 'DB:F5:72:56:C9:EF')].
+		When Address list is not provided, lock procedure will be performed
+		on all set members. During operation, the IUT may send event:
 				CSIP Lock event
 
 Events:


### PR DESCRIPTION
- Add address_count and addr array parameters to set_lock and set_release btp commands.
- Code cleanup for readability
- Preconditions adjustment
Fixes FATAL ERROR in CSIP/CL/SP/BV-07-C, CSIP/CL/SP/BV-03-C, CSIP/CL/SP/BV-04-C, CSIP/CL/SPE/BI-01-C
Merge after https://github.com/zephyrproject-rtos/zephyr/pull/71059