### PR TITLE
boards: Add pylink reset

### DIFF
--- a/autopts/bot/common.py
+++ b/autopts/bot/common.py
@@ -88,6 +88,7 @@ class BotConfigArgs(Namespace):
         self.test_case_limit = args.get('test_case_limit', 0)
         self.simple_mode = args.get('simple_mode', False)
         self.server_args = args.get('server_args', None)
+        self.pylink_reset = args.get('pylink_reset', False)
 
         if self.server_args is not None:
             from autoptsserver import SvrArgumentParser

--- a/autopts/ptsprojects/mynewt/iutctl.py
+++ b/autopts/ptsprojects/mynewt/iutctl.py
@@ -47,6 +47,7 @@ class MynewtCtl:
         assert args.tty_file and args.board_name
 
         self.tty_file = args.tty_file
+        self.pylink_reset = args.pylink_reset
         self.device_core = args.device_core
         self.debugger_snr = get_debugger_snr(self.tty_file) \
             if args.debugger_snr is None else args.debugger_snr

--- a/autopts/ptsprojects/zephyr/iutctl.py
+++ b/autopts/ptsprojects/zephyr/iutctl.py
@@ -64,6 +64,7 @@ class ZephyrCtl:
             self.__class__, self.__init__.__name__, args.kernel_image,
             args.tty_file, args.board_name)
 
+        self.pylink_reset = args.pylink_reset
         self.device_core = args.device_core
         self.debugger_snr = args.debugger_snr
         self.kernel_image = args.kernel_image

--- a/cliparser.py
+++ b/cliparser.py
@@ -82,6 +82,9 @@ class CliParser(argparse.ArgumentParser):
                           help="Specify ykush downstream port number, so on BTP TIMEOUT "
                                "the iut device could be powered off and on.")
 
+        self.add_argument("--pylink_reset", action='store_true', default=False,
+                          help="Use pylink reset.")
+
         # Hidden option to save test cases data in TestCase.db
         self.add_argument("-s", "--store", action="store_true",
                           default=False, help=argparse.SUPPRESS)


### PR DESCRIPTION
jlink.exe randomly crashes the Windows OS. Let's try pylink reset instead.