### PR TITLE
bot: Add BUILD_OR_FLASH ERROR

### DIFF
--- a/autopts/bot/mynewt.py
+++ b/autopts/bot/mynewt.py
@@ -23,6 +23,7 @@ import time
 from pathlib import Path
 
 from autopts import bot
+from autopts.bot.common import BuildAndFlashException
 from autopts.bot.common_features.github import update_sources
 from autopts.client import Client
 from autopts.ptsprojects.boards import release_device, get_build_and_flash, get_board_type
@@ -162,7 +163,7 @@ class MynewtBotClient(bot.common.BotClient):
                 build_and_flash(args.project_path, board_type, overlay, args.debugger_snr)
             except:
                 report.make_error_txt('Build and flash step failed')
-                raise
+                raise BuildAndFlashException
 
             time.sleep(10)
 

--- a/autopts/bot/zephyr.py
+++ b/autopts/bot/zephyr.py
@@ -31,7 +31,7 @@ from autopts.bot.common_features.github import update_sources
 from autopts.ptsprojects.zephyr import ZEPHYR_PROJECT_URL
 from autopts import client as autoptsclient
 
-from autopts.bot.common import BotConfigArgs, BotClient
+from autopts.bot.common import BotConfigArgs, BotClient, BuildAndFlashException
 from autopts.ptsprojects.boards import tty_to_com, release_device, get_build_and_flash, get_board_type
 from autopts.ptsprojects.testcase_db import DATABASE_FILE
 from autopts.ptsprojects.zephyr.iutctl import get_iut, log
@@ -207,7 +207,7 @@ class ZephyrBotClient(BotClient):
                 flush_serial(args.tty_file)
             except:
                 report.make_error_txt('Build and flash step failed')
-                raise
+                raise BuildAndFlashException
 
             time.sleep(10)
 


### PR DESCRIPTION
If the build or flash step for an iut config has failed, set status of its test cases to BUILD_OR_FLASH ERROR and proceed with the next iut config.