### PR TITLE
ci: Remove unnecessary context variable from workflow file

### DIFF
--- a/.github/workflows/check_pr_changes.yaml
+++ b/.github/workflows/check_pr_changes.yaml
@@ -2,14 +2,13 @@ name: Check PR for changes in autopts/wid/
 
 on:
   pull_request:
-    types: [review_requested, ready_for_review, opened, ]
+    types: [ready_for_review, opened]
     branches:
       - master
 
 jobs:
   check_changes:
     runs-on: ubuntu-latest
-    if: github.run_number == 1
     steps:
       - name: Checkout code
         uses: actions/checkout@v3


### PR DESCRIPTION
For some reason if: github.run_number == 1 blocked this workflow job. Now, the action will only run when a pull request is opened or converted from draft to ready for review.