### PR TITLE
mynewt: Enable EATT for GATT tests

### DIFF
--- a/autopts/ptsprojects/mynewt/gatt.py
+++ b/autopts/ptsprojects/mynewt/gatt.py
@@ -133,6 +133,7 @@ def set_pixits(ptses):
     pts.set_pixit("GATT", "TSPX_use_dynamic_pin", "FALSE")
     pts.set_pixit("GATT", "TSPX_delete_ltk", "TRUE")
     pts.set_pixit("GATT", "TSPX_tester_appearance", "0000")
+    pts.set_pixit("GATT", "TSPX_bearer_for_le", "EATT")
 
 
 def test_cases_server(ptses):

--- a/autopts/wid/gatt_client.py
+++ b/autopts/wid/gatt_client.py
@@ -1170,7 +1170,7 @@ def hdl_wid_82(_: WIDParams):
     return True
 
 
-def hdl_wid_90(_: WIDParams):
+def hdl_wid_90(params: WIDParams):
     """
     Please confirm IUT received notification from PTS. Click YES if received,
     otherwise NO.
@@ -1179,6 +1179,11 @@ def hdl_wid_90(_: WIDParams):
     notification send from PTS.
     """
     stack = get_stack()
+
+    if params.test_case_name == 'GATT/CL/GAN/BV-02-C':
+        # multiple handle value notification
+        return stack.gatt_cl.wait_for_notifications(expected_count=2)
+
     return stack.gatt_cl.wait_for_notifications(expected_count=1)
 
 

--- a/errata/mynewt.yaml
+++ b/errata/mynewt.yaml
@@ -1,3 +1,8 @@
 # To add note to the reports about awaited errata, list them here e.g.:
 # GAP/CONN/NCON/BV-01-C: CASE00xxxxx
 # GAP/CONN/NCON/BV-02-C: CASE00xxxxx
+
+GATT/CL/GAD/BV-01-C: Request ID 90121
+GATT/CL/GAD/BV-02-C: Request ID 90121
+GATT/CL/GAD/BV-05-C: Request ID 90121
+GATT/CL/GAD/BV-06-C: Request ID 90121


### PR DESCRIPTION
- Adjust gatt client wid handler
- Enable EATT for GATT tests. This triggers PTS Issue (added specific test cases to mynewt errata list) - PTS database is missing Server Supported Features Charateristic.
Related - https://github.com/apache/mynewt-nimble/pull/1787, 
https://github.com/apache/mynewt-nimble/pull/1791