### PR TITLE
zephyr: mesh: mmdl: use correct api to set pixit

### DIFF
--- a/autopts/ptsprojects/zephyr/mmdl.py
+++ b/autopts/ptsprojects/zephyr/mmdl.py
@@ -60,7 +60,7 @@ def set_pixits(ptses):
     pts.set_pixit("MMDL", "TSPX_sensor_property_ids", "1,0069,0010,FFF0")
     pts.set_pixit("MMDL", "TSPX_enable_IUT_provisioner", "FALSE")
     pts.set_pixit("MMDL", "TSPX_cadence_property_IDs", "1,0069,0010,FFF0")
-    pts-set_pixits("MMDL", "TSPX_iut_comp_data_page", "1")
+    pts.set_pixit("MMDL", "TSPX_iut_comp_data_page", "1")
 
 
 def test_cases(ptses):


### PR DESCRIPTION
Use correct api to set pixit value for mmdl.