### PR TITLE
bot: Fix print of the last test case result

### DIFF
--- a/autopts/client.py
+++ b/autopts/client.py
@@ -829,6 +829,8 @@ def run_test_case_wrapper(func):
         else:
             print(result)
 
+        sys.stdout.flush()
+
         return status, end_time
 
     return wrapper


### PR DESCRIPTION
Result of the last test case before next rebuild was printed after the rebuild, e.g.:
...
31/32   MBT     MBT/CL/BT/BV-07-C   PASS           38.097
32/32   MBT     MBT/CL/BT/BV-08-C   -- west build: generating a build system
Loading Zephyr default modules (Zephyr base).
...
Applying pin reset.
-- runners.nrfjprog: Board with serial number 683511993 flashed successfully.
PASS           31.924