### PR TITLE
tools: github_cron: Fix fetch of repo owner

### DIFF
--- a/tools/cron/github_cron.py
+++ b/tools/cron/github_cron.py
@@ -224,7 +224,7 @@ class GitHubCron(Thread):
 
         pr_info = {
             'number': github_pr_number,
-            'source_repo_owner': pr['user']['login'],
+            'source_repo_owner': pr['head']['repo']['owner']['login'],
             'repo_name': pr['head']['repo']['name'],
             'source_branch': pr['head']['ref'],
             'head_sha': pr['head']['sha'],


### PR DESCRIPTION
Take the login of repo owner instead of the login of the PR creator.