### PR TITLE
tools: cron: pr: Auto assign tests to the correct board

### DIFF
--- a/autopts/bot/common.py
+++ b/autopts/bot/common.py
@@ -338,6 +338,7 @@ def check_call(cmd, env=None, cwd=None, shell=True):
         executable = None
 
     logging.debug(f'Running cmd: {cmd}')
+    sys.stdout.flush()
 
     return subprocess.check_call(cmd, env=env, cwd=cwd, shell=shell, executable=executable)
 

--- a/tools/cron/common.py
+++ b/tools/cron/common.py
@@ -677,7 +677,6 @@ def _generic_pr_job(cron, cfg, pr_cfg, **kwargs):
         ' branch={source_branch} head_sha={head_sha} comment={comment_body} '
         'magic_tag={magic_tag} cfg={cfg}'.format(**pr_cfg, cfg=cfg))
 
-    kwargs['included'], kwargs['excluded'] = parse_test_cases_from_comment(pr_cfg)
     config = get_cron_config(cfg, **kwargs)
 
     # Path to the project


### PR DESCRIPTION
If a magic tag command does not contain a name of a board that should be used for AutoPTS testing, automatically assign tests to the correct boards.