### PR TITLE
Add CAP Handover Procedure Tests

### DIFF
--- a/autopts/wid/cap.py
+++ b/autopts/wid/cap.py
@@ -295,6 +295,9 @@ def hdl_wid_345(params: WIDParams):
 
     # get broadcaster address
     if lt1_test_name.startswith('CAP/INI/UTB/BV-'):
+        # Setup Broadcast
+        hdl_wid_114(params)
+
         # IUT is Broadcaster
         broadcaster_addr = stack.gap.iut_addr_get_addr()
         # TODO: Broadcast Advertising Start uses Random Address for NRF5340 in BTstack's BTP Client
@@ -792,9 +795,7 @@ def hdl_wid_406(params: WIDParams):
         log('hdl_wid_406 exit, unicasst stop event not received')
         return False
 
-    # Setup Broadcast
-    return hdl_wid_114(params)
-
+    return True
 
 def hdl_wid_409(_: WIDParams):
     """Please update metadata in BASE. Then click OK when IUT is ready

--- a/autopts/wid/cap.py
+++ b/autopts/wid/cap.py
@@ -716,8 +716,9 @@ def hdl_wid_400(params: WIDParams):
                                                            config.addr,
                                                            config.ase_id,
                                                            ASCSState.STREAMING,
-                                                           10)
+                                                           20)
             if ev is None:
+                log('hdl_wid_400 exit, not streaming')
                 return False
 
     return True


### PR DESCRIPTION
This PR provides window handler for Unicast to Broadcast (CAP/INI/UTB/*) and Broadcast to Unicast (AP/INI/BTU/*).
Usage in BTstack here: https://github.com/bluekitchen/auto-pts/blob/develop-le-audio-broadcast/autopts/ptsprojects/btstack/cap.py
