### PR TITLE
mynewt: l2cap: Add mynewt specific wid handler

### DIFF
--- a/autopts/ptsprojects/mynewt/l2cap.py
+++ b/autopts/ptsprojects/mynewt/l2cap.py
@@ -22,6 +22,7 @@ from autopts.wid import l2cap_wid_hdl
 from autopts.ptsprojects.stack import get_stack, L2cap
 from autopts.ptsprojects.testcase import TestFunc
 from autopts.ptsprojects.mynewt.ztestcase import ZTestCase
+from autopts.ptsprojects.mynewt.l2cap_wid import l2cap_wid_hdl as l2cap_mynewt_hdl
 
 
 le_psm = 128
@@ -224,6 +225,9 @@ def test_cases(ptses):
                   [TestFunc(lambda: pts.update_pixit_param(
                       "L2CAP", "TSPX_l2ca_cbmps_min", "0040"))],
                   generic_wid_hdl=l2cap_wid_hdl),
+        ZTestCase("L2CAP", "L2CAP/TIM/BV-03-C",
+                  pre_conditions,
+                  generic_wid_hdl=l2cap_mynewt_hdl),
     ]
 
     test_case_name_list = pts.get_test_case_list('L2CAP')

--- a/autopts/ptsprojects/mynewt/l2cap_wid.py
+++ b/autopts/ptsprojects/mynewt/l2cap_wid.py
@@ -1,0 +1,51 @@
+#
+# auto-pts - The Bluetooth PTS Automation Framework
+#
+# Copyright (c) 2024, Codecoup.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms and conditions of the GNU General Public License,
+# version 2, as published by the Free Software Foundation.
+#
+# This program is distributed in the hope it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+
+import logging
+import socket
+
+from autopts.ptsprojects.stack import get_stack
+from autopts.pybtp import btp
+from autopts.wid import generic_wid_hdl
+from autopts.pybtp.types import WIDParams
+
+log = logging.debug
+
+
+def l2cap_wid_hdl(wid, description, test_case_name):
+    log(f'{l2cap_wid_hdl.__name__}, {wid}, {description}, {test_case_name}')
+    return generic_wid_hdl(wid, description, test_case_name, [__name__, 'autopts.wid.l2cap'])
+
+
+def hdl_wid_255(_: WIDParams):
+    """ description: Please send L2CAP Credit Based Connection REQ to PTS."""
+
+    stack = get_stack()
+    l2cap = stack.l2cap
+
+    if l2cap.wid_cnt > 0:
+        btp.l2cap_conn(None, None, l2cap.psm, l2cap.initial_mtu, 1, 1, l2cap.hold_credits)
+        l2cap.wait_for_connection(1)
+        return True
+
+    btp.l2cap_conn(None, None, l2cap.psm, l2cap.initial_mtu, l2cap.num_channels, 1, l2cap.hold_credits)
+
+    # Wait until all channels connected to avoid race condition between channel connection and new received wid
+    for channel_id in range(l2cap.num_channels):
+        l2cap.wait_for_connection(channel_id)
+
+    l2cap.wid_cnt += 1
+
+    return True

--- a/autopts/ptsprojects/stack/layers/l2cap.py
+++ b/autopts/ptsprojects/stack/layers/l2cap.py
@@ -106,6 +106,7 @@ class L2cap:
         self.channels = []
         self.hold_credits = 0
         self.num_channels = 2
+        self.wid_cnt = 0
 
     def chan_lookup_id(self, chan_id):
         for chan in self.channels:


### PR DESCRIPTION
This is needed for test case L2CAP/TIM/BV-03-C. The generic handler for wid 255 is using eatt_conn which is not implemented in nimble. For clarity and readabilty, wid 255 will be handled by mynewt specific handler.