### PR TITLE
tools: cron: add test_case_limit param

### DIFF
--- a/cliparser.py
+++ b/cliparser.py
@@ -54,6 +54,9 @@ class CliParser(argparse.ArgumentParser):
                           help="Names of test cases to exclude. Groups of "
                                "test cases can be specified by profile names")
 
+        self.add_argument("--test_case_limit", nargs='?', type=int, default=0,
+                          help="Limit of test cases to run")
+
         self.add_argument("-r", "--retry", type=int, default=0,
                           help="Repeat test if failed. Parameter specifies "
                                "maximum repeat count per test")

--- a/tools/cron/autopts_cron.py
+++ b/tools/cron/autopts_cron.py
@@ -86,6 +86,9 @@ class AutoPTSMagicTagParser(argparse.ArgumentParser):
                           help="Names of test cases to exclude. Groups of "
                                "test cases can be specified by profile names")
 
+        self.add_argument("--test_case_limit", nargs='?', type=int, default=0,
+                          help="Limit of test cases to run")
+
 
 def run_pending_thread_func():
     if sys.platform == 'win32':
@@ -152,7 +155,7 @@ def check_supported_profiles(test_case_prefixes, job_config):
     if not job_config['included']:
         # 'included' parameter not specified in job config. Assume
         # all profiles supported on this server.
-        return True, []
+        return True, test_case_prefixes
 
     job_config_prefixes = re.sub(r'\s+', r' ', job_config['included']).strip().split(' ')
 
@@ -197,6 +200,7 @@ def autopts_magic_tag_cb(cron, comment_info):
         config['included'] = supported_test_cases
         config['excluded'] = parsed_args.excluded
         config['board'] = board
+        config['test_case_limit'] = parsed_args.test_case_limit
         configs.append(config)
 
     if not configs:
@@ -220,7 +224,8 @@ def schedule_pr_job(cron, pr_info, job_config):
         included_tc = job_config['included']
         excluded_tc = job_config['excluded']
 
-        test_cases, est_duration = get_estimations(cfg_dict, included_tc, excluded_tc)
+        test_cases, est_duration = get_estimations(cfg_dict, included_tc, excluded_tc,
+                                                   job_config['test_case_limit'])
 
         test_case_count = len(test_cases)
         estimations = f', test case count: {test_case_count}, '\

--- a/tools/cron/common.py
+++ b/tools/cron/common.py
@@ -653,6 +653,9 @@ def get_cron_config(cfg, **kwargs):
     if 'excluded' in config and config['excluded'].strip():
         config['bot_options_append'] += f" -e {config['excluded']}"
 
+    if 'test_case_limit' in config and config['test_case_limit']:
+        config['bot_options_append'] += f" --test_case_limit {config['test_case_limit']}"
+
     if 'bot_start_cmd' not in config:
         bot_args = f'{cfg} {config["bot_options_append"]}'
         config['bot_start_cmd'] = \

--- a/tools/cron/estimations.py
+++ b/tools/cron/estimations.py
@@ -95,8 +95,11 @@ def estimate_test_cases_duration(database_file, table_name, test_cases, max_coun
     return est_duration
 
 
-def get_estimations(config, included_tc, excluded_tc):
+def get_estimations(config, included_tc, excluded_tc, limit=None):
     test_cases = estimate_test_cases(config, included_tc, excluded_tc)
+
+    if limit:
+        test_cases = test_cases[:limit]
 
     est_duration = None
     database_file = config['auto_pts'].get('database_file', None)


### PR DESCRIPTION
By using test_case_limit param when triggering cron, we can limit number of test cases to be run when passing only test case prefix (e.g. GATT, GAP)