### PR TITLE
mynewt: wid: add missing argument to wid_hdl

### DIFF
--- a/autopts/ptsprojects/mynewt/gatt_client_wid.py
+++ b/autopts/ptsprojects/mynewt/gatt_client_wid.py
@@ -18,7 +18,7 @@ import socket
 
 from autopts.ptsprojects.stack import get_stack
 from autopts.pybtp import btp
-from autopts.ptsprojects.testcase import MMI
+from autopts.pybtp.types import WIDParams
 from autopts.wid import generic_wid_hdl
 
 log = logging.debug
@@ -36,7 +36,7 @@ def gattc_wid_hdl(wid, description, test_case_name):
                            [__name__, 'autopts.ptsprojects.mynewt.gatt_wid',
                             'autopts.wid.gatt'])
 
-def hdl_wid_142(desc):
+def hdl_wid_142(_: WIDParams):
     """
     Please send an ATT_Write_Request to Client Support Features handle = '0015'O with 0x02 to enable Enhanced ATT.
 
@@ -46,12 +46,12 @@ def hdl_wid_142(desc):
     return True
 
 
-def hdl_wid_400():
+def hdl_wid_400(_: WIDParams):
 
     return True
 
 
-def hdl_wid_402():
+def hdl_wid_402(_: WIDParams):
     """Please initiate an L2CAP Credit Based Connection using LE signaling channel to the PTS."""
 
     return True


### PR DESCRIPTION
Add missing argument to mynewt wid_hdl to avoid
"TypeError: hdl_wid_() takes 0 positional arguments but 1 was given"