### PR TITLE
tools: Fix repo path in list_testcases

### DIFF
--- a/tools/list_testcases.py
+++ b/tools/list_testcases.py
@@ -22,7 +22,7 @@ import sys
 import os
 from os.path import dirname, abspath
 
-AUTOPTS_REPO = dirname(dirname(dirname(abspath(__file__))))
+AUTOPTS_REPO = dirname(dirname(abspath(__file__)))
 sys.path.insert(0, AUTOPTS_REPO)
 
 from autopts.client import get_test_cases


### PR DESCRIPTION
This was causing script to not being able to locate required imports.