### PR TITLE
cron: Add start of an active hub server

### DIFF
--- a/tools/cron/common.py
+++ b/tools/cron/common.py
@@ -529,9 +529,20 @@ def terminate_processes(config):
     if 'vm' in config['cron']:
         close_vm(config)
 
+    if 'active_hub_server_start_cmd' in config['cron']:
+        terminate_process(cmdline='active_hub_server.py')
+
 
 def _start_processes(config, checkout_repos):
     srv_process = None
+
+    if 'active_hub_server_start_cmd' in config['cron']:
+        log(f"Running: {config['cron']['active_hub_server_start_cmd']}")
+        subprocess.Popen(config['cron']['active_hub_server_start_cmd'],
+                         shell=True,
+                         stdout=subprocess.PIPE,
+                         stderr=subprocess.STDOUT,
+                         cwd=config['cron']['autopts_repo'])
 
     if 'vm' in config['cron']:
         try:


### PR DESCRIPTION
It happened that the TCP/IP socket of the server got stuck, so lets restart the process at each cron job.