### PR TITLE
tools: cron: improve test case limit parameter

### DIFF
--- a/tools/cron/autopts_cron.py
+++ b/tools/cron/autopts_cron.py
@@ -227,6 +227,9 @@ def schedule_pr_job(cron, pr_info, job_config):
         test_cases, est_duration = get_estimations(cfg_dict, included_tc, excluded_tc,
                                                    job_config['test_case_limit'])
 
+        job_config.pop('test_case_limit')
+        job_config['included'] = test_cases
+
         test_case_count = len(test_cases)
         estimations = f', test case count: {test_case_count}, '\
                       f'estimated duration: {est_duration}'

--- a/tools/cron/estimations.py
+++ b/tools/cron/estimations.py
@@ -99,7 +99,20 @@ def get_estimations(config, included_tc, excluded_tc, limit=None):
     test_cases = estimate_test_cases(config, included_tc, excluded_tc)
 
     if limit:
-        test_cases = test_cases[:limit]
+        if len(included_tc) == 1:
+            test_cases = test_cases[:limit]
+        else:
+            profile_count = {prefix: 0 for prefix in included_tc}
+            tc_list = []
+            for profile in included_tc:
+                for test_case in test_cases:
+                    if profile_count[profile] == limit:
+                        break
+                    if test_case.startswith(profile):
+                        tc_list.append(test_case)
+                        profile_count[profile] += 1
+
+            test_cases = tc_list
 
     est_duration = None
     database_file = config['auto_pts'].get('database_file', None)


### PR DESCRIPTION
This will enable to run specified amount of test cases from among prefixes (when there is more than one) that are used with magic tag.
