### PR TITLE
mynewt: gatt: add btp gap pair command

### DIFF
--- a/autopts/ptsprojects/mynewt/gatt_client_wid.py
+++ b/autopts/ptsprojects/mynewt/gatt_client_wid.py
@@ -43,6 +43,8 @@ def hdl_wid_142(_: WIDParams):
     Discover all characteristics if needed.
     """
 
+    btp.gap_pair()
+
     return True
 
 


### PR DESCRIPTION
Adding gap_pair in wid_142 fixes various GATT/CL testcases. It may be that PTS used to (before some update) initiate pairing procedure which is why no btp command was used in this handler.
Fixes GATT/CL/GAN/BV-02-C GATT/CL/GAR/BI-36-C GATT/CL/GAR/BI-38-C GATT/CL/GAR/BI-44-C GATT/CL/GAR/BV-08-C GATT/CL/GAR/BV-10-C GATT/CL/GAT/BV-03-C