### PR TITLE
tools: cron: fix cron

### DIFF
--- a/autoptsclient_bot.py
+++ b/autoptsclient_bot.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-
 #
 # auto-pts - The Bluetooth PTS Automation Framework
 #
@@ -21,6 +20,7 @@ import sys
 import threading
 import time
 import schedule
+import copy
 
 from autopts.bot.common import get_absolute_module_path, load_module_from_path
 from autopts.utils import log_running_threads, have_admin_rights, set_global_end
@@ -59,7 +59,7 @@ def import_bot_projects():
         return None, config_path
 
     module = load_module_from_path(config_path)
-    return getattr(module, "BotProjects", None), config_path
+    return copy.deepcopy(getattr(module, "BotProjects", None)), config_path
 
 
 def import_bot_module(project):

--- a/tools/cron/autopts_bisect.py
+++ b/tools/cron/autopts_bisect.py
@@ -24,7 +24,7 @@ $ python3 autopts_bisect.py config_zephyr_bisect SM/CEN/JW/BV-05-C 7ab16c457b304
 
 If last_bad_commit is empty, then takes HEAD commit.
 """
-
+import copy
 import importlib
 import os
 import re
@@ -110,7 +110,7 @@ def load_cfg(cfg):
         raise Exception('{} does not exists!'.format(cfg_path))
 
     mod = load_module_from_path(cfg_path)
-    return mod.BotProjects[0], cfg_path
+    return copy.deepcopy(mod.BotProjects[0]), cfg_path
 
 
 def bisect(cfg, test_case, good_commit, bad_commit=''):

--- a/tools/cron/common.py
+++ b/tools/cron/common.py
@@ -24,6 +24,7 @@ start ssh agent in the same console:
 $ eval `ssh-agent`
 $ ssh-add path/to/id_rsa
 """
+import copy
 import logging
 import os
 import re
@@ -233,7 +234,7 @@ def load_config(cfg):
     if not mod:
         raise Exception(f'Could not load the config {cfg}')
 
-    return mod.BotProjects[0]
+    return copy.deepcopy(mod.BotProjects[0])
 
 
 def find_workspace_in_tree(tree_path, workspace, init_depth=4):


### PR DESCRIPTION
A .py file loaded as a module is cached until it is explicitly removed from sys.modules. So subsequent attempts to load the file only return a reference to the existing module-dictionary. So we need to deep-copy a config.py to prevent overwriting its original values and reuse it e.g. in subsequent PR jobs.