### PR TITLE
mynewt: gatt_cl: add mynewt specific wid handler

### DIFF
--- a/autopts/ptsprojects/mynewt/gatt_client_wid.py
+++ b/autopts/ptsprojects/mynewt/gatt_client_wid.py
@@ -17,6 +17,7 @@ import logging
 import socket
 
 from autopts.ptsprojects.stack import get_stack
+from autopts.ptsprojects.testcase import MMI
 from autopts.pybtp import btp
 from autopts.pybtp.types import WIDParams
 from autopts.wid import generic_wid_hdl
@@ -35,6 +36,49 @@ def gattc_wid_hdl(wid, description, test_case_name):
     return generic_wid_hdl(wid, description, test_case_name,
                            [__name__, 'autopts.ptsprojects.mynewt.gatt_wid',
                             'autopts.wid.gatt'])
+
+
+def hdl_wid_24(params: WIDParams):
+    """
+    Please confirm IUT received include services:
+        Attribute Handle = '0002'O
+        Included Service Attribute handle = '0080'O,
+        End Group Handle = '0085'O,
+        Service UUID = 'A00B'O
+        Attribute Handle = '0021'O
+        Included Service Attribute handle = '0001'O,
+        End Group Handle = '0006'O,
+        Service UUID = 'A00D'O
+        Attribute Handle = '0091'O
+        Included Service Attribute handle = '0001'O
+        End Group Handle = '0006'O,
+        Service UUID = 'A00D'O
+
+    Click Yes if IUT received it, otherwise click No.
+
+    Description: Verify that the Implementation Under Test (IUT) can send
+    Discover all include services in database.
+    """
+    MMI.reset()
+    MMI.parse_description(params.description)
+
+    if not MMI.args:
+        return False
+
+    # split MMI args into tuples (att_hdl, incl_svc_hdl, end_gp_hdl, svc_uuid)
+    mmi_args_tupled = []
+    for i in range(0, len(MMI.args), 4):
+        mmi_args_tupled.append(tuple(MMI.args[i:i + 4]))
+
+    stack = get_stack()
+    # TODO: there is no way to access included service handle wit current API.
+    #  For now, we skip this value when comparing find included services results
+    #  with description
+    incl_svcs = [tup[1:] for tup in stack.gatt_cl.incl_svcs]
+    mmi_args = [tup[1:] for tup in mmi_args_tupled]
+
+    return set(incl_svcs).issubset(set(mmi_args))
+
 
 def hdl_wid_142(_: WIDParams):
     """


### PR DESCRIPTION
Currently there is no way to access included service handle in Nimble with find included services procedure. We still can use other values that we have access to, to compare them with values from MMI which should be enough to pass test GATT/CL/GAD/BV-03-C.