### PR TITLE
zephyr: fix wrong DIS PIXIT value

### DIFF
--- a/autopts/ptsprojects/zephyr/dis.py
+++ b/autopts/ptsprojects/zephyr/dis.py
@@ -55,7 +55,7 @@ def set_pixits(ptses):
     pts.set_pixit("DIS", "TSPX_use_dynamic_pin", "FALSE")
     pts.set_pixit("DIS", "TSPX_delete_ltk", "TRUE")
     pts.set_pixit("DIS", "TSPX_security_enabled", "FALSE")
-    pts.set_pixit("MESH", "TSPX_iut_setup_att_over_br_edr", "FALSE")
+    pts.set_pixit("DIS", "TSPX_iut_setup_att_over_br_edr", "FALSE")
     pts.set_pixit("DIS", "TSPX_tester_appearance", "0000")
 
 


### PR DESCRIPTION
Fixes [issue 1227](https://github.com/auto-pts/auto-pts/issues/1227).