### PR TITLE
 cron: Fix missing descriptions in report emails

### DIFF
--- a/autopts/bot/common.py
+++ b/autopts/bot/common.py
@@ -383,6 +383,7 @@ class BotClient(Client):
                                              config_args.retry,
                                              self.test_case_database,
                                              xml_results_file=self.file_paths['TC_STATS_RESULTS_XML_FILE'])
+                    stats.session_log_dir = all_stats.session_log_dir
 
                     if self.args.use_backup:
                         self._backup_tc_stats(config=config, test_case=None, stats=stats)

--- a/autopts/bot/common.py
+++ b/autopts/bot/common.py
@@ -214,10 +214,10 @@ class BotClient(Client):
             tc_index = test_cases_per_config[continue_config].index(continue_test_case)
             test_cases_per_config[continue_config] = test_cases_per_config[continue_config][tc_index + 1:]
             self.backup['tc_stats'].index += 1
+            self.backup['tc_stats'].update(continue_test_case, 0, 'TIMEOUT')
 
             if not test_cases_per_config[continue_config]:
                 # The faulty test case was the last one in the config. Move to the next config
-                self.backup['tc_stats'].update(continue_test_case, 0, 'TIMEOUT')
                 self._merge_stats(self.backup['all_stats'], self.backup['tc_stats'])
                 self.backup['all_stats'].save_to_backup(self.file_paths['ALL_STATS_JSON_FILE'])
                 self.backup['tc_stats'] = None

--- a/autopts/bot/common.py
+++ b/autopts/bot/common.py
@@ -432,12 +432,18 @@ class BotClient(Client):
             all_stats.save_to_backup(self.file_paths['ALL_STATS_JSON_FILE'])
 
         try:
+            mapping = {'GMCS': 'MCS',
+                       'GTBS': 'TBS'}
             results = all_stats.get_results()
             descriptions = {}
             for test_case_name in list(results.keys()):
-                project_name = test_case_name.split('/')[0]
-                descriptions[test_case_name] = \
-                    self.ptses[0].get_test_case_description(project_name, test_case_name)
+                try:
+                    project_name = test_case_name.split('/')[0]
+                    project_name = mapping.get(project_name, project_name)
+                    descriptions[test_case_name] = \
+                        self.ptses[0].get_test_case_description(project_name, test_case_name)
+                except:
+                    log(f'Failed to get description of {test_case_name}')
 
             all_stats.update_descriptions(descriptions)
             all_stats.pts_ver = str(self.ptses[0].get_version())
@@ -445,8 +451,8 @@ class BotClient(Client):
             all_stats.system_version = str(self.ptses[0].get_system_version())
             if self.args.use_backup:
                 all_stats.save_to_backup(self.file_paths['ALL_STATS_JSON_FILE'])
-        except:
-            log('Failed to generate some stats.')
+        except BaseException as e:
+            log(f'Failed to generate some stats, {e}.')
 
         return all_stats
 

--- a/autopts/bot/common.py
+++ b/autopts/bot/common.py
@@ -443,6 +443,8 @@ class BotClient(Client):
             all_stats.pts_ver = str(self.ptses[0].get_version())
             all_stats.platform = str(self.ptses[0].get_system_model())
             all_stats.system_version = str(self.ptses[0].get_system_version())
+            if self.args.use_backup:
+                all_stats.save_to_backup(self.file_paths['ALL_STATS_JSON_FILE'])
         except:
             log('Failed to generate some stats.')
 

--- a/autopts/client.py
+++ b/autopts/client.py
@@ -576,6 +576,7 @@ class TestCaseRunStats:
         self.pending_config = None
         self.pending_test_case = None
         self.test_run_completed = False
+        self.session_log_dir = None
 
         if self.xml_results and not os.path.exists(self.xml_results):
             os.makedirs(dirname(self.xml_results), exist_ok=True)
@@ -612,6 +613,7 @@ class TestCaseRunStats:
         self.est_duration = self.est_duration + stats2.est_duration
         self.pending_config = stats2.pending_config
         self.pending_test_case = stats2.pending_test_case
+        self.session_log_dir = stats2.session_log_dir
 
         stats2_tree = ElementTree.parse(stats2.xml_results)
         root2 = stats2_tree.getroot()
@@ -1214,16 +1216,19 @@ def get_test_cases(pts, test_cases, excluded):
 
 def run_test_cases(ptses, test_case_instances, args, stats, **kwargs):
     """Runs a list of test cases"""
+    session_log_dir = stats.session_log_dir
 
-    ports_str = '_'.join(str(x) for x in args.cli_port)
-    now = datetime.datetime.now().strftime("%Y_%m_%d_%H_%M_%S")
-    logs_folder = kwargs["file_paths"]["IUT_LOGS_DIR"]
-    session_log_dir = f'{logs_folder}/cli_port_{ports_str}/{now}'
-    try:
-        os.makedirs(session_log_dir)
-    except OSError as e:
-        if e.errno != errno.EEXIST:
-            raise
+    if not session_log_dir:
+        ports_str = '_'.join(str(x) for x in args.cli_port)
+        now = datetime.datetime.now().strftime("%Y_%m_%d_%H_%M_%S")
+        logs_folder = kwargs["file_paths"]["IUT_LOGS_DIR"]
+        session_log_dir = f'{logs_folder}/cli_port_{ports_str}/{now}'
+        stats.session_log_dir = session_log_dir
+        try:
+            os.makedirs(session_log_dir)
+        except OSError as e:
+            if e.errno != errno.EEXIST:
+                raise
 
     test_cases = args.test_cases
     retry_config = getattr(args, 'retry_config', None)

--- a/autopts/config.py
+++ b/autopts/config.py
@@ -44,6 +44,7 @@ def generate_file_paths(file_paths=None, autopts_root_dir=AUTOPTS_ROOT_DIR):
         'TC_STATS_JSON_FILE': os.path.join(FILE_PATHS['TMP_DIR'], 'tc_stats.json'),
         'TEST_CASE_DB_FILE': os.path.join(FILE_PATHS['TMP_DIR'], 'TestCase.db'),
         'BOT_STATE_JSON_FILE': os.path.join(FILE_PATHS['TMP_DIR'], 'bot_state.json'),
+        'BOT_STATE_DIR': os.path.join(FILE_PATHS['TMP_DIR'], 'final_state'),
         'REPORT_README_MD_FILE': os.path.join(FILE_PATHS['TMP_DIR'], 'README.md'),
         'REPORT_DIR': os.path.join(FILE_PATHS['TMP_DIR'], 'autopts_report'),
         'IUT_LOGS_DIR': os.path.join(autopts_root_dir, 'logs'),

--- a/autopts/ptsprojects/boards/nrf53_appcore.py
+++ b/autopts/ptsprojects/boards/nrf53_appcore.py
@@ -1,0 +1,43 @@
+#
+# auto-pts - The Bluetooth PTS Automation Framework
+#
+# Copyright (c) 2023, Codecoup.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms and conditions of the GNU General Public License,
+# version 2, as published by the Free Software Foundation.
+#
+# This program is distributed in the hope it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+
+from .nrf5x import *
+from autopts.bot.common import check_call
+
+board_type = 'nrf5340dk/nrf5340/cpuapp'
+
+
+def build_and_flash(zephyr_wd, board, debugger_snr, conf_file=None, *args):
+    """Build and flash Zephyr binary
+    :param zephyr_wd: Zephyr source path
+    :param board: IUT
+    :param debugger_snr serial number
+    :param conf_file: configuration file to be used
+    """
+    logging.debug("%s: %s %s %s", build_and_flash.__name__, zephyr_wd,
+                  board, conf_file)
+
+    tester_dir = os.path.join(zephyr_wd, 'tests', 'bluetooth', 'tester')
+
+    check_call('rm -rf build/'.split(), cwd=tester_dir)
+
+    bttester_overlay = 'nrf5340_hci_ipc.conf'
+
+    if conf_file and conf_file != 'default' and conf_file != 'prj.conf':
+        bttester_overlay += f';{conf_file}'
+
+    cmd = ['west', 'build', '-b', board, '--', f'-DOVERLAY_CONFIG=\'{bttester_overlay}\'']
+    check_call(cmd, cwd=tester_dir)
+    check_call(['west', 'flash', '--skip-rebuild', '--recover', '-i', debugger_snr], cwd=tester_dir)

--- a/tools/cron/common.py
+++ b/tools/cron/common.py
@@ -50,7 +50,7 @@ sys.path.insert(0, AUTOPTS_REPO)
 
 from autopts.utils import get_global_end, terminate_process
 from tools.cron.autopts_bisect import Bisect, set_run_test_fun
-from autopts.bot.common import load_module_from_path
+from autopts.bot.common import load_module_from_path, save_files
 from autopts.bot.common_features.github import update_repos
 from autopts.bot.common_features.mail import send_mail
 from autopts.config import generate_file_paths, FILE_PATHS
@@ -351,10 +351,7 @@ def pre_cleanup_files(config):
                 else:
                     shutil.rmtree(file_path, ignore_errors=True)
 
-        for file in files_to_save:
-            file_path = os.path.join(autopts_repo, file)
-            if os.path.exists(file_path):
-                shutil.move(file_path, os.path.join(save_dir, os.path.basename(file_path)))
+        save_files(files_to_save, save_dir)
     except:
         pass
 


### PR DESCRIPTION
Minor fixes:
- fix missing descriptions in report emails,
- fix generating redundant folder with session logs and old logs,
- in backup mode, prevent restarting bot by cron if logs pulling takes longer than cron timeout
- add config for building/flashing only appcore of nrf53