### PR TITLE
zephyr: Add support for the nRF5340 Audio devkit

### DIFF
--- a/autopts/bot/common.py
+++ b/autopts/bot/common.py
@@ -136,7 +136,7 @@ class BotClient(Client):
             if args.debugger_snr is None:
                 args.tty_file, args.debugger_snr = get_free_device(args.board_name)
             else:
-                args.tty_file = get_tty(args.debugger_snr)
+                args.tty_file = get_tty(args.debugger_snr, args.board_name)
 
             if args.tty_file is None:
                 log('TTY mode: No free device found')

--- a/autopts/bot/zephyr.py
+++ b/autopts/bot/zephyr.py
@@ -68,10 +68,12 @@ def apply_overlay(zephyr_wd, cfg_name, overlay):
     :param overlay: defines changes to be applied
     :return: None
     """
-    tester_app_dir = os.path.join(zephyr_wd, "tests", "bluetooth", "tester")
+    tester_app_dir = os.getenv("AUTOPTS_SOURCE_DIR_APP")
+    if tester_app_dir is None:
+        tester_app_dir = os.path.join("tests", "bluetooth", "tester")
     cwd = os.getcwd()
 
-    os.chdir(tester_app_dir)
+    os.chdir(os.path.join(zephyr_wd, tester_app_dir))
 
     with open(cfg_name, 'w') as config:
         for k, v in list(overlay.items()):
@@ -193,7 +195,7 @@ class ZephyrBotClient(BotClient):
         configs = []
         for name in pre_overlay + [config] + post_overlay:
             if name in self.iut_config and 'overlay' in self.iut_config[name] \
-                    and len(self.iut_config[name]['overlay']):
+                    and len(self.iut_config[name]['overlay']) and name != 'prj.conf':
                 apply_overlay(args.project_path, name,
                               self.iut_config[name]['overlay'])
             elif not os.path.exists(os.path.join(args.project_path, "tests", "bluetooth", "tester", name)):

--- a/autopts/ptsprojects/boards/__init__.py
+++ b/autopts/ptsprojects/boards/__init__.py
@@ -171,12 +171,22 @@ def get_free_device(board=None):
     """Returns tty path and jlink serial number of a free device."""
     devices = get_device_list()
 
+    ret_snr = None
+    ret_tty = None
+
     for tty, snr in devices.items():
         if tty not in devices_in_use and len(snr) >= 9 and snr.isnumeric():
-            devices_in_use.append(tty)
-            return tty, snr
+            ret_snr = snr
+            ret_tty = tty
+            # Opposite enumeration-order for TTY to coproccessor cores on nRF5340 Audio devkit.
+            if board != 'nrf53_audio':
+                break
 
-    return None, None
+    if ret_tty is not None:
+        devices_in_use.append(ret_tty)
+
+    log("Got free rtt for device {}: {}".format(ret_snr, ret_tty))
+    return ret_tty, ret_snr
 
 
 def get_debugger_snr(tty):
@@ -195,7 +205,7 @@ def get_debugger_snr(tty):
     return jlink
 
 
-def get_tty(debugger_snr):
+def get_tty(debugger_snr, board=None):
     """Return tty or COM of the device with given serial number.
     """
     tty = None
@@ -204,8 +214,11 @@ def get_tty(debugger_snr):
     for dev in devices.keys():
         if devices[dev] == debugger_snr:
             tty = dev
-            break
+            # Opposite enumeration-order for TTY to coproccessor cores on nRF5340 Audio devkit.
+            if board != 'nrf53_audio':
+                break
 
+    log("Got tty for device {}: {}".format(debugger_snr, tty))
     return tty
 
 

--- a/autopts/ptsprojects/boards/nrf53_audio.py
+++ b/autopts/ptsprojects/boards/nrf53_audio.py
@@ -1,0 +1,81 @@
+#
+# auto-pts - The Bluetooth PTS Automation Framework
+#
+# Copyright (c) 2024, Nordic Semiconductor ASA.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms and conditions of the GNU General Public License,
+# version 2, as published by the Free Software Foundation.
+#
+# This program is distributed in the hope it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+
+import os
+
+from .nrf5x import *
+from autopts.bot.common import check_call
+
+board_type = 'nrf5340_audio_dk_nrf5340_cpuapp'
+
+
+def build_and_flash_core(zephyr_wd, build_dir, board, debugger_snr, configs, recover = False):
+    build_dir = os.path.join(zephyr_wd, build_dir)
+    check_call('rm -rf build/'.split(), cwd=build_dir)
+
+    overlay = '-- -DCMAKE_C_FLAGS="-Werror"'
+    for conf in configs:
+        overlay += f' -D{conf}'
+    cmd = ['west', 'build', '-b', board]
+    cmd.extend(overlay.split())
+    check_call(cmd, cwd=build_dir)
+    
+    build_name = str(build_dir).split('/')[-1]
+    check_call("rm ./build_{}.zip || exit 0".format(build_name).split(), cwd=zephyr_wd)
+    check_call("zip -r {}/build_{}.zip build -i '*.hex' '*.config'".format(zephyr_wd, build_name).split(), cwd=build_dir)
+
+    cmd = ['west', 'flash', '--skip-rebuild', '-i', debugger_snr]
+    if recover:
+        cmd.append('--recover')
+    check_call(cmd, cwd=build_dir)
+
+def build_and_flash(zephyr_wd, board, debugger_snr, conf_file=None, *args):
+    """Build and flash Zephyr binary
+    :param zephyr_wd: Zephyr source path
+    :param board: IUT
+    :param debugger_snr serial number
+    :param conf_file: configuration file to be used
+    """
+    source_dir = os.getenv("AUTOPTS_SOURCE_DIR_APP")
+    if source_dir is None:
+        source_dir = os.path.join('tests', 'bluetooth', 'tester')
+
+    logging.debug("%s: %s %s %s %s", build_and_flash.__name__, zephyr_wd,
+                  board, conf_file, source_dir)
+
+    app_core_configs = []
+    if conf_file and conf_file != 'default' and conf_file != 'prj.conf':
+        app_core_configs = [f'OVERLAY_CONFIG=\'{conf_file}\'']
+
+    build_and_flash_core(zephyr_wd,
+                         source_dir,
+                         board,
+                         debugger_snr,
+                         app_core_configs,
+                         True)
+
+    config_dir_net = os.getenv("AUTOPTS_SOURCE_DIR_NET")
+    if config_dir_net is None:
+        net_core_configs = [f'OVERLAY_CONFIG=\'nrf5340_cpunet_iso-bt_ll_sw_split.conf;'
+                            f'../../../tests/bluetooth/tester/nrf5340_hci_ipc_cpunet.conf\'']
+    else:
+        conf_path = os.path.join(zephyr_wd, config_dir_net, 'hci_ipc.conf')
+        net_core_configs = [f'OVERLAY_CONFIG=\'{conf_path}\'']
+
+    build_and_flash_core(zephyr_wd,
+                         os.path.join('samples', 'bluetooth', 'hci_ipc'),
+                         'nrf5340_audio_dk_nrf5340_cpunet',
+                         debugger_snr,
+                         net_core_configs)

--- a/autopts/ptsprojects/zephyr/iutctl.py
+++ b/autopts/ptsprojects/zephyr/iutctl.py
@@ -205,6 +205,7 @@ class ZephyrCtl:
 
     def rtt_logger_stop(self):
         if self.rtt_logger:
+            time.sleep(0.1)  # Make sure all logs have been collected, in case test failed early.
             self.rtt_logger.stop()
 
     def wait_iut_ready_event(self, reset=True):


### PR DESCRIPTION
Adds the nRF5340 audio devkit board, with capabilities to build both application and network cores with configurable separate builds.