### PR TITLE
Use raw string for regex

### DIFF
--- a/autopts/wid/gap.py
+++ b/autopts/wid/gap.py
@@ -1424,7 +1424,7 @@ def hdl_wid_1003(params: WIDParams):
     """
     Please confirm the following number matches IUT: [passkey]
     """
-    pattern = '[\d]{6}'
+    pattern = r'[\d]{6}'
     passkey = re.search(pattern, params.description)[0]
     stack = get_stack()
     bd_addr = btp.pts_addr_get()
@@ -1455,7 +1455,7 @@ def hdl_wid_2001(params: WIDParams):
     """
     The secureId is [passkey]
     """
-    pattern = '[\d]{6}'
+    pattern = r'[\d]{6}'
     passkey = re.search(pattern, params.description)[0]
     stack = get_stack()
     bd_addr = btp.pts_addr_get()
@@ -1472,7 +1472,7 @@ def hdl_wid_2004(params: WIDParams):
     """
     Please confirm that 6 digit number is matched with [passkey].
     """
-    pattern = '[\d]{6}'
+    pattern = r'[\d]{6}'
     passkey = re.search(pattern, params.description)[0]
     stack = get_stack()
     bd_addr = btp.pts_addr_get()

--- a/autopts/wid/gatt.py
+++ b/autopts/wid/gatt.py
@@ -42,7 +42,7 @@ def gattc_wid_hdl_multiple_indications(wid, description, test_case_name):
     if wid == 99:
         log("%s, %r, %r, %s", gattc_wid_hdl_multiple_indications.__name__, wid, description,
             test_case_name)
-        pattern = re.compile("'([0-9a-fA-F]+)'")
+        pattern = re.compile(r"'([0-9a-fA-F]+)'")
         params = pattern.findall(description)
         if not params:
             logging.error("parsing error")
@@ -861,7 +861,7 @@ def hdl_wid_69(params: WIDParams):
 
 
 def hdl_wid_70(params: WIDParams):
-    pattern = re.compile("'([0-9a-fA-F]+)'")
+    pattern = re.compile(r"'([0-9a-fA-F]+)'")
     params = pattern.findall(params.description)
     if not params:
         logging.error("parsing error")
@@ -939,7 +939,7 @@ def hdl_wid_75(params: WIDParams):
 
 
 def hdl_wid_76(params: WIDParams):
-    pattern = re.compile("'([0-9a-fA-F]+)'")
+    pattern = re.compile(r"'([0-9a-fA-F]+)'")
     command_params = pattern.findall(params.description)
     if not command_params:
         logging.error("parsing error")
@@ -1050,7 +1050,7 @@ def hdl_wid_90(_: WIDParams):
 
 
 def hdl_wid_91(params: WIDParams):
-    pattern = re.compile("'([0-9a-fA-F]+)'")
+    pattern = re.compile(r"'([0-9a-fA-F]+)'")
     params = pattern.findall(params.description)
     if not params:
         logging.error("parsing error")
@@ -1161,7 +1161,7 @@ def hdl_wid_98(params: WIDParams):
 
 
 def hdl_wid_99(params: WIDParams):
-    pattern = re.compile("'([0-9a-fA-F]+)'")
+    pattern = re.compile(r"'([0-9a-fA-F]+)'")
     params = pattern.findall(params.description)
     if not params:
         logging.error("parsing error")

--- a/autopts/wid/gatt_client.py
+++ b/autopts/wid/gatt_client.py
@@ -470,7 +470,7 @@ def hdl_wid_35(params: WIDParams):
     result = True
     # Partial matches are allowed for WID 35 as the verify values may be
     # truncated to ATT_MTU
-    pattern = re.compile("'([0-9a-fA-F]+)'")
+    pattern = re.compile(r"'([0-9a-fA-F]+)'")
     params = pattern.findall(params.description)
 
     to_verify = []
@@ -650,7 +650,7 @@ def hdl_wid_50(params: WIDParams):
     Please confirm IUT received characteristic value='Attribute Handle = '0233'O
     Value = 7F11220405060708090A0B0C0405060708090A0B0C 'O in random selected
     adopted database. Click Yes if IUT received it, otherwise click No.
-    
+
     Description: Verify that the Implementation Under Test (IUT) can send
     Read characteristic to PTS random select adopted database."
     """
@@ -990,7 +990,7 @@ def hdl_wid_70(params: WIDParams):
     Description: Verify that the Implementation Under Test (IUT) can send
     write request.
     """
-    pattern = re.compile("'([0-9a-fA-F]+)'")
+    pattern = re.compile(r"'([0-9a-fA-F]+)'")
     params = pattern.findall(params.description)
     if not params:
         logging.error("parsing error")
@@ -1070,7 +1070,7 @@ def hdl_wid_76(params: WIDParams):
     Description: Verify that the Implementation Under Test (IUT) can send
     prepare write request.
     """
-    pattern = re.compile("'([0-9a-fA-F]+)'")
+    pattern = re.compile(r"'([0-9a-fA-F]+)'")
     params = pattern.findall(params.description)
     if not params:
         logging.error("parsing error")
@@ -1196,7 +1196,7 @@ def hdl_wid_91(params: WIDParams):
     notification sent from PTS.
     """
     stack = get_stack()
-    pattern = re.compile("'([0-9a-fA-F]+)'")
+    pattern = re.compile(r"'([0-9a-fA-F]+)'")
     params = pattern.findall(params.description)
     if not params:
         logging.error("parsing error")
@@ -1232,7 +1232,7 @@ def hdl_wid_99(params: WIDParams):
     Description: Verify that the Implementation Under Test (IUT) can receive
     indication sent from PTS.
     """
-    pattern = re.compile("'([0-9a-fA-F]+)'")
+    pattern = re.compile(r"'([0-9a-fA-F]+)'")
     params = pattern.findall(params.description)
     if not params:
         logging.error("parsing error")

--- a/autopts/wid/sm.py
+++ b/autopts/wid/sm.py
@@ -116,7 +116,7 @@ def hdl_wid_142(params: WIDParams):
     """
     Please confirm the following number matches IUT: [passkey]
     """
-    pattern = '[\d]{6}'
+    pattern = r'[\d]{6}'
     passkey = re.search(pattern, params.description)[0]
     stack = get_stack()
     bd_addr = btp.pts_addr_get()


### PR DESCRIPTION
Some string used for regex were not using Python raw string (`r""`). This may cause problems when the regular expression use backslash. Python would try to interpret the backslash as an escape sequence.