### PR TITLE
Fix two PTSes tests for MESH

### DIFF
--- a/autopts/ptsprojects/mynewt/mesh.py
+++ b/autopts/ptsprojects/mynewt/mesh.py
@@ -618,8 +618,10 @@ def test_cases(ptses):
 
         tc_list.append(instance)
 
-    if len(ptses) == 2:
-        tc_list += test_cases_slaves
-        pts2 = ptses[1]
+    if len(ptses) < 2:
+        return tc_list
+
+    tc_list += test_cases_slaves
+    pts2 = ptses[1]
 
     return tc_list

--- a/autopts/ptsprojects/zephyr/mesh.py
+++ b/autopts/ptsprojects/zephyr/mesh.py
@@ -986,8 +986,10 @@ def test_cases(ptses):
 
         tc_list.append(instance)
 
-    if len(ptses) == 2:
-        tc_list += test_cases_slaves
-        pts2 = ptses[1]
+    if len(ptses) < 2:
+        return tc_list
+
+    tc_list += test_cases_slaves
+    pts2 = ptses[1]
 
     return tc_list


### PR DESCRIPTION
It is possible that setup has more than two PTSes available and invalid check was causing those to be skipped. Follow early return pattern as other profiles as this is future proof.