### PR TITLE
Replace key 'error_txt' with 'ERROR_TXT_FILE'

### DIFF
--- a/autopts/bot/zephyr.py
+++ b/autopts/bot/zephyr.py
@@ -141,7 +141,7 @@ class ZephyrBotClient(BotClient):
                 flush_serial(args.tty_file)
             except BaseException as e:
                 traceback.print_exception(e)
-                report.make_error_txt('Build and flash step failed', self.file_paths['error_txt'])
+                report.make_error_txt('Build and flash step failed', self.file_paths['ERROR_TXT_FILE'])
                 raise BuildAndFlashException
 
             time.sleep(10)


### PR DESCRIPTION
The wrong key was used to access error file path. This caused unhandled exception.