### PR TITLE
zephyr: sysbuild configuration for 53/54h

### DIFF
--- a/autopts/ptsprojects/boards/nrf53.py
+++ b/autopts/ptsprojects/boards/nrf53.py
@@ -40,11 +40,11 @@ def build_and_flash(zephyr_wd, board, debugger_snr, conf_file=None, *args):
     if conf_file and conf_file != 'default' and conf_file != 'prj.conf':
         bttester_overlay += f';{conf_file}'
 
-    cmd = ['west', 'build', '-b', board, '--', f'-DEXTRA_CONF_FILE=\'{bttester_overlay}\'']
+    cmd = ['west', 'build', '--no-sysbuild', '-b', board, '--', f'-DEXTRA_CONF_FILE=\'{bttester_overlay}\'']
     check_call(cmd, cwd=tester_dir)
     check_call(['west', 'flash', '--skip-rebuild', '--recover', '-i', debugger_snr], cwd=tester_dir)
 
-    cmd = ['west', 'build', '-b', 'nrf5340dk/nrf5340/cpunet', '--',
+    cmd = ['west', 'build', '--no-sysbuild', '-b', 'nrf5340dk/nrf5340/cpunet', '--',
            f'-DEXTRA_CONF_FILE=\'nrf5340_cpunet_iso-bt_ll_sw_split.conf;'
            f'../../../tests/bluetooth/tester/nrf5340_hci_ipc_cpunet.conf\'']
     check_call(cmd, cwd=controller_dir)

--- a/autopts/ptsprojects/boards/nrf53.py
+++ b/autopts/ptsprojects/boards/nrf53.py
@@ -35,7 +35,7 @@ def build_and_flash(zephyr_wd, board, debugger_snr, conf_file=None, *args):
     check_call('rm -rf build/'.split(), cwd=tester_dir)
     check_call('rm -rf build/'.split(), cwd=controller_dir)
 
-    bttester_overlay = 'nrf5340_hci_ipc.conf'
+    bttester_overlay = 'hci_ipc.conf'
 
     if conf_file and conf_file != 'default' and conf_file != 'prj.conf':
         bttester_overlay += f';{conf_file}'
@@ -46,6 +46,6 @@ def build_and_flash(zephyr_wd, board, debugger_snr, conf_file=None, *args):
 
     cmd = ['west', 'build', '--no-sysbuild', '-b', 'nrf5340dk/nrf5340/cpunet', '--',
            f'-DEXTRA_CONF_FILE=\'nrf5340_cpunet_iso-bt_ll_sw_split.conf;'
-           f'../../../tests/bluetooth/tester/nrf5340_hci_ipc_cpunet.conf\'']
+           f'../../../tests/bluetooth/tester/hci_ipc_cpunet.conf\'']
     check_call(cmd, cwd=controller_dir)
     check_call(['west', 'flash', '--skip-rebuild', '-i', debugger_snr], cwd=controller_dir)

--- a/autopts/ptsprojects/boards/nrf53_appcore.py
+++ b/autopts/ptsprojects/boards/nrf53_appcore.py
@@ -33,7 +33,7 @@ def build_and_flash(zephyr_wd, board, debugger_snr, conf_file=None, *args):
 
     check_call('rm -rf build/'.split(), cwd=tester_dir)
 
-    bttester_overlay = 'nrf5340_hci_ipc.conf'
+    bttester_overlay = 'hci_ipc.conf'
 
     if conf_file and conf_file != 'default' and conf_file != 'prj.conf':
         bttester_overlay += f';{conf_file}'

--- a/autopts/ptsprojects/boards/nrf53_appcore.py
+++ b/autopts/ptsprojects/boards/nrf53_appcore.py
@@ -38,6 +38,6 @@ def build_and_flash(zephyr_wd, board, debugger_snr, conf_file=None, *args):
     if conf_file and conf_file != 'default' and conf_file != 'prj.conf':
         bttester_overlay += f';{conf_file}'
 
-    cmd = ['west', 'build', '-b', board, '--', f'-DEXTRA_CONF_FILE=\'{bttester_overlay}\'']
+    cmd = ['west', 'build', '--no-sysbuild', '-b', board, '--', f'-DEXTRA_CONF_FILE=\'{bttester_overlay}\'']
     check_call(cmd, cwd=tester_dir)
     check_call(['west', 'flash', '--skip-rebuild', '--recover', '-i', debugger_snr], cwd=tester_dir)

--- a/autopts/ptsprojects/boards/nrf53_audio.py
+++ b/autopts/ptsprojects/boards/nrf53_audio.py
@@ -28,7 +28,7 @@ def build_and_flash_core(zephyr_wd, build_dir, board, debugger_snr, configs, rec
     overlay = '-- -DCMAKE_C_FLAGS="-Werror"'
     for conf in configs:
         overlay += f' -D{conf}'
-    cmd = ['west', 'build', '-b', board]
+    cmd = ['west', 'build', '--no-sysbuild', '-b', board]
     cmd.extend(overlay.split())
     check_call(cmd, cwd=build_dir)
     

--- a/autopts/ptsprojects/boards/nrf53_audio.py
+++ b/autopts/ptsprojects/boards/nrf53_audio.py
@@ -69,7 +69,7 @@ def build_and_flash(zephyr_wd, board, debugger_snr, conf_file=None, *args):
     config_dir_net = os.getenv("AUTOPTS_SOURCE_DIR_NET")
     if config_dir_net is None:
         net_core_configs = [f'EXTRA_CONF_FILE=\'nrf5340_cpunet_iso-bt_ll_sw_split.conf;'
-                            f'../../../tests/bluetooth/tester/nrf5340_hci_ipc_cpunet.conf\'']
+                            f'../../../tests/bluetooth/tester/hci_ipc_cpunet.conf\'']
     else:
         conf_path = os.path.join(zephyr_wd, config_dir_net, 'hci_ipc.conf')
         net_core_configs = [f'EXTRA_CONF_FILE=\'{conf_path}\'']

--- a/autopts/ptsprojects/boards/nrf54h.py
+++ b/autopts/ptsprojects/boards/nrf54h.py
@@ -44,7 +44,7 @@ def build_and_flash(zephyr_wd, board, debugger_snr, conf_file=None, *args):
 
     check_call('rm -rf build/'.split(), cwd=tester_dir)
 
-    cmd = ['west', 'build', '-p', 'auto', '-b', board]
+    cmd = ['west', 'build', '--sysbuild', '-p', 'auto', '-b', board]
     if conf_file and conf_file not in ['default', 'prj.conf']:
         if 'audio' in conf_file:
             conf_file += ';overlay-le-audio-ctlr.conf'


### PR DESCRIPTION
Using sysbuild, cpuapp build automatically triggers building hci_ipc build for cpurad. Preserve the old behaviour for 53 with no sysbuild.