### PR TITLE
errata: Cleanup fixed Zephyr specific erratas

### DIFF
--- a/errata/zephyr.yaml
+++ b/errata/zephyr.yaml
@@ -14,38 +14,7 @@ MCP/CL/CGGIT/CHA/BV-12-C: Request ID 28478
 MCP/CL/CGGIT/CHA/BV-14-C: Request ID 28478
 MCP/CL/CGGIT/CHA/BV-15-C: Request ID 28478
 
-BAP/UCL/STR/BV-525-C: https://github.com/zephyrproject-rtos/zephyr/issues/60132 2th CIS not established
-BAP/UCL/STR/BV-526-C: https://github.com/zephyrproject-rtos/zephyr/issues/60132 2th CIS not established
-BAP/UCL/STR/BV-527-C: https://github.com/zephyrproject-rtos/zephyr/issues/60132 2th CIS not established
-BAP/UCL/STR/BV-528-C: https://github.com/zephyrproject-rtos/zephyr/issues/60132 2th CIS not established
-BAP/UCL/STR/BV-529-C: https://github.com/zephyrproject-rtos/zephyr/issues/60132 2th CIS not established
-BAP/UCL/STR/BV-530-C: https://github.com/zephyrproject-rtos/zephyr/issues/60132 2th CIS not established
-BAP/UCL/STR/BV-531-C: https://github.com/zephyrproject-rtos/zephyr/issues/60132 2th CIS not established
-BAP/UCL/STR/BV-532-C: https://github.com/zephyrproject-rtos/zephyr/issues/60132 2th CIS not established
-BAP/UCL/STR/BV-533-C: https://github.com/zephyrproject-rtos/zephyr/issues/60132 2th CIS not established
-BAP/UCL/STR/BV-534-C: https://github.com/zephyrproject-rtos/zephyr/issues/60132 2th CIS not established
-BAP/UCL/STR/BV-537-C: ISO disconnection https://github.com/zephyrproject-rtos/zephyr/issues/60132 2th CIS not established
-BAP/UCL/STR/BV-538-C: ISO disconnection https://github.com/zephyrproject-rtos/zephyr/issues/60132 2th CIS not established
-BAP/UCL/STR/BV-556-C: ISO disconnection https://github.com/zephyrproject-rtos/zephyr/issues/60132 2th CIS not established
-BAP/UCL/STR/BV-557-C: ISO disconnection https://github.com/zephyrproject-rtos/zephyr/issues/60132 2th CIS not established
-BAP/UCL/STR/BV-558-C: ISO disconnection https://github.com/zephyrproject-rtos/zephyr/issues/60132 2th CIS not established
-BAP/UCL/STR/BV-559-C: ISO disconnection https://github.com/zephyrproject-rtos/zephyr/issues/60132 2th CIS not established
-BAP/USR/STR/BV-362-C: https://github.com/zephyrproject-rtos/zephyr/issues/60132 2th CIS not established
-BAP/USR/STR/BV-365-C: https://github.com/zephyrproject-rtos/zephyr/issues/60132 2th CIS not established
-BAP/USR/STR/BV-366-C: https://github.com/zephyrproject-rtos/zephyr/issues/60132 2th CIS not established
-BAP/USR/STR/BV-369-C: ISO disconnection https://github.com/zephyrproject-rtos/zephyr/issues/60132 2th CIS not established
-BAP/USR/STR/BV-370-C: ISO disconnection https://github.com/zephyrproject-rtos/zephyr/issues/60132 2th CIS not established
-BAP/USR/STR/BV-373-C: ISO disconnection https://github.com/zephyrproject-rtos/zephyr/issues/60132 2th CIS not established
-BAP/USR/STR/BV-374-C: ISO disconnection https://github.com/zephyrproject-rtos/zephyr/issues/60132 2th CIS not established
-BAP/USR/STR/BV-377-C: https://github.com/zephyrproject-rtos/zephyr/issues/60132 2th CIS not established
-BAP/USR/STR/BV-380-C: https://github.com/zephyrproject-rtos/zephyr/issues/60132 2th CIS not established
-BAP/USR/STR/BV-383-C: https://github.com/zephyrproject-rtos/zephyr/issues/60132 2th CIS not established
 BASS/SR/CP/BV-21-C:  https://github.com/zephyrproject-rtos/zephyr/issues/64871 No API to request the Broadcast Code without sync
-TBS/SR/SGGIT/CHA/BV-05-C: Request ID 31633
-TBS/SR/SGGIT/CHA/BV-06-C: Request ID 31633
-TBS/SR/SGGIT/CHA/BV-08-C: Request ID 31633
-TBS/SR/SGGIT/CHA/BV-09-C: Request ID 31633
-TBS/SR/SGGIT/CHA/BV-13-C: Request ID 31633
 TBS/SR/SPN/BV-05-C: Request ID 31633
 TBS/SR/SPN/BV-06-C: Request ID 31633
 TBS/SR/SPN/BV-07-C: Request ID 31633
@@ -57,11 +26,6 @@ TBS/SR/SPN/BV-11-C: Request ID 31633
 TBS/SR/CP/BV-10-C: https://github.com/zephyrproject-rtos/zephyr/issues/41738 Disallow Join not possible at runtime
 TBS/SR/SPE/BI-05-C: TSE24847
 GTBS/SR/CP/BV-10-C: https://github.com/zephyrproject-rtos/zephyr/issues/41738 Disallow Join not possible at runtime
-GTBS/SR/SGGIT/CHA/BV-05-C: Request ID 31633
-GTBS/SR/SGGIT/CHA/BV-06-C: Request ID 31633
-GTBS/SR/SGGIT/CHA/BV-08-C: Request ID 31633
-GTBS/SR/SGGIT/CHA/BV-09-C: Request ID 31633
-GTBS/SR/SGGIT/CHA/BV-13-C: Request ID 31633
 GTBS/SR/SPN/BV-05-C: Request ID 31633
 GTBS/SR/SPN/BV-06-C: Request ID 31633
 GTBS/SR/SPN/BV-07-C: Request ID 31633


### PR DESCRIPTION
Not all tests initially affected by 2 ISOs connection issues are passing but those are no longer related to it.