### PR TITLE
wid: gap: Add workaround for conflicting MMIs

### DIFF
--- a/autopts/ptsprojects/stack/layers/gap.py
+++ b/autopts/ptsprojects/stack/layers/gap.py
@@ -107,6 +107,9 @@ class Gap:
         self.periodic_sync_established_rxed = False
         self.periodic_transfer_received = False
 
+        # Used for MMI handling
+        self.delay_mmi = False
+
     def add_connection(self, addr, addr_type):
         self.connections[addr] = GapConnection(addr=addr,
                                                addr_type=addr_type)


### PR DESCRIPTION
This commit implements a temporary workaround for PTS issue 136305 which causes invalid sequence of events in some GAP/SEC/SEM test cases. There are two conflicting MMIs that affect test case verdict when handled in incorrect order.