### PR TITLE
bot: add rtt_logger_timeout parameter

### DIFF
--- a/autopts/bot/common.py
+++ b/autopts/bot/common.py
@@ -121,6 +121,7 @@ class BotConfigArgs(Namespace):
         self.pylink_reset = args.get('pylink_reset', False)
         self.max_server_restart_time = args.get('max_server_restart_time', MAX_SERVER_RESTART_TIME)
         self.use_backup = args.get('use_backup', False)
+        self.rtt_logger_timeout = args.get('rtt_logger_timeout', 0)
 
         if self.ykush or self.active_hub_server:
             self.usb_replug_available = True

--- a/autopts/ptsprojects/mynewt/iutctl.py
+++ b/autopts/ptsprojects/mynewt/iutctl.py
@@ -20,6 +20,7 @@ import shlex
 import os
 import sys
 import serial
+import time
 
 from autopts.pybtp import defs, btp
 from autopts.ptsprojects.boards import Board, get_debugger_snr, tty_to_com
@@ -52,6 +53,7 @@ class MynewtCtl:
         self.debugger_snr = get_debugger_snr(self.tty_file) \
             if args.debugger_snr is None else args.debugger_snr
         self.board = Board(args.board_name, self)
+        self.rtt_logger_timeout = args.rtt_logger_timeout
         self.socat_process = None
         self.socket_srv = None
         self.btp_socket = None
@@ -140,6 +142,8 @@ class MynewtCtl:
 
     def rtt_logger_stop(self):
         if self.rtt_logger:
+            # Make sure all logs have been collected, in case test failed early.
+            time.sleep(self.rtt_logger_timeout)
             self.rtt_logger.stop()
 
     def reset(self):

--- a/autopts/ptsprojects/zephyr/iutctl.py
+++ b/autopts/ptsprojects/zephyr/iutctl.py
@@ -70,6 +70,7 @@ class ZephyrCtl:
         self.kernel_image = args.kernel_image
         self.tty_file = args.tty_file
         self.hci = args.hci
+        self.rtt_logger_timeout = args.rtt_logger_timeout
         self.native = None
         self.gdb = args.gdb
         self.is_running = False
@@ -205,7 +206,8 @@ class ZephyrCtl:
 
     def rtt_logger_stop(self):
         if self.rtt_logger:
-            time.sleep(0.1)  # Make sure all logs have been collected, in case test failed early.
+            # Make sure all logs have been collected, in case test failed early.
+            time.sleep(self.rtt_logger_timeout)
             self.rtt_logger.stop()
 
     def wait_iut_ready_event(self, reset=True):

--- a/cliparser.py
+++ b/cliparser.py
@@ -155,6 +155,9 @@ class CliParser(argparse.ArgumentParser):
                               "Requires rtt support on IUT.",
                               action='store_true', default=False)
 
+            self.add_argument("--rtt_logger_timeout", nargs='?', type=float, default=0,
+                              help="Timeout for rtt logger to make sure all logs have been collected")
+
             self.add_argument("--gdb",
                               help="Skip board resets to avoid gdb server disconnection.",
                               action='store_true', default=False)


### PR DESCRIPTION
rtt_logger_timeout can be used as command line argument or as parameter in config_project.py