### PR TITLE
zephyr: Fix cap.hdl_wid_312 to use cap unicast stop

### DIFF
--- a/autopts/pybtp/btp/cap.py
+++ b/autopts/pybtp/btp/cap.py
@@ -122,10 +122,18 @@ def cap_unicast_audio_update(metadata_tuple):
     cap_command_rsp_succ()
 
 
-def cap_unicast_audio_stop(cig_id):
+BTP_CAP_UNICAST_AUDIO_STOP_FLAG_RELEASE = 0b00000001
+
+def cap_unicast_audio_stop(cig_id, release):
     logging.debug(f"{cap_unicast_audio_stop.__name__}")
 
     data = struct.pack('B', cig_id)
+
+    flags = 0x00
+    if release:
+        flags |= BTP_CAP_UNICAST_AUDIO_STOP_FLAG_RELEASE
+
+    data += struct.pack('?', flags)
 
     iutctl = get_iut()
     iutctl.btp_socket.send(*CAP['unicast_audio_stop'], data=data)

--- a/doc/btp_cap.txt
+++ b/doc/btp_cap.txt
@@ -102,6 +102,10 @@ Commands and responses:
 	Opcode 0x06 - Unicast Audio Stop
 		Controller Index:	<controller id>
 		Command parameters:	CIG_ID (1 octet)
+		Command parameters:	Flags (1 octet)
+		where:
+			- Flags is a bit map of settings:
+				bit 0: To release the streams. If not set, the streams will only be disabled.
 
 		Response parameters:	<none>
 


### PR DESCRIPTION
Modified the hdl_wid_312 handler to call cap_unicast_audio_stop with release = False, so that it performs a disable (and stop) without release.

Why PTS wants us to disable first is unclear, as the test spec states to release, which would be handled by hdl_wid_309.

This is required by https://github.com/zephyrproject-rtos/zephyr/pull/79674