### PR TITLE
boards: update nrf54l board type to nrf54l15dk

### DIFF
--- a/autopts/ptsprojects/boards/nrf54l.py
+++ b/autopts/ptsprojects/boards/nrf54l.py
@@ -16,5 +16,5 @@
 
 from .nrf5x import *
 
-board_type = 'nrf54l15pdk/nrf54l15/cpuapp'
+board_type = 'nrf54l15dk/nrf54l15/cpuapp'
 


### PR DESCRIPTION
updating the board type for nrf54l family as nrf54l15dk