### PR TITLE
Added python venv to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ autopts/bot/config.py
 
 venv
 .venv
+
+.vscode

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@
 */client_secret.json
 */credentials.json
 autopts/bot/config.py
+
+venv
+.venv


### PR DESCRIPTION
Added venv and .venv which are common names for
python virtual environments to the gitignore.