### PR TITLE
wid: tmap: Use raw string for regex

### DIFF
--- a/autopts/wid/tmap.py
+++ b/autopts/wid/tmap.py
@@ -715,7 +715,7 @@ def hdl_wid_2004(params: WIDParams):
     """
     Please confirm that 6 digit number is matched with [passkey].
     """
-    pattern = '[\d]{6}'
+    pattern = r'[\d]{6}'
     passkey = re.search(pattern, params.description)[0]
     stack = get_stack()
     bd_addr = btp.pts_addr_get()


### PR DESCRIPTION
Fix following:
autopts/wid/tmap.py:718: SyntaxWarning: invalid escape sequence '\d'