### PR TITLE
Add tmp to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *~
 *.pyc
 *.log
+tmp
 
 *.xlsx
 *.zip


### PR DESCRIPTION
The tmp directory is creating during manual testing and should never be pushed.