### PR TITLE
csip: Add CSIP/CL/SP/BV-07-C to list of tests for CSIP discovery

### DIFF
--- a/autopts/wid/csip.py
+++ b/autopts/wid/csip.py
@@ -179,10 +179,11 @@ def hdl_wid_20100(params: WIDParams):
     stack.gap.wait_for_connection(timeout=10, addr=addr)
     stack.gap.gap_wait_for_sec_lvl_change(level=2, timeout=30, addr=addr)
 
-    if 'CSIP/CL/SP/BV-04-C' in params.test_case_name or\
+    if 'CSIP/CL/SP/BV-03-C' in params.test_case_name or\
+            'CSIP/CL/SP/BV-04-C' in params.test_case_name or\
+            'CSIP/CL/SP/BV-07-C' in params.test_case_name or\
             'CSIP/CL/SPE/BI-01-C' in params.test_case_name or\
             'CSIP/CL/SPE/BI-02-C' in params.test_case_name or\
-            'CSIP/CL/SP/BV-03-C' in params.test_case_name or\
             'CSIP/CL/SPE/BI-03-C' in params.test_case_name:
         btp.csip_discover(addr_type, addr)
         ev = stack.csip.wait_sirk_ev(addr_type, addr, 30, remove=False)


### PR DESCRIPTION
The test also requires discovery and was failing due to this. Re-arranged the list of tests to be in alphabetical order to make it easier to follow.