### PR TITLE
bot/zephyr: Use EXTRA_CONF_FILE instead of OVERLAY_CONFIG

### DIFF
--- a/autopts/bot/zephyr.py
+++ b/autopts/bot/zephyr.py
@@ -125,7 +125,7 @@ class ZephyrBotClient(BotClient):
 
             configs.append(name)
 
-        # The order is used in the -DOVERLAY_CONFIG="<overlay1>;<...>" option.
+        # The order is used in the -DEXTRA_CONF_FILE="<overlay1>;<...>" option.
         overlays = ';'.join(configs)
 
         log("TTY path: %s" % args.tty_file)

--- a/autopts/ptsprojects/boards/nrf52_wsl.py
+++ b/autopts/ptsprojects/boards/nrf52_wsl.py
@@ -49,7 +49,7 @@ def build_and_flash(zephyr_wd, board, debugger_snr, conf_file=None, *args):
 
     cmd = ['west', 'build', '-p', 'auto', '-b', board]
     if conf_file and conf_file != 'default' and conf_file != 'prj.conf':
-        cmd.extend(('--', '-DOVERLAY_CONFIG=\'{}\''.format(conf_file)))
+        cmd.extend(('--', '-DEXTRA_CONF_FILE=\'{}\''.format(conf_file)))
 
     shell = True
     if sys.platform == 'win32':

--- a/autopts/ptsprojects/boards/nrf53.py
+++ b/autopts/ptsprojects/boards/nrf53.py
@@ -40,12 +40,12 @@ def build_and_flash(zephyr_wd, board, debugger_snr, conf_file=None, *args):
     if conf_file and conf_file != 'default' and conf_file != 'prj.conf':
         bttester_overlay += f';{conf_file}'
 
-    cmd = ['west', 'build', '-b', board, '--', f'-DOVERLAY_CONFIG=\'{bttester_overlay}\'']
+    cmd = ['west', 'build', '-b', board, '--', f'-DEXTRA_CONF_FILE=\'{bttester_overlay}\'']
     check_call(cmd, cwd=tester_dir)
     check_call(['west', 'flash', '--skip-rebuild', '--recover', '-i', debugger_snr], cwd=tester_dir)
 
     cmd = ['west', 'build', '-b', 'nrf5340dk/nrf5340/cpunet', '--',
-           f'-DOVERLAY_CONFIG=\'nrf5340_cpunet_iso-bt_ll_sw_split.conf;'
+           f'-DEXTRA_CONF_FILE=\'nrf5340_cpunet_iso-bt_ll_sw_split.conf;'
            f'../../../tests/bluetooth/tester/nrf5340_hci_ipc_cpunet.conf\'']
     check_call(cmd, cwd=controller_dir)
     check_call(['west', 'flash', '--skip-rebuild', '-i', debugger_snr], cwd=controller_dir)

--- a/autopts/ptsprojects/boards/nrf53_appcore.py
+++ b/autopts/ptsprojects/boards/nrf53_appcore.py
@@ -38,6 +38,6 @@ def build_and_flash(zephyr_wd, board, debugger_snr, conf_file=None, *args):
     if conf_file and conf_file != 'default' and conf_file != 'prj.conf':
         bttester_overlay += f';{conf_file}'
 
-    cmd = ['west', 'build', '-b', board, '--', f'-DOVERLAY_CONFIG=\'{bttester_overlay}\'']
+    cmd = ['west', 'build', '-b', board, '--', f'-DEXTRA_CONF_FILE=\'{bttester_overlay}\'']
     check_call(cmd, cwd=tester_dir)
     check_call(['west', 'flash', '--skip-rebuild', '--recover', '-i', debugger_snr], cwd=tester_dir)

--- a/autopts/ptsprojects/boards/nrf53_audio.py
+++ b/autopts/ptsprojects/boards/nrf53_audio.py
@@ -57,7 +57,7 @@ def build_and_flash(zephyr_wd, board, debugger_snr, conf_file=None, *args):
 
     app_core_configs = []
     if conf_file and conf_file != 'default' and conf_file != 'prj.conf':
-        app_core_configs = [f'OVERLAY_CONFIG=\'{conf_file}\'']
+        app_core_configs = [f'EXTRA_CONF_FILE=\'{conf_file}\'']
 
     build_and_flash_core(zephyr_wd,
                          source_dir,
@@ -68,11 +68,11 @@ def build_and_flash(zephyr_wd, board, debugger_snr, conf_file=None, *args):
 
     config_dir_net = os.getenv("AUTOPTS_SOURCE_DIR_NET")
     if config_dir_net is None:
-        net_core_configs = [f'OVERLAY_CONFIG=\'nrf5340_cpunet_iso-bt_ll_sw_split.conf;'
+        net_core_configs = [f'EXTRA_CONF_FILE=\'nrf5340_cpunet_iso-bt_ll_sw_split.conf;'
                             f'../../../tests/bluetooth/tester/nrf5340_hci_ipc_cpunet.conf\'']
     else:
         conf_path = os.path.join(zephyr_wd, config_dir_net, 'hci_ipc.conf')
-        net_core_configs = [f'OVERLAY_CONFIG=\'{conf_path}\'']
+        net_core_configs = [f'EXTRA_CONF_FILE=\'{conf_path}\'']
 
     build_and_flash_core(zephyr_wd,
                          os.path.join('samples', 'bluetooth', 'hci_ipc'),

--- a/autopts/ptsprojects/boards/nrf54h.py
+++ b/autopts/ptsprojects/boards/nrf54h.py
@@ -48,7 +48,7 @@ def build_and_flash(zephyr_wd, board, debugger_snr, conf_file=None, *args):
     if conf_file and conf_file not in ['default', 'prj.conf']:
         if 'audio' in conf_file:
             conf_file += ';overlay-le-audio-ctlr.conf'
-        cmd.extend(('--', f'-DOVERLAY_CONFIG=\'{conf_file}\''))
+        cmd.extend(('--', f'-DEXTRA_CONF_FILE=\'{conf_file}\''))
 
     check_call(cmd, cwd=tester_dir)
     check_call(['west', 'flash', '--skip-rebuild',

--- a/autopts/ptsprojects/boards/nrf5x.py
+++ b/autopts/ptsprojects/boards/nrf5x.py
@@ -48,7 +48,7 @@ def build_and_flash(zephyr_wd, board, debugger_snr, conf_file=None, *args):
     if conf_file and conf_file not in ['default', 'prj.conf']:
         if 'audio' in conf_file:
             conf_file += ';overlay-le-audio-ctlr.conf'
-        cmd.extend(('--', f'-DOVERLAY_CONFIG=\'{conf_file}\''))
+        cmd.extend(('--', f'-DEXTRA_CONF_FILE=\'{conf_file}\''))
 
     check_call(cmd, cwd=tester_dir)
     check_call(['west', 'flash', '--skip-rebuild', '--recover',


### PR DESCRIPTION
OVERLAY_CONFIG was deprected in Zephyr 3.4:
https://docs.zephyrproject.org/latest/releases/release-notes-3.4.html#build-system-and-infrastructure