### PR TITLE
cap: Register TBS to have 2 CCIDs registered

### DIFF
--- a/autopts/ptsprojects/zephyr/cap.py
+++ b/autopts/ptsprojects/zephyr/cap.py
@@ -145,8 +145,9 @@ def test_cases(ptses):
         TestFunc(stack.aics_init),
         TestFunc(btp.core_reg_svc_vocs),
         TestFunc(stack.vocs_init),
-        # Enable GMCS to have a second CCID in Zephyr stack
+        # Enable GMCS and TBS to have 2 CCIDs in Zephyr stack which is required by some tests
         TestFunc(btp.core_reg_svc_gmcs),
+        TestFunc(btp.core_reg_svc_tbs),
         TestFunc(stack.gmcs_init),
         # Enable CSIP to have access to Start Ordered Access
         # procedure BTP command


### PR DESCRIPTION
The following tests require 2 CCIDs, and are failing if the device does not have have 2 CCIDs registered:

CAP/INI/BST/BV-07-C
CAP/INI/BST/BV-10-C

CAP/INI/UST/BV-13-C
CAP/INI/UST/BV-14-C
CAP/INI/UST/BV-27-C
CAP/INI/UST/BV-28-C
CAP/INI/UST/BV-31-C
CAP/INI/UST/BV-36-C
CAP/INI/UST/BV-37-C

CAP/INI/UTB/BV-04-C