### PR TITLE
client: adjust exception logging

### DIFF
--- a/autopts/client.py
+++ b/autopts/client.py
@@ -1361,9 +1361,12 @@ class Client:
             signal.signal(signal.SIGINT, sigint_handler)
 
             return self.main(args)
-        except BaseException as e:  # Ctrl-C
-            if not isinstance(e, KeyboardInterrupt):
-                logging.exception(e)
+        except BaseException as e:
+            if not isinstance(e, KeyboardInterrupt):   # Ctrl-C
+                if e.code != 0:
+                    # Exit with traceback
+                    logging.exception(e)
+
             set_global_end()
             self.cleanup()
             raise


### PR DESCRIPTION
When running autoptsclient-zephyr.py --help, traceback was printed in terminal. 
![image](https://github.com/user-attachments/assets/2dbb1fe3-48a5-470e-80c2-b69550210467)
This was caused by logging.exception(e) which should not be called when exiting with status 0.