### PR TITLE
Print on Ctrl-C

### DIFF
--- a/autoptsserver.py
+++ b/autoptsserver.py
@@ -487,6 +487,7 @@ class Server(threading.Thread):
 
             except KeyboardInterrupt:
                 # Ctrl-C termination for single instance mode
+                print("Keyboard Interrupt. Single-instance termination")
                 break
 
             except BaseException as e:
@@ -643,6 +644,7 @@ if __name__ == "__main__":
     except KeyboardInterrupt:  # Ctrl-C
         # Termination for multi instance mode
         # because the threads does not receive a signal from Ctrl-C
+        print("Keyboard Interrupt. Multi-instance termination")
         for s in autoptsservers:
             s.terminate()
 


### PR DESCRIPTION
- There is no print when a KeyboardInterrupt is recieved This PR adds prints so the user knows the server is alive and in the process of terminating