### PR TITLE
server: Check that COM port exists

### DIFF
--- a/autoptsserver_requirements.txt
+++ b/autoptsserver_requirements.txt
@@ -4,3 +4,4 @@ utils
 psutil
 yepkit-pykush
 hidapi
+pyserial


### PR DESCRIPTION
- Check has been added to ensure that the selected com port(s) exist. pyserial was used as it was much faster than wmi