### PR TITLE
Zephyr: CAP: Change to use 16_2_1 by default

### DIFF
--- a/autopts/ptsprojects/zephyr/cap.py
+++ b/autopts/ptsprojects/zephyr/cap.py
@@ -89,7 +89,7 @@ def set_pixits(ptses):
     pts.set_pixit("CAP", "TSPX_Extended_Adv_Interval_max", "1200")
     pts.set_pixit("CAP", "TSPX_Periodic_Adv_Interval_min", "600")
     pts.set_pixit("CAP", "TSPX_Periodic_Adv_Interval_max", "600")
-    pts.set_pixit("CAP", "TSPX_BST_CODEC_CONFIG", "8_1_1")
+    pts.set_pixit("CAP", "TSPX_BST_CODEC_CONFIG", "16_2_1")
 
 
 sink_contexts = Context.LIVE | Context.CONVERSATIONAL | Context.MEDIA | Context.RINGTONE

--- a/autopts/wid/cap.py
+++ b/autopts/wid/cap.py
@@ -132,7 +132,7 @@ def hdl_wid_114(params: WIDParams):
     # btp.gap_adv_off()
 
     source_num, metadata = wid_114_settings[params.test_case_name]
-    qos_set_name = '8_1_1'
+    qos_set_name = "16_2_1"
     coding_format = 0x06
     vid = 0x0000
     cid = 0x0000


### PR DESCRIPTION
16_2_1 is the mandatory configuration from BAP so it is supported by all platforms.