### PR TITLE
tmap: Fix failing TMAP tests BMS/ASC/BV-01 and BV-02

### DIFF
--- a/autopts/ptsprojects/zephyr/tmap.py
+++ b/autopts/ptsprojects/zephyr/tmap.py
@@ -79,9 +79,11 @@ def test_cases(ptses):
         TestFunc(btp.core_reg_svc_pacs),
         TestFunc(btp.core_reg_svc_ascs),
         TestFunc(btp.core_reg_svc_bap),
+        TestFunc(btp.core_reg_svc_cap),
+        TestFunc(btp.core_reg_svc_tmap),
         TestFunc(stack.ascs_init),
         TestFunc(stack.bap_init),
-        TestFunc(btp.core_reg_svc_tmap),
+        TestFunc(stack.cap_init),
         TestFunc(stack.tmap_init)
     ]
 

--- a/autopts/wid/tmap.py
+++ b/autopts/wid/tmap.py
@@ -562,6 +562,7 @@ def hdl_wid_506(params: WIDParams):
     source_id = 0x00
     btp.cap_broadcast_adv_stop(source_id)
     btp.cap_broadcast_source_stop(source_id)
+    btp.cap_broadcast_source_release(source_id)
 
     # Get Audio Locations from description
     audio_locations = 0


### PR DESCRIPTION
- Add missing init and register of cap
- Always release previous streams before starting new