### PR TITLE
wid: CAP: move vcp discovery to wid 20100

### DIFF
--- a/autopts/wid/cap.py
+++ b/autopts/wid/cap.py
@@ -1005,6 +1005,9 @@ def hdl_wid_20100(params: WIDParams):
     btp.micp_discover(addr_type, addr)
     stack.micp.wait_discovery_completed_ev(addr_type, addr, 10)
 
+    btp.vcp_discover(addr_type, addr)
+    stack.vcp.wait_discovery_completed_ev(addr_type, addr, 10)
+
     return True
 
 
@@ -1041,21 +1044,25 @@ def hdl_wid_20110(params: WIDParams):
         lt1_test_name = params.test_case_name
 
     stack = get_stack()
-    btp.vcp_discover(addr_type, addr)
-    stack.vcp.wait_discovery_completed_ev(addr_type, addr, 10)
 
     if lt1_test_name == 'CAP/COM/CRC/BV-01-C':
         btp.vcp_set_vol(50, addr_type, addr)
+        stack.vcp.wait_vcp_procedure_ev(addr_type, addr, 10)
     if lt1_test_name == 'CAP/COM/CRC/BV-03-C':
         btp.vcp_unmute(addr_type, addr)
+        stack.vcp.wait_vcp_procedure_ev(addr_type, addr, 10)
     if lt1_test_name == 'CAP/COM/CRC/BV-04-C':
         btp.vcp_mute(addr_type, addr)
+        stack.vcp.wait_vcp_procedure_ev(addr_type, addr, 10)
     if lt1_test_name == 'CAP/COM/CRC/BV-05-C':
         btp.vcp_set_vol(13, addr_type, addr)
+        stack.vcp.wait_vcp_procedure_ev(addr_type, addr, 10)
     if lt1_test_name == 'CAP/COM/CRC/BV-06-C':
         btp.vcp_mute(addr_type, addr)
+        stack.vcp.wait_vcp_procedure_ev(addr_type, addr, 10)
     if lt1_test_name == 'CAP/COM/CRC/BV-09-C':
         btp.aics_set_gain(42, addr_type, addr)
+        stack.aics.wait_aics_procedure_ev(addr_type, addr, 10)
 
     return True
 


### PR DESCRIPTION
For some reason VCP discovery wasn't called in wid handler where cap, bap and micp are discovered. This caused vcp procedures being called before VCP discovered event has been received. Also added wait for vcp procedure ev after some vcp procedures in wid 20106.
Fixes BTP ERROR in test cases: CAP/COM/CRC/BV-01-C, CAP/COM/CRC/BV-03-C CAP/COM/CRC/BV-04-C