### PR TITLE
hap: fix BTP ERROR in HAP/HAUC/STR/BV-01-C

### DIFF
--- a/autopts/ptsprojects/zephyr/hap.py
+++ b/autopts/ptsprojects/zephyr/hap.py
@@ -189,6 +189,8 @@ def test_cases(ptses):
         TestFunc(btp.hap_hauc_init),
         TestFunc(stack.csip_init),
         TestFunc(btp.core_reg_svc_csip),
+        TestFunc(btp.core_reg_svc_cap),
+        TestFunc(stack.cap_init),
     ]
 
     pre_conditions_iac = pre_conditions + [


### PR DESCRIPTION
cap_unicast_setup_ase was called  in hdl_wid_482 without registring cap which resulted in BTP Error with opcode Unknown Command. Test still fails occasionally and will require further investigation.