### PR TITLE
bot: report: Add a note for TIMEOUT result

### DIFF
--- a/autopts/bot/common_features/report.py
+++ b/autopts/bot/common_features/report.py
@@ -203,6 +203,9 @@ def make_report_txt(report_txt_path, results_dict, regressions_list,
         if tc in errata:
             result += ' - ERRATA ' + errata[tc]
 
+        if result[0] == 'TIMEOUT':
+            result += ' - Logs may not be available'
+
         # The first id in the test case is a test group
         tg = tc.split('/')[0]
         f.write("%s%s%s\n" % (tg.ljust(8, ' '), tc.ljust(32, ' '), result))


### PR DESCRIPTION
Add a note to report.txt, that logs may not be available for a test case with TIMEOUT result. The TIMEOUT result means that the autopts bot was externally terminated, because a test case took too long and the bot failed to recover PTS. If backup mode is enabled, the bot can be restarted to resume the test run. Since the PTS was forcefully terminated and the faulty test case will not be rerun by the bot, the test case logs will most likely not be available.