### PR TITLE
bot: email: add test suite summary

### DIFF
--- a/autopts/bot/common.py
+++ b/autopts/bot/common.py
@@ -704,6 +704,7 @@ class BotClient(Client):
         mail_ctx = {'project_name': report_data['project_name'],
                     'repos_info': report_data['repo_status'],
                     'summary': [mail.status_dict2summary_html(report_data['status_count'])],
+                    'profile_summary': mail.profile_summary_html(report_data['tc_results']),
                     'log_url': [],
                     'board': self.bot_config['auto_pts']['board'],
                     'platform': report_data['platform'],
@@ -776,6 +777,7 @@ class BotClient(Client):
     <h2>3. Test Results</h2>
     <p><b>Execution Time</b>: {elapsed_time}</p>
     {summary}
+    {profile_summary}
     <h3>Logs</h3>
     {log_url}
     <p>Sincerely,</p>

--- a/autopts/bot/common_features/mail.py
+++ b/autopts/bot/common_features/mail.py
@@ -69,6 +69,79 @@ def status_dict2summary_html(status_dict):
     return summary
 
 
+class TestGroup:
+    def __init__(self):
+        self.total = 0
+        self.passed = 0
+        self.failed = 0
+        self.pass_rate = 0.0
+
+    def get_pass_rate(self):
+        if self.total > 0:
+            self.pass_rate = (self.passed / float(self.total)) * 100
+
+
+def profile_summary_html(tc_results):
+    """Creates HTML formatted message with summarized profile results"""
+
+    """Dictionary containing profile name as key, test group object as value
+    test_groups = {
+    'ASCS' = TestGroup()
+    }
+    """
+
+    test_groups = {}
+    # Get data from tc_results
+    for tc, res in list(tc_results.items()):
+        result = res[0]
+        profile = tc.split('/')[0]
+        if profile not in test_groups.keys():
+            test_groups[profile] = TestGroup()
+        if result == 'PASS':
+            test_groups[profile].passed += 1
+        else:
+            test_groups[profile].failed += 1
+        test_groups[profile].total += 1
+
+    for tg in test_groups.values():
+        tg.get_pass_rate()
+
+    # Generate table
+
+    table_rows = ""
+    for suite, stats in test_groups.items():
+        table_rows += f"""
+            <tr>
+                <td>{suite}</td>
+                <td>{stats.total}</td>
+                <td>{stats.passed}</td>
+                <td>{stats.failed}</td>
+                <td>{stats.pass_rate:.2f} %</td>
+            </tr>
+            """
+
+    suite_summary = f"""
+        <div>
+            <h3>Test Group/Profile Summary</h3>
+            <table border="1" style="border-collapse: collapse; width: 100%;">
+                <thead>
+                    <tr>
+                        <th>Suite</th>
+                        <th>Total</th>
+                        <th>Pass</th>
+                        <th>Fail</th>
+                        <th>Pass Rate</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {table_rows}
+                </tbody>
+            </table>
+        </div>
+        """
+    return suite_summary
+
+
 def url2html(url, msg):
     """Creates HTML formatted URL with results
     :param url: URL


### PR DESCRIPTION
AutoPTS test session result email will now contain a table underneath summary section that includes statistics regarding each test group - e.g. AICS - 19 test runs, 19 Passed, 0 Failed, 100% Pass rate