### PR TITLE
bot: report: add test group summary to readme.md

### DIFF
--- a/autopts/bot/common.py
+++ b/autopts/bot/common.py
@@ -574,6 +574,7 @@ class BotClient(Client):
         """Creates README.md for Github logging repo
         """
         readme_file = readme_md_path
+        profile_summary = mail.profile_summary(report_data['tc_results'])
 
         Path(os.path.dirname(readme_file)).mkdir(parents=True, exist_ok=True)
 
@@ -585,6 +586,8 @@ class BotClient(Client):
     End time: {report_data["end_time_stamp"]}
 
     PTS version: {report_data["pts_ver"]}
+    
+    {profile_summary}
 
     Repositories:
 
@@ -704,7 +707,7 @@ class BotClient(Client):
         mail_ctx = {'project_name': report_data['project_name'],
                     'repos_info': report_data['repo_status'],
                     'summary': [mail.status_dict2summary_html(report_data['status_count'])],
-                    'profile_summary': mail.profile_summary_html(report_data['tc_results']),
+                    'profile_summary': mail.profile_summary(report_data['tc_results']),
                     'log_url': [],
                     'board': self.bot_config['auto_pts']['board'],
                     'platform': report_data['platform'],

--- a/autopts/bot/common_features/mail.py
+++ b/autopts/bot/common_features/mail.py
@@ -81,7 +81,7 @@ class TestGroup:
             self.pass_rate = (self.passed / float(self.total)) * 100
 
 
-def profile_summary_html(tc_results):
+def profile_summary(tc_results):
     """Creates HTML formatted message with summarized profile results"""
 
     """Dictionary containing profile name as key, test group object as value
@@ -106,8 +106,6 @@ def profile_summary_html(tc_results):
     for tg in test_groups.values():
         tg.get_pass_rate()
 
-    # Generate table
-
     table_rows = ""
     for suite, stats in test_groups.items():
         table_rows += f"""
@@ -123,14 +121,14 @@ def profile_summary_html(tc_results):
     suite_summary = f"""
         <div>
             <h3>Test Group/Profile Summary</h3>
-            <table border="1" style="border-collapse: collapse; width: 100%;">
+            <table border="1" style="border-collapse: collapse; text-align: center;">
                 <thead>
                     <tr>
-                        <th>Suite</th>
-                        <th>Total</th>
-                        <th>Pass</th>
-                        <th>Fail</th>
-                        <th>Pass Rate</th>
+                        <th  width="10em">Suite</th>
+                        <th  width="10em">Total</th>
+                        <th  width="10em">Pass</th>
+                        <th  width="10em">Fail</th>
+                        <th  width="10em">Pass Rate</th>
                     </tr>
                 </thead>
                 <tbody>


### PR DESCRIPTION
Previously implemented profile_summary function is now used to write to readme.md file in Github logging repo and AutoPTS
test session result email. Table width is now adjusted to be displayed properly on various screens
