### PR TITLE
rtt: Fix memory leak at JLink init

### DIFF
--- a/autopts/utils.py
+++ b/autopts/utils.py
@@ -457,6 +457,14 @@ def exit_if_admin():
         sys.exit("Administrator rights are not required to run this script!")
 
 
+def log_memory_usage():
+    process = psutil.Process(os.getpid())
+    mem_info = process.memory_info()
+
+    mem_usage = mem_info.rss / (1024 ** 2)
+    logging.debug(f"Memory usage: {mem_usage:.2f} MB")
+
+
 def main():
     """Main."""
 


### PR DESCRIPTION
Pylink loads a new cache of J-Link DLL at its __init__, but its __del__ does not unload the cache. If RTT logging was used, there was a huge memory leak, about 20MB per test case. Let's reuse the cached lib to prevent the leak.
