### PR TITLE
bot: zephyr: Fix tests matching for mesh_dfd_srv.conf overlay

### DIFF
--- a/autopts/bot/iut_config/zephyr.py
+++ b/autopts/bot/iut_config/zephyr.py
@@ -247,7 +247,7 @@ iut_config = {
             'CONFIG_BT_MESH_BLOB_BLOCK_SIZE_MAX': '256'
         },
         "test_cases": [
-            'DFU/SR-CL/GEN/BV-01-C'
+            'DFU/SR-CL/GEN/BV-01-C',
             'DFUM/CL/FU',
             'DFUM/SR/FD',
             'MBTM/SR/BT',


### PR DESCRIPTION
Missing colon was causing DFUM/CL/FU tests to be build without required overlay.