### PR TITLE
doc: btp_gap: Adds set rpa timeout

### DIFF
--- a/doc/btp_gap.txt
+++ b/doc/btp_gap.txt
@@ -637,6 +637,17 @@ Commands and responses:
 
 		In case of an error, the error response will be returned.
 
+        Opcode 0x30 - Set RPA Timeout command/response
+
+                Controller Index: <controller id>
+                Command parameters: RPA Timeout in seconds (2 octets)
+                Return Parameters: <none>
+
+                This command is used to set RPA timeout. The new RPA timeout value will be
+                used for the next RPA rotation. Valid range is 1s - 3600s.
+
+                In case of an error, the error response will be returned.
+
 Events:
 	Opcode 0x80 - New Settings event
 


### PR DESCRIPTION
Proposal to add gap_set_rpa_timeout command, which would enable dynamically changing rpa timeout.
I've used 0x30 opcode to respect  #1368.