### PR TITLE
tools: cron: stop cron in case of error

### DIFF
--- a/autopts/bot/common.py
+++ b/autopts/bot/common.py
@@ -500,6 +500,9 @@ class BotClient(Client):
 
         try:
             stats = self.run_tests()
+        except:
+            report.make_error_txt(traceback.format_exc(), self.file_paths['ERROR_TXT_FILE'])
+            raise
         finally:
             release_device(self.args.tty_file)
 

--- a/tools/cron/common.py
+++ b/tools/cron/common.py
@@ -593,6 +593,7 @@ def _run_test(config):
     results_file_path = config['file_paths']['TC_STATS_JSON_FILE']
     all_stats_file_path = config['file_paths']['ALL_STATS_JSON_FILE']
     report_file_path = config['file_paths']['REPORT_TXT_FILE']
+    error_file_path = config['file_paths']['ERROR_TXT_FILE']
 
     srv_process, bot_process = _start_processes(config, checkout_repos=True)
     last_check_time = time()
@@ -600,6 +601,9 @@ def _run_test(config):
     # Main thread waits for at least one of subprocesses to finish
     while not config['cron']['cancel_job'].canceled:
         sleep_job(config['cron']['cancel_job'], config['cron']['check_interval'])
+
+        if os.path.exists(error_file_path):
+            break
 
         if srv_process and srv_process.poll() is not None:
             log('server process finished.')


### PR DESCRIPTION
ERROR_TXT_FILE will be written to when invalid PIXIT name or value is set. We check for this file in _run_test function from cron to stop it from restarting indefinitely.

Fixes https://github.com/auto-pts/auto-pts/issues/1377