### PR TITLE
bot: report:  Add 4 columns to xlsx report

### DIFF
--- a/autopts/bot/common.py
+++ b/autopts/bot/common.py
@@ -893,7 +893,7 @@ def get_tc_res_data(tc_results, test_groups):
      dictionary containing profile name as key, TestGroup object as value
      e.g. test_groups = {'ASCS' = TestGroup()}"""
     for tc, res in list(tc_results.items()):
-        result = res[0]
+        result = res["parsed_result"]
         profile = tc.split('/')[0]
         if profile not in test_groups.keys():
             test_groups[profile] = TestGroup()


### PR DESCRIPTION
Fixed:
https://github.com/auto-pts/auto-pts/issues/1380
[Issues1380] Add execution time to the report xlsx
and
https://github.com/auto-pts/auto-pts/issues/1381
[Issues 1381] Split test results columt to an actual result only and extra comment if applicable

Add 4 columns to xlsx report xlsx
Result Additional Info | Start Time | End Time | Duration
changes:
added a function to find xml files,
safer retrieval of values to sxclude KeyError,
added a function that parses 'Result' data into 2 columns(Tuple),
handling potential exceptions
Cosmetic Changes:
clearer nomenclature,

Example:
[example_report.xlsx](https://github.com/user-attachments/files/18904421/example_report.xlsx)



