### PR TITLE
ptscontrol: update enable_maximum_logging function

### DIFF
--- a/autopts/ptscontrol.py
+++ b/autopts/ptscontrol.py
@@ -972,6 +972,7 @@ class PyPTS:
         log("%s %s", self.enable_maximum_logging.__name__, enable)
         self._pts.EnableMaximumLogging(enable)
         self._pts_logger.enable_maximum_logging(enable)
+        self.add_recov(self.enable_maximum_logging, enable)
 
     def set_call_timeout(self, timeout):
         """Sets a timeout period in milliseconds for the RunTestCase() calls


### PR DESCRIPTION
This is fixing issue #1360: With enable_maximum_log enabled during test sessions with more than one test cases to run, every test run after PTS TIMEOUT verdict from previous one caused to disable setting and PTS debug logs weren't produced