### PR TITLE
docs: Clean up whitespaces and unify convention used

### DIFF
--- a/doc/btp_aics.txt
+++ b/doc/btp_aics.txt
@@ -3,289 +3,289 @@ Audio Input Control Service (ID 10)
 
 Commands and responses:
 
-	Opcode 0x00 - Error response
+        Opcode 0x00 - Error response
 
-	Opcode 0x01 - Read supported commands
+        Opcode 0x01 - Read supported commands
 
-		Controller Index:	<controller id>
-		Command parameters:	<none>
-		Response parameters:	<supported commands> (variable)
+                Controller Index:       <controller id>
+                Command parameters:     <none>
+                Response parameters:    <supported commands> (variable)
 
-		Each bit in response is a flag indicating if command with
-		opcode matching bit number is supported. Bit set to 1 means
-		that command is supported. Bit 0 is reserved and shall always
-		be set to 0. If specific bit is not present in response (less
-		than required bytes received) it shall be assumed that command
-		is not supported.
+                Each bit in response is a flag indicating if command with
+                opcode matching bit number is supported. Bit set to 1 means
+                that command is supported. Bit 0 is reserved and shall always
+                be set to 0. If specific bit is not present in response (less
+                than required bytes received) it shall be assumed that command
+                is not supported.
 
-		In case of an error, the error response will be returned.
+                In case of an error, the error response will be returned.
 
-	Opcode 0x02 - Set Gain
+        Opcode 0x02 - Set Gain
 
-		Controller Index:	<controller id>
-		Command parameters:     Gain Value (1 octet)
-					Address_Type (1 octet)
-					Address (6 octets)
-		Response parameters:	<none>
+                Controller Index:       <controller id>
+                Command parameters:     Gain Value (1 octet)
+                                        Address_Type (1 octet)
+                                        Address (6 octets)
+                Response parameters:    <none>
 
-		This command can be used either by server or client and is used for
-		setting gain value. During operation, the IUT may send event:
-				AICS State event
-				AICS Procedure Event
+                This command can be used either by server or client and is used for
+                setting gain value. During operation, the IUT may send event:
+                        AICS State event
+                        AICS Procedure Event
 
-		In case of an error, the error response will be returned.
+                In case of an error, the error response will be returned.
 
-	Opcode 0x03 - Mute
+        Opcode 0x03 - Mute
 
-		Controller Index:	<controller id>
-		Command parameters:     Address_Type (1 octet)
-					Address (6 octets)
-		Response parameters:	<none>
+                Controller Index:       <controller id>
+                Command parameters:     Address_Type (1 octet)
+                                        Address (6 octets)
+                Response parameters:    <none>
 
-		This command can be used either by server or client and is used to
-		request Audio Input Control Point Mute operation.
-		During operation, the IUT may send event:
-				AICS State event
-				AICS Procedure Event
+                This command can be used either by server or client and is used to
+                request Audio Input Control Point Mute operation.
+                During operation, the IUT may send event:
+                        AICS State event
+                        AICS Procedure Event
 
-		In case of an error, the error response will be returned.
+                In case of an error, the error response will be returned.
 
-	Opcode 0x04 - Unmute
+        Opcode 0x04 - Unmute
 
-		Controller Index:	<controller id>
-		Command parameters:     Address_Type (1 octet)
-					Address (6 octets)
-		Response parameters:	<none>
+                Controller Index:       <controller id>
+                Command parameters:     Address_Type (1 octet)
+                                        Address (6 octets)
+                Response parameters:    <none>
 
-		This command can be used either by server or client and is used to
-		request Audio Input Control Point Unmute operation.
-		During operation, the IUT may send event:
-				AICS State event
-				AICS Procedure Event
+                This command can be used either by server or client and is used to
+                request Audio Input Control Point Unmute operation.
+                During operation, the IUT may send event:
+                        AICS State event
+                        AICS Procedure Event
 
-		In case of an error, the error response will be returned.
+                In case of an error, the error response will be returned.
 
-	Opcode 0x05 - Set manual gain
+        Opcode 0x05 - Set manual gain
 
-		Controller Index:	<controller id>
-		Command parameters:     Address_Type (1 octet)
-					Address (6 octets)
-		Response parameters:	<none>
+                Controller Index:       <controller id>
+                Command parameters:     Address_Type (1 octet)
+                                        Address (6 octets)
+                Response parameters:    <none>
 
-		This command can be used either by server or client and is used to
-		request Audio Input Control Point to set gain mode to manual.
-		During operation, the IUT may send event:
-				AICS State event
-				AICS Procedure Event
+                This command can be used either by server or client and is used to
+                request Audio Input Control Point to set gain mode to manual.
+                During operation, the IUT may send event:
+                        AICS State event
+                        AICS Procedure Event
 
-		In case of an error, the error response will be returned.
+                In case of an error, the error response will be returned.
 
-	Opcode 0x06 - Set automatic gain
+        Opcode 0x06 - Set automatic gain
 
-		Controller Index:	<controller id>
-		Command parameters:     Address_Type (1 octet)
-					Address (6 octets)
-		Response parameters:	<none>
+                Controller Index:       <controller id>
+                Command parameters:     Address_Type (1 octet)
+                                        Address (6 octets)
+                Response parameters:    <none>
 
-		This command can be used either by server or client and is used to
-		request Audio Input Control Point to set gain mode to automatic.
-		During operation, the IUT may send event:
-				AICS State event
-				AICS Procedure Event
+                This command can be used either by server or client and is used to
+                request Audio Input Control Point to set gain mode to automatic.
+                During operation, the IUT may send event:
+                                AICS State event
+                                AICS Procedure Event
 
-		In case of an error, the error response will be returned.
+                In case of an error, the error response will be returned.
 
-	Opcode 0x07 - Set manual gain only
+        Opcode 0x07 - Set manual gain only
 
-		Controller Index:	<controller id>
-		Command parameters:     Address_Type (1 octet)
-					Address (6 octets)
-		Response parameters:	<none>
+                Controller Index:       <controller id>
+                Command parameters:     Address_Type (1 octet)
+                                        Address (6 octets)
+                Response parameters:    <none>
 
-		This command can be used by server and is used to request Audio Input
-		Control Point to set gain mode to manual gain only.
+                This command can be used by server and is used to request Audio Input
+                Control Point to set gain mode to manual gain only.
 
-		In case of an error, the error response will be returned.
+                In case of an error, the error response will be returned.
 
-	Opcode 0x08 - Set automatic gain only
+        Opcode 0x08 - Set automatic gain only
 
-		Controller Index:	<controller id>
-		Command parameters:     Address_Type (1 octet)
-					Address (6 octets)
-		Response parameters:	<none>
+                Controller Index:       <controller id>
+                Command parameters:     Address_Type (1 octet)
+                                        Address (6 octets)
+                Response parameters:    <none>
 
-		This command can be used by server and is used to request Audio Input
-		Control Point to set gain mode to automatic gain only.
+                This command can be used by server and is used to request Audio Input
+                Control Point to set gain mode to automatic gain only.
 
-		In case of an error, the error response will be returned.
+                In case of an error, the error response will be returned.
 
-	Opcode 0x09 - Description set
+        Opcode 0x09 - Description set
 
-		Controller Index:	<controller id>
-		Command parameters:	Description Length (1 octet)
-					Description (0-255 octets)
-		Response parameters:	<none>
+                Controller Index:       <controller id>
+                Command parameters:     Description Length (1 octet)
+                                        Description (0-255 octets)
+                Response parameters:    <none>
 
-		This command can be used either by server or client and is used for
-		setting Audio Input Control Point description.
-		During operation, the IUT may send an event:
-				AICS Description Event
+                This command can be used either by server or client and is used for
+                setting Audio Input Control Point description.
+                During operation, the IUT may send an event:
+                        AICS Description Event
 
-		In case of an error, the error response will be returned.
+                In case of an error, the error response will be returned.
 
-	Opcode 0x0a - Mute Disable
+        Opcode 0x0a - Mute Disable
 
-		Controller Index:       <controller id>
-		Command parameters:     Address_Type (1 octet)
-					Address (6 octets)
-		Response parameters:	<none>
+                Controller Index:       <controller id>
+                Command parameters:     Address_Type (1 octet)
+                                        Address (6 octets)
+                Response parameters:    <none>
 
-		This command can be used by server and is used for disabling Mute operation.
+                This command can be used by server and is used for disabling Mute operation.
 
-		In case of an error, the error response will be returned.
+                In case of an error, the error response will be returned.
 
-	Opcode 0x0b - Gain setting properties get
+        Opcode 0x0b - Gain setting properties get
 
-		Controller Index:	<controller id>
-		Command parameters:     Address_Type (1 octet)
-					Address (6 octets)
-		Response parameters:	<none>
+                Controller Index:       <controller id>
+                Command parameters:     Address_Type (1 octet)
+                                        Address (6 octets)
+                Response parameters:    <none>
 
-		This command can be used either by server or client and is used for
-		reading Gain Setting Properties characteristic.
-		During operation, the IUT may send event:
-				AICS Gain Setting Properties event.
+                This command can be used either by server or client and is used for
+                reading Gain Setting Properties characteristic.
+                During operation, the IUT may send event:
+                        AICS Gain Setting Properties event.
 
-		In case of an error, the error response will be returned.
+                In case of an error, the error response will be returned.
 
-	Opcode 0x0c - Audio Input Type get
+        Opcode 0x0c - Audio Input Type get
 
-		Controller Index:	<controller id>
-		Command parameters:     Address_Type (1 octet)
-					Address (6 octets)
-		Response parameters:	<none>
+                Controller Index:       <controller id>
+                Command parameters:     Address_Type (1 octet)
+                                        Address (6 octets)
+                Response parameters:    <none>
 
-		This command can be used either by server or client and is used for
-		reading Audio Input Type characteristic.
-		During operation, the IUT may send event:
-				AICS Input Type event.
+                This command can be used either by server or client and is used for
+                reading Audio Input Type characteristic.
+                During operation, the IUT may send event:
+                        AICS Input Type event.
 
-		In case of an error, the error response will be returned.
+                In case of an error, the error response will be returned.
 
-	Opcode 0x0d - Audio Input Status get
+        Opcode 0x0d - Audio Input Status get
 
-		Controller Index:	<controller id>
-		Command parameters:     Address_Type (1 octet)
-					Address (6 octets)
-		Response parameters:	<none>
+                Controller Index:       <controller id>
+                Command parameters:     Address_Type (1 octet)
+                                        Address (6 octets)
+                Response parameters:    <none>
 
-		This command can be used either by server or client and is used for
-		reading Audio Input Status characteristic.
-		During operation, the IUT may send event:
-				AICS Status event.
+                This command can be used either by server or client and is used for
+                reading Audio Input Status characteristic.
+                During operation, the IUT may send event:
+                        AICS Status event.
 
-		In case of an error, the error response will be returned.
+                In case of an error, the error response will be returned.
 
-	Opcode 0x0e - Audio Input State get
+        Opcode 0x0e - Audio Input State get
 
-		Controller Index:	<controller id>
-		Command parameters:     Address_Type (1 octet)
-					Address (6 octets)
-		Response parameters:	<none>
+                Controller Index:       <controller id>
+                Command parameters:     Address_Type (1 octet)
+                                        Address (6 octets)
+                Response parameters:    <none>
 
-		This command can be used either by server or client and is used for
-		reading Audio Input State characteristic.
-		During operation, the IUT may send event:
-				AICS State event.
+                This command can be used either by server or client and is used for
+                reading Audio Input State characteristic.
+                During operation, the IUT may send event:
+                        AICS State event.
 
-		In case of an error, the error response will be returned.
+                In case of an error, the error response will be returned.
 
-	Opcode 0x0f - Audio Input Description get
+        Opcode 0x0f - Audio Input Description get
 
-		Controller Index:	<controller id>
-		Command parameters:     Address_Type (1 octet)
-					Address (6 octets)
-		Response parameters:	<none>
+                Controller Index:       <controller id>
+                Command parameters:     Address_Type (1 octet)
+                                        Address (6 octets)
+                Response parameters:    <none>
 
-		This command can be used either by server or client and is used for
-		reading Audio Input Control Point description.
-		During operation, the IUT may send event:
-				AICS Description Event.
+                This command can be used either by server or client and is used for
+                reading Audio Input Control Point description.
+                During operation, the IUT may send event:
+                                AICS Description Event.
 
-		In case of an error, the error response will be returned.
+                In case of an error, the error response will be returned.
 
 Events:
-	Opcode 0x80 - AICS State event
+        Opcode 0x80 - AICS State event
 
-		Controller Index:	<controller id>
-		Event parameters:	Address_Type (1 octet)
-					Address (6 octets)
-					ATT status (1 octet)
-					Gain (1 octet)
-					Mute (1 octet)
-					Mode (1 octet)
+                Controller Index:       <controller id>
+                Event parameters:       Address_Type (1 octet)
+                                        Address (6 octets)
+                                        ATT status (1 octet)
+                                        Gain (1 octet)
+                                        Mute (1 octet)
+                                        Mode (1 octet)
 
-		This event returns Audio Input State information regarding gain value,
-		mute state and gain mode.
+                This event returns Audio Input State information regarding gain value,
+                mute state and gain mode.
 
-	Opcode 0x81 - AICS Gain Setting Properties event
+        Opcode 0x81 - AICS Gain Setting Properties event
 
-		Controller Index:	<controller id>
-		Event parameters:	Address_Type (1 octet)
-					Address (6 octets)
-					ATT status (1 octet)
-					Units (1 octet)
-					Minimum (1 octet)
-					Maximum (1 octet)
+                Controller Index:       <controller id>
+                Event parameters:       Address_Type (1 octet)
+                                        Address (6 octets)
+                                        ATT status (1 octet)
+                                        Units (1 octet)
+                                        Minimum (1 octet)
+                                        Maximum (1 octet)
 
-		This event returns Gain Setting Properties information - units,
-		minimum and maximum value.
+                This event returns Gain Setting Properties information - units,
+                minimum and maximum value.
 
-	Opcode 0x82 - AICS Input Type Event
+        Opcode 0x82 - AICS Input Type Event
 
-		Controller Index:	<controller id>
-		Event parameters:	Address_Type (1 octet)
-					Address (6 octets)
-					ATT status (1 octet)
-					Type (1 octet)
+                Controller Index:       <controller id>
+                Event parameters:       Address_Type (1 octet)
+                                        Address (6 octets)
+                                        ATT status (1 octet)
+                                        Type (1 octet)
 
-		This event returns Audio Input Type information.
-		0 - Unspecified
-		1 - Bluetooth
-		2 - Microphone
-		3 - Analog
-		4 - Digital
-		5 - Radio
-		6 - Streaming
+                This event returns Audio Input Type information.
+                        0 - Unspecified
+                        1 - Bluetooth
+                        2 - Microphone
+                        3 - Analog
+                        4 - Digital
+                        5 - Radio
+                        6 - Streaming
 
-	Opcode 0x83 - AICS Status Event
+        Opcode 0x83 - AICS Status Event
 
-		Controller Index:	<controller id>
-		Event parameters:	Address_Type (1 octet)
-					Address (6 octets)
-					ATT status (1 octet)
-					Status (1 octet)
+                Controller Index:       <controller id>
+                Event parameters:       Address_Type (1 octet)
+                                        Address (6 octets)
+                                        ATT status (1 octet)
+                                        Status (1 octet)
 
-		This event returns Audio Input Status information.
-		0 - Inactive, 1 - Active.
+                This event returns Audio Input Status information.
+                        0 - Inactive, 1 - Active.
 
-	Opcode 0x84 - AICS Description Event
+        Opcode 0x84 - AICS Description Event
 
-		Controller Index:	<controller id>
-		Event parameters:	Address_Type (1 octet)
-					Address (6 octets)
-					ATT status (1 octet)
-					Description length (1 octet)
-					Description (1 octet)
+                Controller Index:       <controller id>
+                Event parameters:       Address_Type (1 octet)
+                                        Address (6 octets)
+                                        ATT status (1 octet)
+                                        Description length (1 octet)
+                                        Description (1 octet)
 
-		This event returns Audio Input Description information.
+                This event returns Audio Input Description information.
 
-	Opcode 0x85 - AICS Procedure Event
+        Opcode 0x85 - AICS Procedure Event
 
-		Controller Index:	<controller id>
-		Event parameters:	Address_Type (1 octet)
-					Address (6 octets)
-					ATT status (1 octet)
-					Opcode (1 octet)
+                Controller Index:       <controller id>
+                Event parameters:       Address_Type (1 octet)
+                                        Address (6 octets)
+                                        ATT status (1 octet)
+                                        Opcode (1 octet)
 
-		This event returns AICS operation opcode information.
+                This event returns AICS operation opcode information.

--- a/doc/btp_ascs.txt
+++ b/doc/btp_ascs.txt
@@ -3,241 +3,241 @@ ASCS Service (ID 13)
 
 Commands and responses:
 
-	Opcode 0x00 - Error response
+        Opcode 0x00 - Error response
 
-	Opcode 0x01 - Read Supported Commands command/response
+        Opcode 0x01 - Read Supported Commands command/response
 
-		Controller Index:	<controller id>
-		Command parameters:	<none>
-		Response parameters:	<supported commands> (variable)
+                Controller Index:       <controller id>
+                Command parameters:     <none>
+                Response parameters:    <supported commands> (variable)
 
-		Each bit in response is a flag indicating if command with
-		opcode matching bit number is supported. Bit set to 1 means
-		that command is supported. Bit 0 is reserved and shall always
-		be set to 0. If specific bit is not present in response (less
-		than required bytes received) it shall be assumed that command
-		is not supported.
+                Each bit in response is a flag indicating if command with
+                opcode matching bit number is supported. Bit set to 1 means
+                that command is supported. Bit 0 is reserved and shall always
+                be set to 0. If specific bit is not present in response (less
+                than required bytes received) it shall be assumed that command
+                is not supported.
 
-		In case of an error, the error response will be returned.
+                In case of an error, the error response will be returned.
 
-	Opcode 0x02: ASCS Configure Codec
+        Opcode 0x02: ASCS Configure Codec
 
-		Controller Index:	<controller id>
-		Command parameters:	Address_Type (1 octet)
-					Address (6 octets)
-					ASE ID (1 octet)
-					Coding Format (1 octet)
-					VID (2 octets)
-					CID (2 octets)
-					Config LTVs len (1 octet)
-					Config LTVs (varies)
-		Response parameters:    <None>
+                Controller Index:       <controller id>
+                Command parameters:     Address_Type (1 octet)
+                                        Address (6 octets)
+                                        ASE ID (1 octet)
+                                        Coding Format (1 octet)
+                                        VID (2 octets)
+                                        CID (2 octets)
+                                        Config LTVs len (1 octet)
+                                        Config LTVs (varies)
+                Response parameters:    <None>
 
-        The values for Config LTVs as defined in Assigned Numbers,
-        Codec_Specific_Configuration LTV.
+                The values for Config LTVs as defined in Assigned Numbers,
+                Codec_Specific_Configuration LTV.
 
-		In case of an error, the error status response will be returned.
-		In case of a success, the IUT continues processing the command
-		asynchronously. At the end of the command processing, the ASCS
-		Operation Completed event will be sent.
+                In case of an error, the error status response will be returned.
+                In case of a success, the IUT continues processing the command
+                asynchronously. At the end of the command processing, the ASCS
+                Operation Completed event will be sent.
 
-	Opcode 0x03: ASCS Configure QoS
+        Opcode 0x03: ASCS Configure QoS
 
-		Controller Index:	<controller id>
-		Command parameters:	Address_Type (1 octet)
-					Address (6 octets)
-					ASE ID (1 octet)
-					CIG ID (1 octet)
-					CIS ID (1 octet)
-					Sdu Interval (3 octet)
-					Framing (1 octet)
-					Max Sdu Size (2 octets)
-					Retransmission Number (1 octets)
-					Max Transport Latency (2 octets)
-					Presentation Delay (3 octets)
-		Response parameters:    <None>
+                Controller Index:       <controller id>
+                Command parameters:     Address_Type (1 octet)
+                                        Address (6 octets)
+                                        ASE ID (1 octet)
+                                        CIG ID (1 octet)
+                                        CIS ID (1 octet)
+                                        Sdu Interval (3 octet)
+                                        Framing (1 octet)
+                                        Max Sdu Size (2 octets)
+                                        Retransmission Number (1 octets)
+                                        Max Transport Latency (2 octets)
+                                        Presentation Delay (3 octets)
+                Response parameters:    <None>
 
-        The values of the other parameters as defined in ASCS_v1.0.pdf
-        Table 5.3: Config QoS operation format, i.e.:
+                The values of the other parameters as defined in ASCS_v1.0.pdf
+                Table 5.3: Config QoS operation format, i.e.:
 
-        Valid SDU Interval values:
-                    0x0000ff - 0x0fffff
+                Valid SDU Interval values:
+                        0x0000ff - 0x0fffff
 
-        Valid Framing values:
-                    0x00 = Unframed
-                    0x01 = Framed
+                Valid Framing values:
+                        0x00 = Unframed
+                        0x01 = Framed
 
-        Valid Max Sdu Size values:
-                    0x00 - 0x0fff
+                Valid Max Sdu Size values:
+                        0x00 - 0x0fff
 
-        Valid Retransmission Number values:
-                    0x00 - 0xff
+                Valid Retransmission Number values:
+                        0x00 - 0xff
 
-        Valid Max Transport Latency values:
-                    0x0005 – 0x0FA0
+                Valid Max Transport Latency values:
+                        0x0005 – 0x0FA0
 
-		In case of an error, the error status response will be returned.
-		In case of a success, the IUT continues processing the command
-		asynchronously. At the end of the command processing, the ASCS
-		Operation Completed event will be sent.
+                In case of an error, the error status response will be returned.
+                In case of a success, the IUT continues processing the command
+                asynchronously. At the end of the command processing, the ASCS
+                Operation Completed event will be sent.
 
-	Opcode 0x04: ASCS Enable
+        Opcode 0x04: ASCS Enable
 
-		Controller Index:	<controller id>
-		Command parameters:	Address_Type (1 octet)
-					Address (6 octets)
-					ASE_ID (1 octet)
-		Response parameters:	<None>
+                Controller Index:       <controller id>
+                Command parameters:     Address_Type (1 octet)
+                                        Address (6 octets)
+                                        ASE_ID (1 octet)
+                Response parameters:    <None>
 
-		In case of an error, the error status response will be returned.
-		In case of a success, the IUT continues processing the command
-		asynchronously. At the end of the command processing, the ASCS
-		Operation Completed event will be sent.
+                In case of an error, the error status response will be returned.
+                In case of a success, the IUT continues processing the command
+                asynchronously. At the end of the command processing, the ASCS
+                Operation Completed event will be sent.
 
-	Opcode 0x05: ASCS Receiver Start Ready
+        Opcode 0x05: ASCS Receiver Start Ready
 
-		Controller Index:	<controller id>
-		Command parameters:	Address_Type (1 octet)
-					Address (6 octets)
-					ASE_ID (1 octet)
-		Response parameters:	<None>
+                Controller Index:       <controller id>
+                Command parameters:     Address_Type (1 octet)
+                                        Address (6 octets)
+                                        ASE_ID (1 octet)
+                Response parameters:    <None>
 
-		In case of an error, the error status response will be returned.
-		In case of a success, the IUT continues processing the command
-		asynchronously. At the end of the command processing, the ASCS
-		Operation Completed event will be sent.
+                In case of an error, the error status response will be returned.
+                In case of a success, the IUT continues processing the command
+                asynchronously. At the end of the command processing, the ASCS
+                Operation Completed event will be sent.
 
-	Opcode 0x06: ASCS Receiver Stop Ready
+        Opcode 0x06: ASCS Receiver Stop Ready
 
-		Controller Index:	<controller id>
-		Command parameters:	Address_Type (1 octet)
-					Address (6 octets)
-					ASE_ID (1 octet)
-		Response parameters:	<None>
+                Controller Index:       <controller id>
+                Command parameters:     Address_Type (1 octet)
+                                        Address (6 octets)
+                                        ASE_ID (1 octet)
+                Response parameters:    <None>
 
-		In case of an error, the error status response will be returned.
-		In case of a success, the IUT continues processing the command
-		asynchronously. At the end of the command processing, the ASCS
-		Operation Completed event will be sent.
+                In case of an error, the error status response will be returned.
+                In case of a success, the IUT continues processing the command
+                asynchronously. At the end of the command processing, the ASCS
+                Operation Completed event will be sent.
 
-	Opcode 0x07: ASCS Disable
+        Opcode 0x07: ASCS Disable
 
-		Controller Index:	<controller id>
-		Command parameters:	Address_Type (1 octet)
-					Address (6 octets)
-					ASE_ID (1 octet)
-		Response parameters:	<None>
+                Controller Index:       <controller id>
+                Command parameters:     Address_Type (1 octet)
+                                        Address (6 octets)
+                                        ASE_ID (1 octet)
+                Response parameters:    <None>
 
-		In case of an error, the error status response will be returned.
-		In case of a success, the IUT continues processing the command
-		asynchronously. At the end of the command processing, the ASCS
-		Operation Completed event will be sent.
+                In case of an error, the error status response will be returned.
+                In case of a success, the IUT continues processing the command
+                asynchronously. At the end of the command processing, the ASCS
+                Operation Completed event will be sent.
 
-	Opcode 0x08: ASCS Release
+        Opcode 0x08: ASCS Release
 
-		Controller Index:	<controller id>
-		Command parameters:	Address_Type (1 octet)
-					Address (6 octets)
-					ASE_ID (1 octet)
-		Response parameters:	<None>
+                Controller Index:       <controller id>
+                Command parameters:     Address_Type (1 octet)
+                                        Address (6 octets)
+                                        ASE_ID (1 octet)
+                Response parameters:    <None>
 
-		In case of an error, the error status response will be returned.
-		In case of a success, the IUT continues processing the command
-		asynchronously. At the end of the command processing, the ASCS
-		Operation Completed event will be sent.
+                In case of an error, the error status response will be returned.
+                In case of a success, the IUT continues processing the command
+                asynchronously. At the end of the command processing, the ASCS
+                Operation Completed event will be sent.
 
-	Opcode 0x09: ASCS Update Metadata
+        Opcode 0x09: ASCS Update Metadata
 
-		Controller Index:	<controller id>
-		Command parameters:	Address_Type (1 octet)
-					Address (6 octets)
-					ASE_ID (1 octet)
-		Response parameters:	<None>
+                Controller Index:       <controller id>
+                Command parameters:     Address_Type (1 octet)
+                                        Address (6 octets)
+                                        ASE_ID (1 octet)
+                Response parameters:    <None>
 
-		In case of an error, the error status response will be returned.
-		In case of a success, the IUT continues processing the command
-		asynchronously. At the end of the command processing, the ASCS
-		Operation Completed event will be sent.
+                In case of an error, the error status response will be returned.
+                In case of a success, the IUT continues processing the command
+                asynchronously. At the end of the command processing, the ASCS
+                Operation Completed event will be sent.
 
-	Opcode 0x0a: Add CIS to CIG
+        Opcode 0x0a: Add CIS to CIG
 
-		Controller Index:	<controller id>
-		Command parameters:	Address_Type (1 octet)
-					Address (6 octets)
-					ASE_ID (1 octet)
-					CIG ID (1 octet)
-					CIS ID (1 octet)
-		Response parameters:	<None>
+                Controller Index:       <controller id>
+                Command parameters:     Address_Type (1 octet)
+                                        Address (6 octets)
+                                        ASE_ID (1 octet)
+                                        CIG ID (1 octet)
+                                        CIS ID (1 octet)
+                Response parameters:    <None>
 
-        This command is used to set up an unicast group in the IUT stack
-		before the ASCS Configure QoS operation for each ASE is called.
+                This command is used to set up an unicast group in the IUT stack
+                before the ASCS Configure QoS operation for each ASE is called.
 
-		In case of an error, the error status response will be returned.
+                In case of an error, the error status response will be returned.
 
-	Opcode 0x0b: Preconfigure QoS
+        Opcode 0x0b: Preconfigure QoS
 
-		Controller Index:	<controller id>
-		Command parameters:	CIG ID (1 octet)
-					CIS ID (1 octet)
-					Sdu Interval (3 octet)
-					Framing (1 octet)
-					Max Sdu Size (2 octets)
-					Retransmission Number (1 octets)
-					Max Transport Latency (2 octets)
-					Presentation Delay (3 octets)
-		Response parameters:	<None>
+                Controller Index:       <controller id>
+                Command parameters:     CIG ID (1 octet)
+                                        CIS ID (1 octet)
+                                        Sdu Interval (3 octet)
+                                        Framing (1 octet)
+                                        Max Sdu Size (2 octets)
+                                        Retransmission Number (1 octets)
+                                        Max Transport Latency (2 octets)
+                                        Presentation Delay (3 octets)
+                Response parameters:    <None>
 
-        This command is used to configure a QoS of an unicast group before
-        the ASCS Configure QoS operation for each ASE is executed.
+                This command is used to configure a QoS of an unicast group before
+                the ASCS Configure QoS operation for each ASE is executed.
 
-		In case of an error, the error status response will be returned.
+                In case of an error, the error status response will be returned.
 
 Events:
-	Opcode 0x80 - ASCS Operation Completed event
+        Opcode 0x80 - ASCS Operation Completed event
 
-		Controller Index:	<controller id>
-		Event parameters:	Address_Type (1 octet)
-					Address (6 octets)
-					ASE_ID (1 octet)
-					Opcode (1 octet)
-					Status (1 octet)
-					Flags (1 octet)
+                Controller Index:       <controller id>
+                Event parameters:       Address_Type (1 octet)
+                                        Address (6 octets)
+                                        ASE_ID (1 octet)
+                                        Opcode (1 octet)
+                                        Status (1 octet)
+                                        Flags (1 octet)
 
-		Valid Opcode values:
-		            0x01 = Config Codec
-		            0x02 = Config QoS
-		            0x03 = Enable
-		            0x04 = Receiver Start Ready
-		            0x05 = Disable
-		            0x06 = Receiver Stop Ready
-		            0x07 = Update Metadata
-		            0x08 = Release
+                Valid Opcode values:
+                        0x01 = Config Codec
+                        0x02 = Config QoS
+                        0x03 = Enable
+                        0x04 = Receiver Start Ready
+                        0x05 = Disable
+                        0x06 = Receiver Stop Ready
+                        0x07 = Update Metadata
+                        0x08 = Release
 
-		Valid Status values:
-		            0x00 = success
-		            0x01 = error
+                Valid Status values:
+                        0x00 = success
+                        0x01 = error
 
-		Valid Flags values: RFU
+                Valid Flags values: RFU
 
-		This event indicates that the IUT has finished ASCS operation
-		initiated by ASCS client or server.
+                This event indicates that the IUT has finished ASCS operation
+                initiated by ASCS client or server.
 
-	Opcode 0x81 - Characteristic Subscribed
+        Opcode 0x81 - Characteristic Subscribed
 
-		Controller Index:	<controller id>
-		Event parameters:	Address_Type (1 octet)
-					Address (6 octets)
-					Handle (2 octets)
+                Controller Index:       <controller id>
+                Event parameters:       Address_Type (1 octet)
+                                        Address (6 octets)
+                                        Handle (2 octets)
 
-		This event indicates that a lower tester has subscribed to
-		an ASCS characteristic with a given handle.
+                This event indicates that a lower tester has subscribed to
+                an ASCS characteristic with a given handle.
 
-	Opcode 0x82 - ASE State changed
+        Opcode 0x82 - ASE State changed
 
-		Controller Index:	<controller id>
-		Event parameters:	Address_Type (1 octet)
-					Address (6 octets)
-					ASE_ID (1 octet)
-					State (1 octet)
+                Controller Index:       <controller id>
+                Event parameters:       Address_Type (1 octet)
+                                        Address (6 octets)
+                                        ASE_ID (1 octet)
+                                        State (1 octet)
 
-		This event indicates that ASE state has been changed.
+                This event indicates that ASE state has been changed.

--- a/doc/btp_bap.txt
+++ b/doc/btp_bap.txt
@@ -3,461 +3,482 @@ BAP Service (ID 14)
 
 Commands and responses:
 
-	Opcode 0x00 - Error response
+        Opcode 0x00 - Error response
 
-	Opcode 0x01 - Read supported commands
-		Controller Index:    <controller id>
-		Command parameters:  <none>
-		Response parameters: <supported commands> (variable)
+        Opcode 0x01 - Read supported commands
 
-		Each bit in response is a flag indicating if command with
-		opcode matching bit number is supported. Bit set to 1 means
-		that command is supported. Bit 0 is reserved and shall always
-		be set to 0. If specific bit is not present in response (less
-		than required bytes received) it shall be assumed that command
-		is not supported.
+                Controller Index:    <controller id>
+                Command parameters:  <none>
+                Response parameters: <supported commands> (variable)
 
-		In case of an error, the error response will be returned.
+                Each bit in response is a flag indicating if command with
+                opcode matching bit number is supported. Bit set to 1 means
+                that command is supported. Bit 0 is reserved and shall always
+                be set to 0. If specific bit is not present in response (less
+                than required bytes received) it shall be assumed that command
+                is not supported.
 
-	Opcode 0x02 - Discover and Subscribe
-		Controller Index:    <controller id>
-		Command parameters:	Address_Type (1 octet)
-					Address  (6 octets)
-		Response parameters: <none>
+                In case of an error, the error response will be returned.
 
-        This command is used to discover all remote PACS and ASCS
-        characteristics. In case of an error, the error status response
-        will be returned. In case of a success, the IUT continues processing
-        the command asynchronously. During discovery, the IUT may send events:
-                    Discover and Subscribe Completed event
-                    Codec Capabilities Found event
-                    ASE Found event
+        Opcode 0x02 - Discover and Subscribe
 
-	Opcode 0x03 - Send
-		Controller Index:    <controller id>
-		Command parameters:	Address_Type (1 octet)
-					Address  (6 octets)
-					ASE ID (1 octet)
-					Data len (1 octet)
-					Data (varies)
-		Response parameters:	Number of buffered bytes of data (1 octet)
+                Controller Index:    <controller id>
+                Command parameters:  Address_Type (1 octet)
+                                     Address  (6 octets)
+                Response parameters: <none>
 
-        This command is used to send a data packet stream to the given ASE.
-        In case of an error, the error status response will be returned.
-        In case of a success, the IUT continues processing the command
-        asynchronously.
+                This command is used to discover all remote PACS and ASCS
+                characteristics. In case of an error, the error status response
+                will be returned. In case of a success, the IUT continues processing
+                the command asynchronously. During discovery, the IUT may send events:
+                        Discover and Subscribe Completed event
+                        Codec Capabilities Found event
+                        ASE Found event
 
-	Opcode 0x04 - Broadcast Source Setup
-		Controller Index:	<controller id>
-		Command parameters:	Streams Per Subgroup (1 octet)
-					Subgroups (1 octet)
-					Sdu Interval (3 octets)
-					Framing (1 octet)
-					Max SDU (2 octets)
-					Retransmission Num (1 octet)
-					Max Transport Latency (2 octets)
-					Presentation Delay (3 octets)
-					Coding Format (1 octet)
-					VID (2 octets)
-					CID (2 octets)
-					LTVs length (1 octet)
-					LTVs (varies)
-		Response parameters:	Current_Settings (4 Octets) (see btp_gap.txt)
-					Broadcast ID (3 Octets)
+        Opcode 0x03 - Send
 
-        This command is used to set up and configure a Broadcast Source
-        with the given Codec Config.
-        In case of an error, the error status response will be returned.
-        In case of a success, the IUT continues processing the command
-        asynchronously.
+                Controller Index:    <controller id>
+                Command parameters:  Address_Type (1 octet)
+                                     Address  (6 octets)
+                                     ASE ID (1 octet)
+                                     Data len (1 octet)
+                                     Data (varies)
+                Response parameters: Number of buffered bytes of data (1 octet)
 
-	Opcode 0x05 - Broadcast Source Release
-		Controller Index:	<controller id>
-		Command parameters:	Broadcast ID (3 Octets)
-		Response parameters:	<none>
+                This command is used to send a data packet stream to the given ASE.
+                In case of an error, the error status response will be returned.
+                In case of a success, the IUT continues processing the command
+                asynchronously.
 
-        This command is used to release resources used by Broadcast Source.
-        In case of an error, the error status response will be returned.
-        In case of a success, the IUT continues processing the command
-        asynchronously.
+        Opcode 0x04 - Broadcast Source Setup
 
-	Opcode 0x06 - Start Broadcast Advertising
-		Controller Index:	<controller id>
-		Command parameters:	Broadcast ID (3 Octets)
-		Response parameters:	<none>
+                Controller Index:       <controller id>
+                Command parameters:     Streams Per Subgroup (1 octet)
+                                        Subgroups (1 octet)
+                                        Sdu Interval (3 octets)
+                                        Framing (1 octet)
+                                        Max SDU (2 octets)
+                                        Retransmission Num (1 octet)
+                                        Max Transport Latency (2 octets)
+                                        Presentation Delay (3 octets)
+                                        Coding Format (1 octet)
+                                        VID (2 octets)
+                                        CID (2 octets)
+                                        LTVs length (1 octet)
+                                        LTVs (varies)
+                Response parameters:    Current_Settings (4 Octets) (see btp_gap.txt)
+                                        Broadcast ID (3 Octets)
 
-        This command is used to start the Broadcast Audio Announcement
-        advertising (extended and periodic).
-        In case of an error, the error status response will be returned.
-        In case of a success, the IUT continues processing the command
-        asynchronously.
+                This command is used to set up and configure a Broadcast Source
+                with the given Codec Config.
+                In case of an error, the error status response will be returned.
+                In case of a success, the IUT continues processing the command
+                asynchronously.
 
-	Opcode 0x07 - Stop Broadcast Advertising
-		Controller Index:	<controller id>
-		Command parameters:	Broadcast ID (3 Octets)
-		Response parameters:	<none>
+        Opcode 0x05 - Broadcast Source Release
 
-        This command is used to stop the Broadcast Audio Announcement
-        advertising (extended and periodic).
-        In case of an error, the error status response will be returned.
-        In case of a success, the IUT continues processing the command
-        asynchronously.
+                Controller Index:       <controller id>
+                Command parameters:     Broadcast ID (3 Octets)
+                Response parameters:    <none>
 
-	Opcode 0x08 - Start Broadcast Source
-		Controller Index:	<controller id>
-		Command parameters:	Broadcast ID (3 Octets)
-		Response parameters:	<none>
+                This command is used to release resources used by Broadcast Source.
+                In case of an error, the error status response will be returned.
+                In case of a success, the IUT continues processing the command
+                asynchronously.
 
-        This command is used to start BIS ISO data streaming.
-        In case of an error, the error status response will be returned.
-        In case of a success, the IUT continues processing the command
-        asynchronously.
+        Opcode 0x06 - Start Broadcast Advertising
 
-	Opcode 0x09 - Stop Broadcast Source
-		Controller Index:	<controller id>
-		Command parameters:	Broadcast ID (3 Octets)
-		Response parameters:	<none>
+                Controller Index:       <controller id>
+                Command parameters:     Broadcast ID (3 Octets)
+                Response parameters:    <none>
 
-        This command is used to stop BIS ISO data streaming.
-        In case of an error, the error status response will be returned.
-        In case of a success, the IUT continues processing the command
-        asynchronously.
+                This command is used to start the Broadcast Audio Announcement
+                advertising (extended and periodic).
+                In case of an error, the error status response will be returned.
+                In case of a success, the IUT continues processing the command
+                asynchronously.
 
-	Opcode 0x0a - Broadcast Sink Setup
-		Controller Index:	<controller id>
-		Command parameters:	<none>
-		Response parameters:	<none>
+        Opcode 0x07 - Stop Broadcast Advertising
 
-        This command is used to set up a Broadcast Sink.
-        In case of an error, the error status response will be returned.
-        In case of a success, the IUT continues processing the command
-        asynchronously.
+                Controller Index:       <controller id>
+                Command parameters:     Broadcast ID (3 Octets)
+                Response parameters:    <none>
 
-	Opcode 0x0b - Broadcast Sink Release
-		Controller Index:	<controller id>
-		Command parameters:	<none>
-		Response parameters:	<none>
+                This command is used to stop the Broadcast Audio Announcement
+                advertising (extended and periodic).
+                In case of an error, the error status response will be returned.
+                In case of a success, the IUT continues processing the command
+                asynchronously.
 
-        This command is used to release resources used by Broadcast Sink.
-        In case of an error, the error status response will be returned.
-        In case of a success, the IUT continues processing the command
-        asynchronously.
+        Opcode 0x08 - Start Broadcast Source
 
-	Opcode 0x0c - Broadcast Scan Start
-		Controller Index:	<controller id>
-		Command parameters:	<none>
-		Response parameters:	<none>
+                Controller Index:       <controller id>
+                Command parameters:     Broadcast ID (3 Octets)
+                Response parameters:    <none>
 
-        This command is used to start scanning for BAA when in Sink role.
-        In case of an error, the error status response will be returned.
-        In case of a success, the IUT continues processing the command
-        asynchronously.
+                This command is used to start BIS ISO data streaming.
+                In case of an error, the error status response will be returned.
+                In case of a success, the IUT continues processing the command
+                asynchronously.
 
-	Opcode 0x0d - Broadcast Scan Stop
-		Controller Index:	<controller id>
-		Command parameters:	<none>
-		Response parameters:	<none>
+        Opcode 0x09 - Stop Broadcast Source
+                Controller Index:       <controller id>
+                Command parameters:     Broadcast ID (3 Octets)
+                Response parameters:    <none>
 
-        This command is used to stop scanning for BAA when in Sink role.
-        In case of an error, the error status response will be returned.
-        In case of a success, the IUT continues processing the command
-        asynchronously.
+                This command is used to stop BIS ISO data streaming.
+                In case of an error, the error status response will be returned.
+                In case of a success, the IUT continues processing the command
+                asynchronously.
 
-	Opcode 0x0e - Broadcast Sink Sync
-		Controller Index:	<controller id>
-		Command parameters:	Address_Type (1 octet)
-					Address  (6 octets)
-					Broadcast ID (3 octets)
-					Advertiser SID (1 octet)
-					Skip (2 octet)
-					Sync Timeout (2 octets)
-					Past Available (1 octet)
-                    Source ID (1 octet)
-		Response parameters:	<none>
+        Opcode 0x0a - Broadcast Sink Setup
 
-        This command is used to start synchronization with the source
-        broadcaster.
-        In case of an error, the error status response will be returned.
-        In case of a success, the IUT continues processing the command
-        asynchronously.
+                Controller Index:       <controller id>
+                Command parameters:     <none>
+                Response parameters:    <none>
 
-	Opcode 0x0f - Broadcast Sink Stop
-		Controller Index:	<controller id>
-		Command parameters:	Address_Type (1 octet)
-					Address  (6 octets)
-					Broadcast ID (3 Octets)
-		Response parameters:	<none>
+                This command is used to set up a Broadcast Sink.
+                In case of an error, the error status response will be returned.
+                In case of a success, the IUT continues processing the command
+                asynchronously.
 
-        This command is used to stop synchronization with the source
-        broadcaster.
-        In case of an error, the error status response will be returned.
-        In case of a success, the IUT continues processing the command
-        asynchronously.
+        Opcode 0x0b - Broadcast Sink Release
 
-    Opcode 0x10 - Broadcast Sink BIS Sync
-		Controller Index:	<controller id>
-		Command parameters:	Address_Type (1 octet)
-					Address (6 octets)
-					Broadcast ID (3 octets)
-					Requested BID Sync (4 octets)
-		Response parameters:	<none>
+                Controller Index:       <controller id>
+                Command parameters:     <none>
+                Response parameters:    <none>
 
-		This command is used to start PA/BIS Sync.
-		In case of an error, the error status response will be returned.
-        In case of a success, the IUT continues processing the command
-        asynchronously.
+                This command is used to release resources used by Broadcast Sink.
+                In case of an error, the error status response will be returned.
+                In case of a success, the IUT continues processing the command
+                asynchronously.
 
-	Opcode 0x11 - Discover Scan Delegators
-		Controller Index:	<controller id>
-		Command parameters:	Address_Type (1 octet)
-					Address (6 octets)
-		Response parameters:	<none>
+        Opcode 0x0c - Broadcast Scan Start
 
-		This command is used to start a discovery of Scan Delegators.
-		In case of an error, the error status response will be returned.
-        In case of a success, the IUT continues processing the command
-        asynchronously.
+                Controller Index:       <controller id>
+                Command parameters:     <none>
+                Response parameters:    <none>
 
-    Opcode 0x12 - Broadcast Assistant Scan Start
-		Controller Index:	<controller id>
-		Command parameters:	Address_Type (1 octet)
-					Address (6 octets)
-		Response parameters:	<none>
+                This command is used to start scanning for BAA when in Sink role.
+                In case of an error, the error status response will be returned.
+                In case of a success, the IUT continues processing the command
+                asynchronously.
 
-		This command is used to
-		        In case of an error, the error status response will be returned.
-        In case of a success, the IUT continues processing the command
-        asynchronously.
+        Opcode 0x0d - Broadcast Scan Stop
 
-    Opcode 0x13 - Broadcast Assistant Scan Stop
-		Controller Index:	<controller id>
-		Command parameters:	Address_Type (1 octet)
-					Address (6 octets)
-		Response parameters:	<none>
+                Controller Index:       <controller id>
+                Command parameters:     <none>
+                Response parameters:    <none>
 
-		This command is used in Broadcast Assistant role to start a discovery of
-		Broadcast Audio Announcements.
-		In case of an error, the error status response will be returned.
-        In case of a success, the IUT continues processing the command
-        asynchronously.
+                This command is used to stop scanning for BAA when in Sink role.
+                In case of an error, the error status response will be returned.
+                In case of a success, the IUT continues processing the command
+                asynchronously.
 
-    Opcode 0x14 - Add Broadcast Source
-		Controller Index:	<controller id>
-		Command parameters:	Scan Delegator Address Type (1 octet)
-					Scan Delegator Address  (6 octets)
-					Broadcaster Address Type (1 octet)
-					Broadcaster Address (6 octets)
-					Advertiser SID (1 octet)
-					Broadcast ID (3 octets)
-					PA Sync (1 octet)
-					PA Interval (2 octets)
-					Num Subgroups (1 octet)
-					Subgroups (varies)
-		Response parameters:	<none>
+        Opcode 0x0e - Broadcast Sink Sync
 
-        This command is used in Broadcast Assistant role to perform
-        Add Source operation on a remote Scan Delegator.
-        In case of an error, the error status response will be returned.
-        In case of a success, the IUT continues processing the command
-        asynchronously.
+                Controller Index:       <controller id>
+                Command parameters:     Address_Type (1 octet)
+                                        Address  (6 octets)
+                                        Broadcast ID (3 octets)
+                                        Advertiser SID (1 octet)
+                                        Skip (2 octet)
+                                        Sync Timeout (2 octets)
+                                        Past Available (1 octet)
+                                        Source ID (1 octet)
+                Response parameters:    <none>
+
+                This command is used to start synchronization with the source
+                broadcaster.
+                In case of an error, the error status response will be returned.
+                In case of a success, the IUT continues processing the command
+                asynchronously.
+
+        Opcode 0x0f - Broadcast Sink Stop
+
+                Controller Index:       <controller id>
+                Command parameters:     Address_Type (1 octet)
+                                        Address  (6 octets)
+                                        Broadcast ID (3 Octets)
+                Response parameters:    <none>
+
+                This command is used to stop synchronization with the source
+                broadcaster.
+                In case of an error, the error status response will be returned.
+                In case of a success, the IUT continues processing the command
+                asynchronously.
+
+        Opcode 0x10 - Broadcast Sink BIS Sync
+
+                Controller Index:       <controller id>
+                Command parameters:     Address_Type (1 octet)
+                                        Address (6 octets)
+                                        Broadcast ID (3 octets)
+                                        Requested BID Sync (4 octets)
+                Response parameters:    <none>
+
+                This command is used to start PA/BIS Sync.
+                In case of an error, the error status response will be returned.
+                In case of a success, the IUT continues processing the command
+                asynchronously.
+
+        Opcode 0x11 - Discover Scan Delegators
+
+                Controller Index:       <controller id>
+                Command parameters:     Address_Type (1 octet)
+                                        Address (6 octets)
+                Response parameters:    <none>
+
+                This command is used to start a discovery of Scan Delegators.
+                In case of an error, the error status response will be returned.
+                In case of a success, the IUT continues processing the command
+                asynchronously.
+
+        Opcode 0x12 - Broadcast Assistant Scan Start
+
+                Controller Index:       <controller id>
+                Command parameters:     Address_Type (1 octet)
+                                        Address (6 octets)
+                Response parameters:    <none>
+
+                This command is used to In case of an error, the error status
+                response will be returned. In case of a success, the IUT
+                continues processing the command asynchronously.
+
+        Opcode 0x13 - Broadcast Assistant Scan Stop
+
+                Controller Index:       <controller id>
+                Command parameters:     Address_Type (1 octet)
+                                        Address (6 octets)
+                Response parameters:    <none>
+
+                This command is used in Broadcast Assistant role to start a discovery of
+                Broadcast Audio Announcements.
+                In case of an error, the error status response will be returned.
+                In case of a success, the IUT continues processing the command
+                asynchronously.
+
+        Opcode 0x14 - Add Broadcast Source
+
+                Controller Index:       <controller id>
+                Command parameters:     Scan Delegator Address Type (1 octet)
+                                        Scan Delegator Address  (6 octets)
+                                        Broadcaster Address Type (1 octet)
+                                        Broadcaster Address (6 octets)
+                                        Advertiser SID (1 octet)
+                                        Broadcast ID (3 octets)
+                                        PA Sync (1 octet)
+                                        PA Interval (2 octets)
+                                        Num Subgroups (1 octet)
+                                        Subgroups (varies)
+                Response parameters:    <none>
+
+                This command is used in Broadcast Assistant role to perform
+                Add Source operation on a remote Scan Delegator.
+                In case of an error, the error status response will be returned.
+                In case of a success, the IUT continues processing the command
+                asynchronously.
 
     Opcode 0x15 - Remove Broadcast Source
-		Controller Index:	<controller id>
-		Command parameters:	Address_Type (1 octet)
-					Address  (6 octets)
-					Source ID (1 octet)
-		Response parameters:	<none>
 
-        This command is used in Broadcast Assistant role to perform
-        Remove Source operation on a remote Scan Delegator.
-        In case of an error, the error status response will be returned.
-        In case of a success, the IUT continues processing the command
-        asynchronously.
+                Controller Index:       <controller id>
+                Command parameters:     Address_Type (1 octet)
+                                        Address  (6 octets)
+                                        Source ID (1 octet)
+                Response parameters:    <none>
+
+                This command is used in Broadcast Assistant role to perform
+                Remove Source operation on a remote Scan Delegator.
+                In case of an error, the error status response will be returned.
+                In case of a success, the IUT continues processing the command
+                asynchronously.
 
     Opcode 0x16 - Modify Broadcast Source
-		Controller Index:	<controller id>
-		Command parameters:	Address_Type (1 octet)
-					Address  (6 octets)
-					Source ID (1 octet)
-					PA_Sync (1 octet)
-					PA_Interval (2 octets)
-					Num_Subgroups (1 octet)
-					Subgroups (varies)
-		Response parameters:	<none>
 
-		This command is used in Broadcast Assistant role to perform
-		Modify Source operation on a remote Scan Delegator.
-		In case of an error, the error status response will be returned.
-        In case of a success, the IUT continues processing the command
-        asynchronously.
+                Controller Index:       <controller id>
+                Command parameters:     Address_Type (1 octet)
+                                        Address  (6 octets)
+                                        Source ID (1 octet)
+                                        PA_Sync (1 octet)
+                                        PA_Interval (2 octets)
+                                        Num_Subgroups (1 octet)
+                                        Subgroups (varies)
+                Response parameters:    <none>
+
+                This command is used in Broadcast Assistant role to perform
+                Modify Source operation on a remote Scan Delegator.
+                In case of an error, the error status response will be returned.
+                In case of a success, the IUT continues processing the command
+                asynchronously.
 
     Opcode 0x17 - Set Broadcast Code
-		Controller Index:	<controller id>
-		Command parameters:	Address_Type (1 octet)
-					Address  (6 octets)
-					Source ID (1 octet)
-					Broadcast Code (16 octets)
-		Response parameters:	<none>
 
-		This command is used to set Broadcast Code in the IUT.
-		In case of an error, the error status response will be returned.
+                Controller Index:       <controller id>
+                Command parameters:     Address_Type (1 octet)
+                                        Address  (6 octets)
+                                        Source ID (1 octet)
+                                        Broadcast Code (16 octets)
+                Response parameters:    <none>
+
+                This command is used to set Broadcast Code in the IUT.
+                In case of an error, the error status response will be returned.
         In case of a success, the IUT continues processing the command
         asynchronously.
 
     Opcode 0x18 - Send PAST
-		Controller Index:	<controller id>
-		Command parameters:	Address_Type (1 octet)
-					Address  (6 octets)
-					Source ID (1 octet)
-		Response parameters:	<none>
+                Controller Index:       <controller id>
+                Command parameters:     Address_Type (1 octet)
+                                        Address  (6 octets)
+                                        Source ID (1 octet)
+                Response parameters:    <none>
 
-		This command is used in Broadcast Assistant role to trigger
-		a PAST transfer.
-		In case of an error, the error status response will be returned.
-        In case of a success, the IUT continues processing the command
-        asynchronously.
+                This command is used in Broadcast Assistant role to trigger
+                a PAST transfer.
+                In case of an error, the error status response will be returned.
+                In case of a success, the IUT continues processing the command
+                asynchronously.
 
 Events:
-	Opcode 0x80 - Discover and Subscribe Completed event
+        Opcode 0x80 - Discover and Subscribe Completed event
 
-		Controller Index:	<controller id>
-		Event parameters:	Address_Type (1 octet)
-					Address (6 octets)
-					Status  (1 octet)
+                Controller Index:       <controller id>
+                Event parameters:       Address_Type (1 octet)
+                                        Address (6 octets)
+                                        Status  (1 octet)
 
-        This event indicates that the IUT finished discovery of PACS and ASCS
-        characteristics and subscribing to their notifications.
+                This event indicates that the IUT finished discovery of PACS and ASCS
+                characteristics and subscribing to their notifications.
 
-	Opcode 0x81 - Codec Capabilities Found event
+        Opcode 0x81 - Codec Capabilities Found event
 
-		Controller Index:	<controller id>
-		Event parameters:	Address_Type (1 octet)
-					Address (6 octets)
-					PAC dir (1 octet)
-					Coding Format (1 octet)
-					Frequencies (2 octets)
-					Frame Durations (1 octet)
-					Octets Per Frame (4 octets)
-					Supported Audio Channel Counts (1 octet)
+                Controller Index:       <controller id>
+                Event parameters:       Address_Type (1 octet)
+                                        Address (6 octets)
+                                        PAC dir (1 octet)
+                                        Coding Format (1 octet)
+                                        Frequencies (2 octets)
+                                        Frame Durations (1 octet)
+                                        Octets Per Frame (4 octets)
+                                        Supported Audio Channel Counts (1 octet)
 
-        About parameters:
-            Frequencies: a bitfield as defined in Assigned Numbers,
-            6.12.4.1 Supported_Sampling_Frequencies.
+                About parameters:
+                Frequencies: a bitfield as defined in Assigned Numbers,
+                6.12.4.1 Supported_Sampling_Frequencies.
 
-            Frame durations: as defined in Assigned Numbers, 6.12.4.2
-            Supported_Frame_Durations.
+                Frame durations: as defined in Assigned Numbers, 6.12.4.2
+                Supported_Frame_Durations.
 
-            Octets Per Frame: as defined in Assigned Numbers 6.12.4.4
-            Supported_Octets_Per_Codec_Frame.
+                Octets Per Frame: as defined in Assigned Numbers 6.12.4.4
+                Supported_Octets_Per_Codec_Frame.
 
-		This event returns the found PACS capabilities record info.
+                This event returns the found PACS capabilities record info.
 
-	Opcode 0x82 - ASE Found event
+        Opcode 0x82 - ASE Found event
 
-		Controller Index:	<controller id>
-		Event parameters:	Address_Type (1 octet)
-					Address (6 octets)
-					ASE ID (1 octet)
+                Controller Index:       <controller id>
+                Event parameters:       Address_Type (1 octet)
+                                        Address (6 octets)
+                                        ASE ID (1 octet)
 
-        This event returns the found ASE info.
+                This event returns the found ASE info.
 
-	Opcode 0x83 - Stream Received event
+        Opcode 0x83 - Stream Received event
 
-		Controller Index:	<controller id>
-		Event parameters:	Address_Type (1 octet)
-					Address (6 octets)
-					ASE ID (1 octet)
-					Data len (1 octet)
-					Data (varies)
+                Controller Index:       <controller id>
+                Event parameters:       Address_Type (1 octet)
+                                        Address (6 octets)
+                                        ASE ID (1 octet)
+                                        Data len (1 octet)
+                                        Data (varies)
 
-        This event returns the received data stream packet.
+                This event returns the received data stream packet.
 
-	Opcode 0x84 - BAA Found event
+        Opcode 0x84 - BAA Found event
 
-		Controller Index:	<controller id>
-		Event parameters:	Address_Type (1 octet)
-					Address (6 octets)
-					Broadcast_ID (3 octets)
-					Advertiser_SID (1 octet)
-					PA_Interval (2 octets)
+                Controller Index:       <controller id>
+                Event parameters:       Address_Type (1 octet)
+                                        Address (6 octets)
+                                        Broadcast_ID (3 octets)
+                                        Advertiser_SID (1 octet)
+                                        PA_Interval (2 octets)
 
         This event returns info from scanned Broadcast Audio Announcement.
 
-	Opcode 0x85 - BIS Found event
+        Opcode 0x85 - BIS Found event
 
-		Controller Index:	<controller id>
-		Event parameters:	Address_Type (1 octet)
-					Address (6 octets)
-					Broadcast ID (3 octets)
-					Presentation Delay (3 octets)
-					Subgroup ID (1 octet)
-					BIS ID (1 octet)
-					Coding Format (1 octet)
-					VID (2 octets)
-					CID (2 octets)
-					Codec Config LTVs length (1 octet)
-					Codec Config LTVs (varies)
+                Controller Index:       <controller id>
+                Event parameters:       Address_Type (1 octet)
+                                        Address (6 octets)
+                                        Broadcast ID (3 octets)
+                                        Presentation Delay (3 octets)
+                                        Subgroup ID (1 octet)
+                                        BIS ID (1 octet)
+                                        Coding Format (1 octet)
+                                        VID (2 octets)
+                                        CID (2 octets)
+                                        Codec Config LTVs length (1 octet)
+                                        Codec Config LTVs (varies)
 
-        This event returns info of found Broadcast Isochronous Stream.
+                This event returns info of found Broadcast Isochronous Stream.
 
-	Opcode 0x86 - BIS Synced event
+        Opcode 0x86 - BIS Synced event
 
-		Controller Index:	<controller id>
-		Event parameters:	Address_Type (1 octet)
-					Address (6 octets)
-					Broadcast ID (3 octets)
-					BIS ID (1 octet)
+                Controller Index:       <controller id>
+                Event parameters:       Address_Type (1 octet)
+                                        Address (6 octets)
+                                        Broadcast ID (3 octets)
+                                        BIS ID (1 octet)
 
-        This event is received when IUT has successfully synced to a BIS.
+                This event is received when IUT has successfully synced to a BIS.
 
-	Opcode 0x87 - BIS Stream Received event
+        Opcode 0x87 - BIS Stream Received event
 
-		Controller Index:	<controller id>
-		Event parameters:	Address_Type (1 octet)
-					Address (6 octets)
-				    Broadcast ID (3 octets)
-					BIS ID (1 octet)
-					Data Length (1 octet)
-					Data (varies)
+                Controller Index:       <controller id>
+                Event parameters:       Address_Type (1 octet)
+                                        Address (6 octets)
+                                        Broadcast ID (3 octets)
+                                        BIS ID (1 octet)
+                                        Data Length (1 octet)
+                                        Data (varies)
 
-        This event returns data from received ISO Data packet.
+                This event returns data from received ISO Data packet.
 
-	Opcode 0x88 - Scan Delegator Found event
+        Opcode 0x88 - Scan Delegator Found event
 
-		Controller Index:	<controller id>
-		Event parameters:	Address_Type (1 octet)
-					Address (6 octets)
+                Controller Index:       <controller id>
+                Event parameters:       Address_Type (1 octet)
+                                        Address (6 octets)
 
-        This event informs that a Scan Delegator instance has been discovered.
+                This event informs that a Scan Delegator instance has been discovered.
 
-	Opcode 0x89 - Broadcast Receive State event
+        Opcode 0x89 - Broadcast Receive State event
 
-		Controller Index:	<controller id>
-		Event parameters:	Address_Type (1 octet)
-					Address (6 octets)
-					Source ID (1 octet)
-					Broadcaster Address Type (1 octet)
-					Broadcaster Address (6 octets)
-					Advertiser SID (1 octet)
-					Broadcast ID (3 octets)
-					PA Sync State (1 octet)
-					BIG Encryption (1 octet)
-					Num Subgroups (1 octet)
-					Subgroups (varies)
+                Controller Index:       <controller id>
+                Event parameters:       Address_Type (1 octet)
+                                        Address (6 octets)
+                                        Source ID (1 octet)
+                                        Broadcaster Address Type (1 octet)
+                                        Broadcaster Address (6 octets)
+                                        Advertiser SID (1 octet)
+                                        Broadcast ID (3 octets)
+                                        PA Sync State (1 octet)
+                                        BIG Encryption (1 octet)
+                                        Num Subgroups (1 octet)
+                                        Subgroups (varies)
 
-        This event is received when the Broadcast Receive State characteristic
-        of the remote server has been updated.
+                This event is received when the Broadcast Receive State characteristic
+                of the remote server has been updated.
 
-	Opcode 0x8a - PA Sync Request event
+        Opcode 0x8a - PA Sync Request event
 
-		Controller Index:	<controller id>
-		Event parameters:	Address_Type (1 octet)
-					Address (6 octets)
-					Source ID (1 octet)
-					Advertiser SID (1 octet)
-					Broadcast ID (3 octets)
-                    PAST Available (1 octet)
-	                PA Interval (2 octets)
+                Controller Index:       <controller id>
+                Event parameters:       Address_Type (1 octet)
+                                        Address (6 octets)
+                                        Source ID (1 octet)
+                                        Advertiser SID (1 octet)
+                                        Broadcast ID (3 octets)
+                                        PAST Available (1 octet)
+                                        PA Interval (2 octets)
 
-        This event is received when a remote Broadcast Assistant has requested
-        a PA Sync from of the IUT.
+                This event is received when a remote Broadcast Assistant has requested
+                a PA Sync from of the IUT.

--- a/doc/btp_cap.txt
+++ b/doc/btp_cap.txt
@@ -3,264 +3,268 @@ CAP Service (ID 26)
 
 Commands and responses:
 
-	Opcode 0x00 - Error response
+        Opcode 0x00 - Error response
 
-	Opcode 0x01 - Read Supported Commands command/response
+        Opcode 0x01 - Read Supported Commands command/response
 
-		Controller Index:	<non-controller>
-		Command parameters:	<none>
-		Response parameters:	<supported commands> (variable)
+                Controller Index:       <non-controller>
+                Command parameters:     <none>
+                Response parameters:    <supported commands> (variable)
 
-		Each bit in response is a flag indicating if command with
-		opcode matching bit number is supported. Bit set to 1 means
-		that command is supported. Bit 0 is reserved and shall always
-		be set to 0. If specific bit is not present in response (less
-		than required bytes received) it shall be assumed that command
-		is not supported.
+                Each bit in response is a flag indicating if command with
+                opcode matching bit number is supported. Bit set to 1 means
+                that command is supported. Bit 0 is reserved and shall always
+                be set to 0. If specific bit is not present in response (less
+                than required bytes received) it shall be assumed that command
+                is not supported.
 
-		In case of an error, the error response will be returned.
+                In case of an error, the error response will be returned.
 
-	Opcode 0x02 - Discover and Subscribe
-		Controller Index:	<controller id>
-		Command parameters:	Address_Type (1 octet)
-					Address (6 octets)
-		Response parameters:	<none>
+        Opcode 0x02 - Discover and Subscribe
 
-		This command is used to discover all remote PACS, ASCS and BASS
-		characteristics. In case of an error, the error status response
-		will be returned. In case of a success, the IUT continues processing
-		the command asynchronously. During discovery, the IUT may send events:
-					Discover and Subscribe Completed event
-					Codec Capabilities Found event
-					ASE Found event
+                Controller Index:       <controller id>
+                Command parameters:     Address_Type (1 octet)
+                                        Address (6 octets)
+                Response parameters:    <none>
 
-	Opcode 0x03 - Unicast Setup ASE
-		Controller Index:	<controller id>
-		Command parameters:	Address_Type (1 octet)
-					Address (6 octets)
-					ASE_ID (1 octet)
-					CIS_ID (1 octet)
-					CIG_ID (1 octet)
-					Coding Format (1 octet)
-					VID (2 octets)
-					CID (2 octets)
-					Sdu Interval (3 octets)
-					Framing (1 octet)
-					Max SDU (2 octets)
-					Retransmission Num (1 octet)
-					Max Transport Latency (2 octets)
-					Presentation Delay (3 octets)
-					Codec Config LTVs length (1 octet)
-					Metadata LTVs length (1 octet)
-					LTVs (varies)
+                This command is used to discover all remote PACS, ASCS and BASS
+                characteristics. In case of an error, the error status response
+                will be returned. In case of a success, the IUT continues processing
+                the command asynchronously. During discovery, the IUT may send events:
+                                        Discover and Subscribe Completed event
+                                        Codec Capabilities Found event
+                                        ASE Found event
 
-		Response parameters:	<none>
+        Opcode 0x03 - Unicast Setup ASE
 
-		This command is used to configure an ASE locally before executing
-		the Unicast Audio Start procedure. Can be called once per ASE,
-		while twice per CIS, as the Sink/Source ASE might share single CIS.
-		In case of an error, the error status response will be returned.
+                Controller Index:       <controller id>
+                Command parameters:     Address_Type (1 octet)
+                                        Address (6 octets)
+                                        ASE_ID (1 octet)
+                                        CIS_ID (1 octet)
+                                        CIG_ID (1 octet)
+                                        Coding Format (1 octet)
+                                        VID (2 octets)
+                                        CID (2 octets)
+                                        Sdu Interval (3 octets)
+                                        Framing (1 octet)
+                                        Max SDU (2 octets)
+                                        Retransmission Num (1 octet)
+                                        Max Transport Latency (2 octets)
+                                        Presentation Delay (3 octets)
+                                        Codec Config LTVs length (1 octet)
+                                        Metadata LTVs length (1 octet)
+                                        LTVs (varies)
+                Response parameters:    <none>
 
-	Opcode 0x04 - Unicast Audio Start
-		Controller Index:	<controller id>
-		Command parameters:	CIG_ID (1 octet)
-					Set Type (1 octet)
+                This command is used to configure an ASE locally before executing
+                the Unicast Audio Start procedure. Can be called once per ASE,
+                while twice per CIS, as the Sink/Source ASE might share single CIS.
+                In case of an error, the error status response will be returned.
 
-		Valid Set Type values:
-					0x00 = Ad-Hoc Set
-					0x01 = CSIP Coordinated Set
+        Opcode 0x04 - Unicast Audio Start
 
-		Response parameters: <none>
+                Controller Index:       <controller id>
+                Command parameters:     CIG_ID (1 octet)
+                                        Set Type (1 octet)
+                Response parameters: <none>
 
-		This command is used to execute the Unicast Audio Start procedure.
-		In case of an error, the error status response will be returned.
-		In case of a success, the IUT continues processing the command
-		asynchronously.
+                Valid Set Type values:
+                        0x00 = Ad-Hoc Set
+                        0x01 = CSIP Coordinated Set
 
-	Opcode 0x05 - Unicast Audio Update
-		Controller Index:	<controller id>
-		Command parameters:	Stream Count (1 octet)
-					Data (varies)
+                This command is used to execute the Unicast Audio Start procedure.
+                In case of an error, the error status response will be returned.
+                In case of a success, the IUT continues processing the command
+                asynchronously.
 
-		where Data can contain one or multiple structures defined as:
-					Address_Type (1 octet)
-					Address (6 octets)
-					ASE_ID (1 octet)
-					Metadata LTVs length (1 octet)
-					Metadata LTVs (varies)
-		The number of structures is specified with the Stream Count.
-		The Address_Type, Address and ASE_ID are used to select the right
-		stream instance.
+        Opcode 0x05 - Unicast Audio Update
 
-		Response parameters: <none>
+                Controller Index:       <controller id>
+                Command parameters:     Stream Count (1 octet)
+                                        Data (varies)
+                Response parameters: <none>
 
-		This command is used to execute the Unicast Audio Update procedure.
-		In case of an error, the error status response will be returned.
-		In case of a success, the IUT continues processing the command
-		asynchronously.
+                Data can contain one or multiple structures defined as:
+                        Address_Type (1 octet)
+                        Address (6 octets)
+                        ASE_ID (1 octet)
+                        Metadata LTVs length (1 octet)
+                        Metadata LTVs (varies)
+                The number of structures is specified with the Stream Count.
+                The Address_Type, Address and ASE_ID are used to select the right
+                stream instance.
 
-	Opcode 0x06 - Unicast Audio Stop
-		Controller Index:	<controller id>
-		Command parameters:	CIG_ID (1 octet)
-		Command parameters:	Flags (1 octet)
-		where:
-			- Flags is a bit map of settings:
-				bit 0: To release the streams. If not set, the streams will only be disabled.
+                This command is used to execute the Unicast Audio Update procedure.
+                In case of an error, the error status response will be returned.
+                In case of a success, the IUT continues processing the command
+                asynchronously.
 
-		Response parameters:	<none>
+        Opcode 0x06 - Unicast Audio Stop
 
-		This command is used to execute the Unicast Audio Stop procedure.
-		In case of an error, the error status response will be returned.
-		In case of a success, the IUT continues processing the command
-		asynchronously.
+                Controller Index:       <controller id>
+                Command parameters:     CIG_ID (1 octet)
+                Command parameters:     Flags (1 octet)
+                Response parameters:    <none>
 
-	Opcode 0x07 - Broadcast Source Setup Stream
-		Controller Index:	<controller id>
-		Command parameters:	Source ID (1 octet)
-					Subgroup ID (1 octet)
-					Coding Format (1 octet)
-					VID (2 octets)
-					CID (2 octets)
-					Codec Config LTVs len (1 octet)
-					Metadata LTVs len (1 octet)
-					LTVs (varies)
-		where Source ID and Subgroup ID are local identifiers.
+                Flags is a bit map of settings:
+                        bit 0: To release the streams. If not set, the streams will only be disabled.
 
-		Response parameters:	<none>
+                This command is used to execute the Unicast Audio Stop procedure.
+                In case of an error, the error status response will be returned.
+                In case of a success, the IUT continues processing the command
+                asynchronously.
 
-		This command is used to configure the local source stream before
-		start of the source advertising.
-		In case of an error, the error status response will be returned.
+        Opcode 0x07 - Broadcast Source Setup Stream
 
-	Opcode 0x08 - Broadcast Source Setup Subgroup
-		Controller Index:	<controller id>
-		Command parameters:	Source ID (1 octet)
-					Subgroup ID (1 octet)
-					Coding Format (1 octet)
-					VID (2 octets)
-					CID (2 octets)
-					Codec Config LTVs len (1 octet)
-					Metadata LTVs len (1 octet)
-					LTVs (varies)
-		where Source ID and Subgroup ID are local identifiers.
+                Controller Index:       <controller id>
+                Command parameters:     Source ID (1 octet)
+                                        Subgroup ID (1 octet)
+                                        Coding Format (1 octet)
+                                        VID (2 octets)
+                                        CID (2 octets)
+                                        Codec Config LTVs len (1 octet)
+                                        Metadata LTVs len (1 octet)
+                                        LTVs (varies)
+                Response parameters:    <none>
 
-		Response parameters:	<none>
+                Source ID and Subgroup ID are local identifiers.
 
-		This command is used to configure the local source subgroup before
-		start of the source advertising.
-		In case of an error, the error status response will be returned.
+                This command is used to configure the local source stream before
+                start of the source advertising.
+                In case of an error, the error status response will be returned.
 
-	Opcode 0x09 - Broadcast Source Setup
-		Controller Index:	<controller id>
-		Command parameters:	Source ID (1 octet)
-					Broadcast ID (3 octets)
-					Sdu Interval (3 octets)
-					Framing (1 octet)
-					Max SDU (2 octets)
-					Retransmission Num (1 octet)
-					Max Transport Latency (2 octets)
-					Presentation Delay (3 octets)
-					Flags (1 octet)
-					Broadcast Code (16 octet)
-		where:
-			- Source ID is a local identifier.
-			- Flags is a bit map of settings:
-				bit 0: Use encryption and the given Broadcast Code
-				bit 1: Setup Codec Config at Subgroup level
+        Opcode 0x08 - Broadcast Source Setup Subgroup
 
-		Response parameters:
-					Source ID (1 octet)
-					GAP Settings (4 octets)
-					Broadcast Code (16 octet)
+                Controller Index:       <controller id>
+                Command parameters:     Source ID (1 octet)
+                                        Subgroup ID (1 octet)
+                                        Coding Format (1 octet)
+                                        VID (2 octets)
+                                        CID (2 octets)
+                                        Codec Config LTVs len (1 octet)
+                                        Metadata LTVs len (1 octet)
+                                        LTVs (varies)
+                Response parameters:    <none>
 
-		This command is used to configure the local source before start of
-		the source advertising.
-		In case of an error, the error status response will be returned.
+                Source ID and Subgroup ID are local identifiers.
 
-	Opcode 0x0a - Broadcast Source Release
-		Controller Index:	<controller id>
-		Command parameters:	Source ID (1 octet)
+                This command is used to configure the local source subgroup before
+                start of the source advertising.
+                In case of an error, the error status response will be returned.
 
-		Response parameters:	<none>
+        Opcode 0x09 - Broadcast Source Setup
 
-		This command is used to release the local source.
-		In case of an error, the error status response will be returned.
+                Controller Index:       <controller id>
+                Command parameters:     Source ID (1 octet)
+                                        Broadcast ID (3 octets)
+                                        Sdu Interval (3 octets)
+                                        Framing (1 octet)
+                                        Max SDU (2 octets)
+                                        Retransmission Num (1 octet)
+                                        Max Transport Latency (2 octets)
+                                        Presentation Delay (3 octets)
+                                        Flags (1 octet)
+                                        Broadcast Code (16 octet)
+                Response parameters:    Source ID (1 octet)
+                                        GAP Settings (4 octets)
+                                        Broadcast Code (16 octet)
 
-	Opcode 0x0b - Broadcast Advertising Start
-		Controller Index:	<controller id>
-		Command parameters:	Source ID (1 octet)
+                Source ID is a local identifier.
+                Flags is a bit map of settings:
+                        bit 0: Use encryption and the given Broadcast Code
+                        bit 1: Setup Codec Config at Subgroup level
 
-		Response parameters:	<none>
+                This command is used to configure the local source before start of
+                the source advertising.
+                In case of an error, the error status response will be returned.
 
-		This command is used to start the Extended and Periodic advertising
-		of the broadcast source.
-		In case of an error, the error status response will be returned.
+        Opcode 0x0a - Broadcast Source Release
 
-	Opcode 0x0c - Broadcast Advertising Stop
-		Controller Index:	<controller id>
-		Command parameters:	Source ID (1 octet)
+                Controller Index:       <controller id>
+                Command parameters:     Source ID (1 octet)
+                Response parameters:    <none>
 
-		Response parameters:	<none>
+                This command is used to release the local source.
+                In case of an error, the error status response will be returned.
 
-		This command is used to stop the Extended and Periodic advertising
-		of the broadcast source.
-		In case of an error, the error status response will be returned.
+        Opcode 0x0b - Broadcast Advertising Start
 
-	Opcode 0x0d - Broadcast Source Start
-		Controller Index:	<controller id>
-		Command parameters:	Source ID (1 octet)
+                Controller Index:       <controller id>
+                Command parameters:     Source ID (1 octet)
+                Response parameters:    <none>
 
-		Response parameters:	<none>
+                This command is used to start the Extended and Periodic advertising
+                of the broadcast source.
+                In case of an error, the error status response will be returned.
 
-		This command is used to start the streaming of the broadcast source.
-		In case of an error, the error status response will be returned.
+        Opcode 0x0c - Broadcast Advertising Stop
 
-	Opcode 0x0e - Broadcast Source Stop
-		Controller Index:	<controller id>
-		Command parameters:	Source ID (1 octet)
+                Controller Index:       <controller id>
+                Command parameters:     Source ID (1 octet)
+                Response parameters:    <none>
 
-		Response parameters:	<none>
+                This command is used to stop the Extended and Periodic advertising
+                of the broadcast source.
+                In case of an error, the error status response will be returned.
 
-		This command is used to stop the streaming of the broadcast source.
-		In case of an error, the error status response will be returned.
+        Opcode 0x0d - Broadcast Source Start
 
-	Opcode 0x0f - Broadcast Source Update
-		Controller Index:	<controller id>
-		Command parameters:	Source ID (1 octet)
-					Metadata LTVs length (1 octet)
-					Metadata LTVs (varies)
+                Controller Index:       <controller id>
+                Command parameters:     Source ID (1 octet)
+                Response parameters:    <none>
 
-		Response parameters:	<none>
+                This command is used to start the streaming of the broadcast source.
+                In case of an error, the error status response will be returned.
 
-		This command is used to update the metadata in BASE.
-		In case of an error, the error status response will be returned.
+        Opcode 0x0e - Broadcast Source Stop
+
+                Controller Index:       <controller id>
+                Command parameters:     Source ID (1 octet)
+                Response parameters:    <none>
+
+                This command is used to stop the streaming of the broadcast source.
+                In case of an error, the error status response will be returned.
+
+        Opcode 0x0f - Broadcast Source Update
+
+                Controller Index:       <controller id>
+                Command parameters:     Source ID (1 octet)
+                                        Metadata LTVs length (1 octet)
+                                        Metadata LTVs (varies)
+                Response parameters:    <none>
+
+                This command is used to update the metadata in BASE.
+                In case of an error, the error status response will be returned.
 
 Events:
-	Opcode 0x80 - Discover and Subscribe Completed event
+        Opcode 0x80 - Discover and Subscribe Completed event
 
-		Controller Index:	<controller id>
-		Event parameters:	Address_Type (1 octet)
-					Address (6 octets)
-					Status  (1 octet)
-		where Status is 0x00 in case of success and 0x01 in case of failure.
+                Controller Index:       <controller id>
+                Event parameters:       Address_Type (1 octet)
+                                        Address (6 octets)
+                                        Status  (1 octet)
 
-        This event indicates that the IUT finished discovery of the Unicast
-        characteristics and subscribing to their notifications.
+                Status is 0x00 in case of success and 0x01 in case of failure.
 
-	Opcode 0x81 - Unicast Start Completed
+                This event indicates that the IUT finished discovery of the Unicast
+                characteristics and subscribing to their notifications.
 
-		Controller Index:	<controller id>
-		Event parameters:	CIG ID (1 octet)
-					Status  (1 octet)
-		where Status is 0x00 in case of success and 0x01 in case of failure.
+        Opcode 0x81 - Unicast Start Completed
 
-        This event indicates that the IUT finished starting the Unicast source.
+                Controller Index:       <controller id>
+                Event parameters:       CIG ID (1 octet)
+                                        Status  (1 octet)
 
-	Opcode 0x82 - Unicast Stop Completed
+                Status is 0x00 in case of success and 0x01 in case of failure.
 
-		Controller Index:	<controller id>
-		Event parameters:	CIG ID (1 octet)
-					Status  (1 octet)
-		where Status is 0x00 in case of success and 0x01 in case of failure.
+                This event indicates that the IUT finished starting the Unicast source.
 
-        This event indicates that the IUT finished starting the Unicast source.
+        Opcode 0x82 - Unicast Stop Completed
+
+                Controller Index:       <controller id>
+                Event parameters:       CIG ID (1 octet)
+                                        Status  (1 octet)
+                Status is 0x00 in case of success and 0x01 in case of failure.
+
+                This event indicates that the IUT finished starting the Unicast source.

--- a/doc/btp_cas.txt
+++ b/doc/btp_cas.txt
@@ -3,55 +3,55 @@ CAS Service (ID 21)
 
 Commands and responses:
 
-	Opcode 0x00 - Error response
+        Opcode 0x00 - Error response
 
-	Opcode 0x01 - Read Supported Commands command/response
+        Opcode 0x01 - Read Supported Commands command/response
 
-		Controller Index:	<non-controller>
-		Command parameters:	<none>
-		Response parameters:	<supported commands> (variable)
+                Controller Index:       <non-controller>
+                Command parameters:     <none>
+                Response parameters:    <supported commands> (variable)
 
-		Each bit in response is a flag indicating if command with
-		opcode matching bit number is supported. Bit set to 1 means
-		that command is supported. Bit 0 is reserved and shall always
-		be set to 0. If specific bit is not present in response (less
-		than required bytes received) it shall be assumed that command
-		is not supported.
+                Each bit in response is a flag indicating if command with
+                opcode matching bit number is supported. Bit set to 1 means
+                that command is supported. Bit 0 is reserved and shall always
+                be set to 0. If specific bit is not present in response (less
+                than required bytes received) it shall be assumed that command
+                is not supported.
 
-		In case of an error, the error response will be returned.
+                In case of an error, the error response will be returned.
 
-	Opcode 0x02: CAS Set Member Lock
+        Opcode 0x02: CAS Set Member Lock
 
-		Controller Index:	<controller id>
-		Command parameters:	Address_Type (1 octet)
-					Address (6 octets)
-					Lock (1 octet)
-					Force (1 octet)
-		Response parameters:	<None>
+                Controller Index:       <controller id>
+                Command parameters:     Address_Type (1 octet)
+                                        Address (6 octets)
+                                        Lock (1 octet)
+                                        Force (1 octet)
+                Response parameters:    <None>
 
-		Address Type is a byte; Address type of the PTS address.
-		Address is a 6 octet address; Address of the PTS.
-		Lock is a boolean; True to set the Lock; False to release the Lock.
-		Force is a boolean; True to force the Lock operation; False otherwise.
-		Force is only relevant when releasing the member Lock. 
-		In this case it will force release the lock, regardless of who took the lock. 
+                Address Type is a byte; Address type of the PTS address.
+                Address is a 6 octet address; Address of the PTS.
+                Lock is a boolean; True to set the Lock; False to release the Lock.
+                Force is a boolean; True to force the Lock operation; False otherwise.
+                Force is only relevant when releasing the member Lock. 
+                In this case it will force release the lock, regardless of who took the lock. 
 
-		This command is used to set the member Lock. 
-		
-		In case of an error, the error response will be returned.
+                This command is used to set the member Lock. 
+                
+                In case of an error, the error response will be returned.
 
-	Opcode 0x02: CAS Get Member RSI
+        Opcode 0x02: CAS Get Member RSI
 
-		Controller Index:	<controller id>
-		Command parameters:	Address_Type (1 octet)
-					Address (6 octets)
-		Response parameters:	RSI (6 octets)
+                Controller Index:       <controller id>
+                Command parameters:     Address_Type (1 octet)
+                                        Address (6 octets)
+                Response parameters:    RSI (6 octets)
 
-		Address Type is a byte; Address type of the PTS address.
-		Address is a 6 octet address; Address of the PTS.
-		
-		RSI is a 6 octet Resolvable Set Identifier.
+                Address Type is a byte; Address type of the PTS address.
+                Address is a 6 octet address; Address of the PTS.
+                
+                RSI is a 6 octet Resolvable Set Identifier.
 
-		This command is used to generate and return a new RSI (Resolvable Set Identifier). 
-		
-		In case of an error, the error response will be returned.
+                This command is used to generate and return a new RSI (Resolvable Set Identifier). 
+                
+                In case of an error, the error response will be returned.

--- a/doc/btp_ccp.txt
+++ b/doc/btp_ccp.txt
@@ -3,469 +3,469 @@ CCP Service (ID 19)
 
 Commands and responses:
 
-	Opcode 0x00 - Error response
+        Opcode 0x00 - Error response
 
-	Opcode 0x01 - Read Supported Commands command/response
+        Opcode 0x01 - Read Supported Commands command/response
 
-		Controller Index:	<non-controller>
-		Command parameters:	<none>
-		Response parameters:	<supported commands> (variable)
+                Controller Index:       <non-controller>
+                Command parameters:     <none>
+                Response parameters:    <supported commands> (variable)
 
-		Each bit in response is a flag indicating if command with
-		opcode matching bit number is supported. Bit set to 1 means
-		that command is supported. Bit 0 is reserved and shall always
-		be set to 0. If specific bit is not present in response (less
-		than required bytes received) it shall be assumed that command
-		is not supported.
+                Each bit in response is a flag indicating if command with
+                opcode matching bit number is supported. Bit set to 1 means
+                that command is supported. Bit 0 is reserved and shall always
+                be set to 0. If specific bit is not present in response (less
+                than required bytes received) it shall be assumed that command
+                is not supported.
 
-		In case of an error, the error response will be returned.
+                In case of an error, the error response will be returned.
 
-	Opcode 0x02: CCP Discover TBS
+        Opcode 0x02: CCP Discover TBS
 
-		Controller Index:	<controller id>
-		Command parameters:	Address_Type (1 octet)
-					Address (6 octets)
-		Response parameters:	<None>
+                Controller Index:       <controller id>
+                Command parameters:     Address_Type (1 octet)
+                                        Address (6 octets)
+                Response parameters:    <None>
 
-		Address Type is a byte; Address type of the PTS address.
-		Address is a 6 octet address; Address of the PTS.
-		This command is used to discover the GTBS and any TBS instances and all 
-		their characteristics. It will also enable notifications/indications for all 
-		characteristics that support it.
+                Address Type is a byte; Address type of the PTS address.
+                Address is a 6 octet address; Address of the PTS.
+                This command is used to discover the GTBS and any TBS instances and all 
+                their characteristics. It will also enable notifications/indications for all 
+                characteristics that support it.
 
-		Note: A Discovery Complete Event will be issued when discovery has completed.
-		Also, the IUT may send Characteristic Handles Event.
+                Note: A Discovery Complete Event will be issued when discovery has completed.
+                Also, the IUT may send Characteristic Handles Event.
 
-		In case of an error, the error response will be returned.
+                In case of an error, the error response will be returned.
 
-	Opcode 0x03: CCP Accept Call
+        Opcode 0x03: CCP Accept Call
 
-		Controller Index:	<controller id>
-		Command parameters:	Address_Type (1 octet)
-					Address (6 octets)
-					Index (1 octet)
-					Call Identifier (1 octet)
-		Response parameters:	<None>
+                Controller Index:       <controller id>
+                Command parameters:     Address_Type (1 octet)
+                                        Address (6 octets)
+                                        Index (1 octet)
+                                        Call Identifier (1 octet)
+                Response parameters:    <None>
 
-		Address Type is a byte; Address type of the PTS address.
-		Address is a 6 octet address; Address of the PTS.
-		Index is a byte; It holds the index of the TBS to address.
-		Note: To address the GTBS use an index value of BT_TBS_GTBS_INDEX(0xff).
-		To address an ordinary TBS use an index value in the range [0, TBS_COUNT[, 
-		where TBS_COUNT is the number of TBS instances returned by the Discovery 
-		Complete Event.
+                Address Type is a byte; Address type of the PTS address.
+                Address is a 6 octet address; Address of the PTS.
+                Index is a byte; It holds the index of the TBS to address.
+                Note: To address the GTBS use an index value of BT_TBS_GTBS_INDEX(0xff).
+                To address an ordinary TBS use an index value in the range [0, TBS_COUNT[, 
+                where TBS_COUNT is the number of TBS instances returned by the Discovery 
+                Complete Event.
 
-		Call Identifier is a byte; A unique Call Identifier assigned by the Server.
+                Call Identifier is a byte; A unique Call Identifier assigned by the Server.
 
-		This command is used to Accept a Call.
+                This command is used to Accept a Call.
 
-		In case of an error, the error response will be returned.
+                In case of an error, the error response will be returned.
 
-	Opcode 0x04: CCP Terminate Call
+        Opcode 0x04: CCP Terminate Call
 
-		Controller Index:	<controller id>
-		Command parameters:	Address_Type (1 octet)
-					Address (6 octets)
-					Index (1 octet)
-					Call Identifier (1 octet)
-		Response parameters:	<None>
+                Controller Index:       <controller id>
+                Command parameters:     Address_Type (1 octet)
+                                        Address (6 octets)
+                                        Index (1 octet)
+                                        Call Identifier (1 octet)
+                Response parameters:    <None>
 
-		Address Type is a byte; Address type of the PTS address.
-		Address is a 6 octet address; Address of the PTS.
-		Index is a byte; It holds the index of the TBS to address.
-		Note: To address the GTBS use an index value of BT_TBS_GTBS_INDEX(0xff).
-		To address an ordinary TBS use an index value in the range [0, TBS_COUNT[, 
-		where TBS_COUNT is the number of TBS instances returned by the Discovery 
-		Complete Event.
+                Address Type is a byte; Address type of the PTS address.
+                Address is a 6 octet address; Address of the PTS.
+                Index is a byte; It holds the index of the TBS to address.
+                Note: To address the GTBS use an index value of BT_TBS_GTBS_INDEX(0xff).
+                To address an ordinary TBS use an index value in the range [0, TBS_COUNT[, 
+                where TBS_COUNT is the number of TBS instances returned by the Discovery 
+                Complete Event.
 
-		Call Identifier is a byte; A unique Call Identifier assigned by the Server.
+                Call Identifier is a byte; A unique Call Identifier assigned by the Server.
 
-		This command is used to add Terminate a Call.
+                This command is used to add Terminate a Call.
 
-		In case of an error, the error response will be returned.
+                In case of an error, the error response will be returned.
 
-	Opcode 0x05: CCP Originate Call
+        Opcode 0x05: CCP Originate Call
 
-		Controller Index:	<controller id>
-		Command parameters:	Address_Type (1 octet)
-					Address (6 octets)
-					Index (1 octet)
-					Call URI Length (1 octet)
-					Call URI (N octets)
-		Response parameters:	<None>
+                Controller Index:       <controller id>
+                Command parameters:     Address_Type (1 octet)
+                                        Address (6 octets)
+                                        Index (1 octet)
+                                        Call URI Length (1 octet)
+                                        Call URI (N octets)
+                Response parameters:    <None>
 
-		Address Type is a byte; Address type of the PTS address.
-		Address is a 6 octet address; Address of the PTS.
-		Index is a byte; It holds the index of the TBS to address.
-		Note: To address the GTBS use an index value of BT_TBS_GTBS_INDEX(0xff).
-		To address an ordinary TBS use an index value in the range [0, TBS_COUNT[, 
-		where TBS_COUNT is the number of TBS instances returned by the Discovery 
-		Complete Event.
+                Address Type is a byte; Address type of the PTS address.
+                Address is a 6 octet address; Address of the PTS.
+                Index is a byte; It holds the index of the TBS to address.
+                Note: To address the GTBS use an index value of BT_TBS_GTBS_INDEX(0xff).
+                To address an ordinary TBS use an index value in the range [0, TBS_COUNT[, 
+                where TBS_COUNT is the number of TBS instances returned by the Discovery 
+                Complete Event.
 
-		Call URI Length is a byte; Length in bytes of the Call URI.
+                Call URI Length is a byte; Length in bytes of the Call URI.
 
-		Call URI is a zero-terminated UTF-8 string; Call URI expressed as <URI scheme>:
-		<Caller ID>, where <URI Scheme> must be one of the supported URI Schemes.
+                Call URI is a zero-terminated UTF-8 string; Call URI expressed as <URI scheme>:
+                <Caller ID>, where <URI Scheme> must be one of the supported URI Schemes.
 
-		This command is used to Originate a Call.
+                This command is used to Originate a Call.
 
-		In case of an error, the error response will be returned.
+                In case of an error, the error response will be returned.
 
-	Opcode 0x06: CCP Read Call States
+        Opcode 0x06: CCP Read Call States
 
-		Controller Index:	<controller id>
-		Command parameters:	Address_Type (1 octet)
-					Address (6 octets)
-					Index (1 octet)
-		Response parameters:	<None>
+                Controller Index:       <controller id>
+                Command parameters:     Address_Type (1 octet)
+                                        Address (6 octets)
+                                        Index (1 octet)
+                Response parameters:    <None>
 
-		Address Type is a byte; Address type of the PTS address.
-		Address is a 6 octet address; Address of the PTS.
-		Index is a byte; It holds the index of the TBS to address.
-		Note: To address the GTBS use an index value of BT_TBS_GTBS_INDEX(0xff).
-		To address an ordinary TBS use an index value in the range [0, TBS_COUNT[, 
-		where TBS_COUNT is the number of TBS instances returned by the Discovery 
-		Complete Event.
+                Address Type is a byte; Address type of the PTS address.
+                Address is a 6 octet address; Address of the PTS.
+                Index is a byte; It holds the index of the TBS to address.
+                Note: To address the GTBS use an index value of BT_TBS_GTBS_INDEX(0xff).
+                To address an ordinary TBS use an index value in the range [0, TBS_COUNT[, 
+                where TBS_COUNT is the number of TBS instances returned by the Discovery 
+                Complete Event.
 
-		This command is used to read the current Call states.
+                This command is used to read the current Call states.
 
-		Note: A Read Call States Event will be issued when the Call States have 
-		been read.
+                Note: A Read Call States Event will be issued when the Call States have 
+                been read.
 
-		In case of an error, the error response will be returned.
+                In case of an error, the error response will be returned.
 
-	Opcode 0x07 - Read Bearer Name
+        Opcode 0x07 - Read Bearer Name
 
-		Controller Index:	<controller id>
-		Command parameters:     Address_Type (1 octet)
-					Address (6 octets)
-					Index (1 octets)
-		Response parameters:    <none>
+                Controller Index:       <controller id>
+                Command parameters:     Address_Type (1 octet)
+                                        Address (6 octets)
+                                        Index (1 octets)
+                Response parameters:    <none>
 
-		This command is used to read bearer provider name of a TBS instance.
-		During operation, the IUT may send event:
-				Characteristic String Value Event
+                This command is used to read bearer provider name of a TBS instance.
+                During operation, the IUT may send event:
+                        Characteristic String Value Event
 
-	Opcode 0x08 - Read Bearer UCI
+        Opcode 0x08 - Read Bearer UCI
 
-		Controller Index:	<controller id>
-		Command parameters:     Address_Type (1 octet)
-					Address (6 octets)
-					Index (1 octets)
-		Response parameters:    <none>
+                Controller Index:       <controller id>
+                Command parameters:     Address_Type (1 octet)
+                                        Address (6 octets)
+                                        Index (1 octets)
+                Response parameters:    <none>
 
-		This command is used to read UCI of a TBS instance.
-		During operation, the IUT may send event:
-				Characteristic String Value Event
+                This command is used to read UCI of a TBS instance.
+                During operation, the IUT may send event:
+                        Characteristic String Value Event
 
-	Opcode 0x09 - Read Bearer Technology
+        Opcode 0x09 - Read Bearer Technology
 
-		Controller Index:	<controller id>
-		Command parameters:     Address_Type (1 octet)
-					Address (6 octets)
-					Index (1 octets)
-		Response parameters:    <none>
+                Controller Index:       <controller id>
+                Command parameters:     Address_Type (1 octet)
+                                        Address (6 octets)
+                                        Index (1 octets)
+                Response parameters:    <none>
 
-		This command is used to read technology of a TBS instance.
-		0x01 - 3G
-		0x02 - 4G
-		0x03 - LTE
-		0x04 - Wi-Fi
-		0x05 - 5G
-		0x06 - GSM
-		0x07 - CDMA
-		0x08 - 2G
-		0x09 - WCDMA
+                This command is used to read technology of a TBS instance.
+                        0x01 - 3G
+                        0x02 - 4G
+                        0x03 - LTE
+                        0x04 - Wi-Fi
+                        0x05 - 5G
+                        0x06 - GSM
+                        0x07 - CDMA
+                        0x08 - 2G
+                        0x09 - WCDMA
 
-		During operation, the IUT may send event:
-				Characteristic String Value Event
+                During operation, the IUT may send event:
+                        Characteristic String Value Event
 
-	Opcode 0x0a - Read URI List
+        Opcode 0x0a - Read URI List
 
-		Controller Index:	<controller id>
-		Command parameters:     Address_Type (1 octet)
-					Address (6 octets)
-					Index (1 octets)
-		Response parameters:    <none>
+                Controller Index:       <controller id>
+                Command parameters:     Address_Type (1 octet)
+                                        Address (6 octets)
+                                        Index (1 octets)
+                Response parameters:    <none>
 
-		This command is used to read URI schemes list of a TBS instance.
-		During operation, the IUT may send event:
-				Characteristic String Value Event
+                This command is used to read URI schemes list of a TBS instance.
+                During operation, the IUT may send event:
+                        Characteristic String Value Event
 
-	Opcode 0x0b - Read Signal Strength
+        Opcode 0x0b - Read Signal Strength
 
-		Controller Index:	<controller id>
-		Command parameters:     Address_Type (1 octet)
-					Address (6 octets)
-					Index (1 octets)
-		Response parameters:    <none>
+                Controller Index:       <controller id>
+                Command parameters:     Address_Type (1 octet)
+                                        Address (6 octets)
+                                        Index (1 octets)
+                Response parameters:    <none>
 
-		This command is used to read current signal strength list of a TBS instance.
-		During operation, the IUT may send event:
-				Characteristic Value Event
+                This command is used to read current signal strength list of a TBS instance.
+                During operation, the IUT may send event:
+                        Characteristic Value Event
 
-	Opcode 0x0c - Read Signal Interval
+        Opcode 0x0c - Read Signal Interval
 
-		Controller Index:	<controller id>
-		Command parameters:     Address_Type (1 octet)
-					Address (6 octets)
-					Index (1 octets)
-		Response parameters:    <none>
+                Controller Index:       <controller id>
+                Command parameters:     Address_Type (1 octet)
+                                        Address (6 octets)
+                                        Index (1 octets)
+                Response parameters:    <none>
 
-		This command is used to read current signal strength reporting
-		interval of a TBS instance.
-		During operation, the IUT may send event:
-				Characteristic Value Event
-
-	Opcode 0x0d - Read Current Calls
+                This command is used to read current signal strength reporting
+                interval of a TBS instance.
+                During operation, the IUT may send event:
+                                Characteristic Value Event
+
+        Opcode 0x0d - Read Current Calls
 
-		Controller Index:	<controller id>
-		Command parameters:     Address_Type (1 octet)
-					Address (6 octets)
-					Index (1 octets)
-		Response parameters:    <none>
-
-		This command is used to read list of current calls of a TBS instance.
-
-	Opcode 0x0e - Read CCID
-
-		Controller Index:	<controller id>
-		Command parameters:     Address_Type (1 octet)
-					Address (6 octets)
-					Index (1 octets)
-		Response parameters:    <none>
-
-		This command is used to read content ID of a TBS instance.
-		During operation, the IUT may send event:
-				Characteristic Value Event
-
-	Opcode 0x0f - Read Call URI
-
-		Controller Index:	<controller id>
-		Command parameters:     Address_Type (1 octet)
-					Address (6 octets)
-					Index (1 octets)
-		Response parameters:    <none>
-
-		This command is used to read call target URI of a TBS instance.
-		During operation, the IUT may send event:
-				Read String Value event
-
-	Opcode 0x10 - Read Status Flags
-
-		Controller Index:	<controller id>
-		Command parameters:     Address_Type (1 octet)
-					Address (6 octets)
-					Index (1 octets)
-		Response parameters:    <none>
-
-		This command is used to read the feature and status value
-		of a TBS instance.
-		During operation, the IUT may send event:
-				Characteristic Value Event
-
-	Opcode 0x11 - Read Optional Opcodes
-
-		Controller Index:	<controller id>
-		Command parameters:     Address_Type (1 octet)
-					Address (6 octets)
-					Index (1 octets)
-		Response parameters:    <none>
-
-		This command is used to read supported opcodes of a TBS instance.
-		During operation, the IUT may send event:
-				Characteristic Value Event
-
-	Opcode 0x12 - Read Friendly Name
-
-		Controller Index:	<controller id>
-		Command parameters:     Address_Type (1 octet)
-					Address (6 octets)
-					Index (1 octets)
-		Response parameters:    <none>
-
-		This command is used to read the friendly name of a call
-		for a TBS instance.
-		During operation, the IUT may send event:
-				Characteristic String Value Event
-
-	Opcode 0x13 - Read Remote URI
-
-		Controller Index:	<controller id>
-		Command parameters:     Address_Type (1 octet)
-					Address (6 octets)
-					Index (1 octets)
-		Response parameters:    <none>
-
-		This command is used to read the remote URI of a TBS instance.
-		During operation, the IUT may send event:
-				Characteristic String Value Event
-
-	Opcode 0x14 - Set Signal Interval
-
-		Controller Index:	<controller id>
-		Command parameters:     Address_Type (1 octet)
-					Address (6 octets)
-					Index (1 octets)
-					Interval (1 octets)
-		Response parameters:    <none>
-
-		This command is used to Set the signal strength reporting interval
-		for a TBS instance.
-		During operation, the IUT may send event:
-				Characteristic Value Event
-
-	Opcode 0x15 - Hold Call
-
-		Controller Index:	<controller id>
-		Command parameters:     Address_Type (1 octet)
-					Address (6 octets)
-					Index (1 octets)
-					Call ID (1 octets)
-		Response parameters:    <none>
-
-		This command is used to request to hold a call.
-		During operation, the IUT may send event:
-				Call Control Point event
-
-	Opcode 0x16 - Retrieve Call
-
-		Controller Index:	<controller id>
-		Command parameters:     Address_Type (1 octet)
-					Address (6 octets)
-					Index (1 octets)
-					Call ID (1 octets)
-		Response parameters:    <none>
-
-		This command is used to retrieve call from (local) hold.
-		During operation, the IUT may send event:
-				Call Control Point event
-
-	Opcode 0x17 - Join Calls
-
-		Controller Index:	<controller id>
-		Command parameters:     Address_Type (1 octet)
-					Address (6 octets)
-					Index (1 octets)
-					Count (1 octet)
-					Call IDs (varies)
-		Response parameters:    <none>
-
-		This command is used to join multiple calls. Call IDs is an array
-		of 1 octet Call IDs.
-		During operation, the IUT may send event:
-				Call Control Point event
+                Controller Index:       <controller id>
+                Command parameters:     Address_Type (1 octet)
+                                        Address (6 octets)
+                                        Index (1 octets)
+                Response parameters:    <none>
+
+                This command is used to read list of current calls of a TBS instance.
+
+        Opcode 0x0e - Read CCID
+
+                Controller Index:       <controller id>
+                Command parameters:     Address_Type (1 octet)
+                                        Address (6 octets)
+                                        Index (1 octets)
+                Response parameters:    <none>
+
+                This command is used to read content ID of a TBS instance.
+                During operation, the IUT may send event:
+                        Characteristic Value Event
+
+        Opcode 0x0f - Read Call URI
+
+                Controller Index:       <controller id>
+                Command parameters:     Address_Type (1 octet)
+                                        Address (6 octets)
+                                        Index (1 octets)
+                Response parameters:    <none>
+
+                This command is used to read call target URI of a TBS instance.
+                During operation, the IUT may send event:
+                        Read String Value event
+
+        Opcode 0x10 - Read Status Flags
+
+                Controller Index:       <controller id>
+                Command parameters:     Address_Type (1 octet)
+                                        Address (6 octets)
+                                        Index (1 octets)
+                Response parameters:    <none>
+
+                This command is used to read the feature and status value
+                of a TBS instance.
+                During operation, the IUT may send event:
+                        Characteristic Value Event
+
+        Opcode 0x11 - Read Optional Opcodes
+
+                Controller Index:       <controller id>
+                Command parameters:     Address_Type (1 octet)
+                                        Address (6 octets)
+                                        Index (1 octets)
+                Response parameters:    <none>
+
+                This command is used to read supported opcodes of a TBS instance.
+                During operation, the IUT may send event:
+                        Characteristic Value Event
+
+        Opcode 0x12 - Read Friendly Name
+
+                Controller Index:       <controller id>
+                Command parameters:     Address_Type (1 octet)
+                                        Address (6 octets)
+                                        Index (1 octets)
+                Response parameters:    <none>
+
+                This command is used to read the friendly name of a call
+                for a TBS instance.
+                During operation, the IUT may send event:
+                        Characteristic String Value Event
+
+        Opcode 0x13 - Read Remote URI
+
+                Controller Index:       <controller id>
+                Command parameters:     Address_Type (1 octet)
+                                        Address (6 octets)
+                                        Index (1 octets)
+                Response parameters:    <none>
+
+                This command is used to read the remote URI of a TBS instance.
+                During operation, the IUT may send event:
+                        Characteristic String Value Event
+
+        Opcode 0x14 - Set Signal Interval
+
+                Controller Index:       <controller id>
+                Command parameters:     Address_Type (1 octet)
+                                        Address (6 octets)
+                                        Index (1 octets)
+                                        Interval (1 octets)
+                Response parameters:    <none>
+
+                This command is used to Set the signal strength reporting interval
+                for a TBS instance.
+                During operation, the IUT may send event:
+                        Characteristic Value Event
+
+        Opcode 0x15 - Hold Call
+
+                Controller Index:       <controller id>
+                Command parameters:     Address_Type (1 octet)
+                                        Address (6 octets)
+                                        Index (1 octets)
+                                        Call ID (1 octets)
+                Response parameters:    <none>
+
+                This command is used to request to hold a call.
+                During operation, the IUT may send event:
+                        Call Control Point event
+
+        Opcode 0x16 - Retrieve Call
+
+                Controller Index:       <controller id>
+                Command parameters:     Address_Type (1 octet)
+                                        Address (6 octets)
+                                        Index (1 octets)
+                                        Call ID (1 octets)
+                Response parameters:    <none>
+
+                This command is used to retrieve call from (local) hold.
+                During operation, the IUT may send event:
+                        Call Control Point event
+
+        Opcode 0x17 - Join Calls
+
+                Controller Index:       <controller id>
+                Command parameters:     Address_Type (1 octet)
+                                        Address (6 octets)
+                                        Index (1 octets)
+                                        Count (1 octet)
+                                        Call IDs (varies)
+                Response parameters:    <none>
+
+                This command is used to join multiple calls. Call IDs is an array
+                of 1 octet Call IDs.
+                During operation, the IUT may send event:
+                        Call Control Point event
 
 Events:
-	Opcode 0x80 - Discover Completed event
+        Opcode 0x80 - Discover Completed event
 
-		Controller Index:	<controller id>
-		Event parameters:	Status (4 octets)
-					TBS Count (1 octet)
-					GTBS Found (1 octet)
+                Controller Index:       <controller id>
+                Event parameters:       Status (4 octets)
+                                        TBS Count (1 octet)
+                                        GTBS Found (1 octet)
 
-		Status is an integer; A Status of 0 indicates success, any other value indicates an error.
-		TBS Count is byte; Returning the number of TBS instances found.
-		GTBS Found is a boolean; True if an instance of GTBS was found; False otherwise.
+                Status is an integer; A Status of 0 indicates success, any other value indicates an error.
+                TBS Count is byte; Returning the number of TBS instances found.
+                GTBS Found is a boolean; True if an instance of GTBS was found; False otherwise.
 
-        	This event indicates that the IUT finished discovery of GTBS and TBS instances,
-        	their characteristics and optionally subscribing to their notifications/indications.
+                This event indicates that the IUT finished discovery of GTBS and TBS instances,
+                their characteristics and optionally subscribing to their notifications/indications.
 
-	Opcode 0x81 - Read Call States event
+        Opcode 0x81 - Read Call States event
 
-		Controller Index:	<controller id>
-		Event parameters:	Status (4 octets)
-					Index (1 octet)
-					Call Count (1 octet)
-					<repeated for each call>
-						Call Index (1 octet)
-						State (1 octet)
-						Flags (1 octet)
+                Controller Index:       <controller id>
+                Event parameters:       Status (4 octets)
+                                        Index (1 octet)
+                                        Call Count (1 octet)
+                                        <repeated for each call>
+                                        Call Index (1 octet)
+                                        State (1 octet)
+                                        Flags (1 octet)
 
-		Status is an integer; A Status of 0 indicates success, any other value indicates an error.
+                Status is an integer; A Status of 0 indicates success, any other value indicates an error.
 
-		Index is a byte; It holds the index of the TBS to address.
-		Note: To address the GTBS use an index value of BT_TBS_GTBS_INDEX(0xff).
-		To address an ordinary TBS use an index value in the range [0, TBS_COUNT[, 
-		where TBS_COUNT is the number of TBS instances returned by the Discovery 
-		Complete Event.
+                Index is a byte; It holds the index of the TBS to address.
+                Note: To address the GTBS use an index value of BT_TBS_GTBS_INDEX(0xff).
+                To address an ordinary TBS use an index value in the range [0, TBS_COUNT[, 
+                where TBS_COUNT is the number of TBS instances returned by the Discovery 
+                Complete Event.
 
-		Call Count is byte; It holds the number of active calls.
+                Call Count is byte; It holds the number of active calls.
 
-		Call Index is a byte; It holds the Server assigned Call Identifier.
+                Call Index is a byte; It holds the Server assigned Call Identifier.
 
-		State is a byte; It holds the call state (see below).
+                State is a byte; It holds the call state (see below).
 
-		Flags is a byte: It holds additional information about the call (see below)
+                Flags is a byte: It holds additional information about the call (see below)
 
-		State is an enum with the following values:
-			0 - Incoming
-			1 - Dialling
-			2 - Alerting
-			3 - Active
-			4 - Locally Held
-			5 - Remotely Held
-			6 - Locally and Remotely Held
+                State is an enum with the following values:
+                        0 - Incoming
+                        1 - Dialling
+                        2 - Alerting
+                        3 - Active
+                        4 - Locally Held
+                        5 - Remotely Held
+                        6 - Locally and Remotely Held
 
-		Flags is bitfield with the following values:
-			Bit 0 - Incoming/Outgoing
-			Bit 1 - Not Withheld/Withheld
-			Bit 2 - Provided by Network/Withheld by Network
-			
-        	This event indicates that the IUT finished reading the call states.
-		If there are any active calls, Call Count > 0, Call State (3 octets) will 
-		be returned for each active call.
+                Flags is bitfield with the following values:
+                        Bit 0 - Incoming/Outgoing
+                        Bit 1 - Not Withheld/Withheld
+                        Bit 2 - Provided by Network/Withheld by Network
+                        
+                This event indicates that the IUT finished reading the call states.
+                If there are any active calls, Call Count > 0, Call State (3 octets) will 
+                be returned for each active call.
 
-	Opcode 0x82 - Characteristics Handles Event
+        Opcode 0x82 - Characteristics Handles Event
 
-		Controller Index:	<controller id>
-		Event parameters:	Bearer Provider Name Handle (2 octets)
-					Bearer UCI Handle (2 octets)
-					Bearer Technology Handle (2 octets)
-					URI List Handle (2 octets)
-					Signal Strength Handle (2 octets)
-					Signal Interval Handle (2 octets)
-					Current Calls Handle (2 octets)
-					CCID Handle (2 octets)
-					Status Flags Handle (2 octets)
-					Bearer URI Handle (2 octets)
-					Call State Handle (2 octets)
-					Call Control Point Handle (2 octets)
-					Optional Opcodes Handle (2 octets)
-					Termination Reasons Handle (2 octets)
-					Incoming Call Handle (2 octets)
-					Friendly Name Handle (2 octets)
+                Controller Index:       <controller id>
+                Event parameters:       Bearer Provider Name Handle (2 octets)
+                                        Bearer UCI Handle (2 octets)
+                                        Bearer Technology Handle (2 octets)
+                                        URI List Handle (2 octets)
+                                        Signal Strength Handle (2 octets)
+                                        Signal Interval Handle (2 octets)
+                                        Current Calls Handle (2 octets)
+                                        CCID Handle (2 octets)
+                                        Status Flags Handle (2 octets)
+                                        Bearer URI Handle (2 octets)
+                                        Call State Handle (2 octets)
+                                        Call Control Point Handle (2 octets)
+                                        Optional Opcodes Handle (2 octets)
+                                        Termination Reasons Handle (2 octets)
+                                        Incoming Call Handle (2 octets)
+                                        Friendly Name Handle (2 octets)
 
-		This event returns handles of TBS characteristics.
+                This event returns handles of TBS characteristics.
 
-	Opcode 0x83 - Characteristic Value Event
+        Opcode 0x83 - Characteristic Value Event
 
-		Controller Index:	<controller id>
-		Event parameters:	Address_Type (1 octet)
-					Address (6 octets)
-					Status (1 octet)
-					Instance Index (4 octets)
-					Value (1 octet)
+                Controller Index:       <controller id>
+                Event parameters:       Address_Type (1 octet)
+                                        Address (6 octets)
+                                        Status (1 octet)
+                                        Instance Index (4 octets)
+                                        Value (1 octet)
 
-		This event returns integer value of characteristic.
+                This event returns integer value of characteristic.
 
-	Opcode 0x84 - Characteristic String Value Event
+        Opcode 0x84 - Characteristic String Value Event
 
-		Controller Index:	<controller id>
-		Event parameters:	Address_Type (1 octet)
-					Address (6 octets)
-					Status (1 octet)
-					Instance Index (4 octets)
-					Data Length (1 octet)
-					String Data (varies)
+                Controller Index:       <controller id>
+                Event parameters:       Address_Type (1 octet)
+                                        Address (6 octets)
+                                        Status (1 octet)
+                                        Instance Index (4 octets)
+                                        Data Length (1 octet)
+                                        String Data (varies)
 
-		This event returns string value of characteristic.
+                This event returns string value of characteristic.
 
-	Opcode 0x85 - Call Control Point Event
+        Opcode 0x85 - Call Control Point Event
 
-		Controller Index:	<controller id>
-		Event parameters:	Address_Type (1 octet)
-					Address (6 octets)
-					Status (1 octet)
+                Controller Index:       <controller id>
+                Event parameters:       Address_Type (1 octet)
+                                        Address (6 octets)
+                                        Status (1 octet)
 
-		This event returns status value for call control functions.
+                This event returns status value for call control functions.

--- a/doc/btp_core.txt
+++ b/doc/btp_core.txt
@@ -3,83 +3,83 @@ Core Service (ID 0)
 
 Commands and responses:
 
-	Opcode 0x00 - Error response
+        Opcode 0x00 - Error response
 
-	Opcode 0x01 - Read Supported Commands command/response
+        Opcode 0x01 - Read Supported Commands command/response
 
-		Controller Index:	<non-controller>
-		Command parameters:	<none>
-		Response parameters:	<supported commands> (variable)
+                Controller Index:       <non-controller>
+                Command parameters:     <none>
+                Response parameters:    <supported commands> (variable)
 
-		Each bit in response is a flag indicating if command with
-		opcode matching bit number is supported. Bit set to 1 means
-		that command is supported. Bit 0 is reserved and shall always
-		be set to 0. If specific bit is not present in response (less
-		than required bytes received) it shall be assumed that command
-		is not supported.
+                Each bit in response is a flag indicating if command with
+                opcode matching bit number is supported. Bit set to 1 means
+                that command is supported. Bit 0 is reserved and shall always
+                be set to 0. If specific bit is not present in response (less
+                than required bytes received) it shall be assumed that command
+                is not supported.
 
-		In case of an error, the error response will be returned.
+                In case of an error, the error response will be returned.
 
-	Opcode 0x02 - Read Supported Services command/response
+        Opcode 0x02 - Read Supported Services command/response
 
-		Controller Index:	<non-controller>
-		Command parameters:	<none>
-		Response parameters:	<supported services> (variable)
+                Controller Index:       <non-controller>
+                Command parameters:     <none>
+                Response parameters:    <supported services> (variable)
 
-		Each bit in response is a flag indicating if service with ID
-		matching bit number is supported. Bit set to 1 means that
-		service is supported. If specific bit is not present in response
-		(less than required bytes received) it shall be assumed that
-		service is not supported.
+                Each bit in response is a flag indicating if service with ID
+                matching bit number is supported. Bit set to 1 means that
+                service is supported. If specific bit is not present in response
+                (less than required bytes received) it shall be assumed that
+                service is not supported.
 
-		In case of an error, the error response will be returned.
+                In case of an error, the error response will be returned.
 
-	Opcode 0x03 - Register Service command/response
+        Opcode 0x03 - Register Service command/response
 
-		Controller Index:	<non-controller>
-		Command parameters:	Service ID (1 octet)
-		Response parameters:	<none>
+                Controller Index:       <non-controller>
+                Command parameters:     Service ID (1 octet)
+                Response parameters:    <none>
 
-		In case a command is sent for an undeclared service ID, it will
-		be rejected. Also there will be no events for undeclared
-		service ID.
+                In case a command is sent for an undeclared service ID, it will
+                be rejected. Also there will be no events for undeclared
+                service ID.
 
-		In case of an error, the error response will be returned.
+                In case of an error, the error response will be returned.
 
-	Opcode 0x04 - Unregister Service command/response
+        Opcode 0x04 - Unregister Service command/response
 
-		Controller Index:	<non-controller>
-		Command parameters:	Service ID (1 octet)
-		Response parameters:	<none>
+                Controller Index:       <non-controller>
+                Command parameters:     Service ID (1 octet)
+                Response parameters:    <none>
 
-		In case of an error, the error response will be returned.
+                In case of an error, the error response will be returned.
 
-	Opcode 0x05 - Log message at IUT
+        Opcode 0x05 - Log message at IUT
 
-		Controller Index:	<non-controller>
-		Command parameters:	Log_Message_Length (2 Octets)
-					Log_Message (variable)
-		Response parameters:	<none>
+                Controller Index:       <non-controller>
+                Command parameters:     Log_Message_Length (2 Octets)
+                                        Log_Message (variable)
+                Response parameters:    <none>
 
-		In case of an error, the error response will be returned.
+                In case of an error, the error response will be returned.
 
-	Opcode 0x06 - Read BTP MTU
+        Opcode 0x06 - Read BTP MTU
 
-		Controller Index:	<non-controller>
-		Command parameters:	<none>
-		Response parameters:	BTP_MTU (2 octets)
+                Controller Index:       <non-controller>
+                Command parameters:     <none>
+                Response parameters:    BTP_MTU (2 octets)
 
-		This allows to read BTP protocol MTU on OUT device. MTU is maximum
-		number of bytes that IUT can receive or send (including BTP header).
+                This allows to read BTP protocol MTU on OUT device. MTU is maximum
+                number of bytes that IUT can receive or send (including BTP header).
 
-		In case of an error, the error response will be returned.
+                In case of an error, the error response will be returned.
 
 Events:
-	Opcode 0x80 - IUT ready event
+        Opcode 0x80 - IUT ready event
 
-		Controller Index:	<non-controller>
-		Event parameters:	<none>
+                Controller Index:       <non-controller>
+                Event parameters:       <none>
 
-		This event indicates that IUT has been initialized and is ready to
-		receive BTP commands.
-		Tester shall wait for this event before sending any command to the IUT.
+                This event indicates that IUT has been initialized and is ready to
+                receive BTP commands.
+                Tester shall wait for this event before sending any command to the IUT.

--- a/doc/btp_csip.txt
+++ b/doc/btp_csip.txt
@@ -3,102 +3,101 @@ CSIP Service (ID 25)
 
 Commands and responses:
 
-	Opcode 0x00 - Error response
+        Opcode 0x00 - Error response
 
-	Opcode 0x01 - Read Supported Commands command/response
+        Opcode 0x01 - Read Supported Commands command/response
 
-		Controller Index:	<controller id>
-		Command parameters:	<none>
-		Response parameters:	<supported commands> (variable)
+                Controller Index:       <controller id>
+                Command parameters:     <none>
+                Response parameters:    <supported commands> (variable)
 
-		Each bit in response is a flag indicating if command with
-		opcode matching bit number is supported. Bit set to 1 means
-		that command is supported. Bit 0 is reserved and shall always
-		be set to 0. If specific bit is not present in response (less
-		than required bytes received) it shall be assumed that command
-		is not supported.
+                Each bit in response is a flag indicating if command with
+                opcode matching bit number is supported. Bit set to 1 means
+                that command is supported. Bit 0 is reserved and shall always
+                be set to 0. If specific bit is not present in response (less
+                than required bytes received) it shall be assumed that command
+                is not supported.
 
-		In case of an error, the error response will be returned.
+                In case of an error, the error response will be returned.
 
-	Opcode 0x02 - Discover and Subscribe
-		Controller Index:	<controller id>
-		Command parameters:	Address_Type (1 octet)
-					Address (6 octets)
-		Response parameters:	<none>
+        Opcode 0x02 - Discover and Subscribe
+                Controller Index:       <controller id>
+                Command parameters:     Address_Type (1 octet)
+                                        Address (6 octets)
+                Response parameters:    <none>
 
-		This command is used to discover all remote CSIP characteristics.
-		In case of an error, the error status response will be returned.
-		In case of a success, the IUT continues processing the command
-		asynchronously.
-		During operation, the IUT may send events:
-				CSIP Lock event
-				CSIP Sirk event
+                This command is used to discover all remote CSIP characteristics.
+                In case of an error, the error status response will be returned.
+                In case of a success, the IUT continues processing the command
+                asynchronously.
+                During operation, the IUT may send events:
+                                CSIP Lock event
+                                CSIP Sirk event
 
-	Opcode 0x03 - Start Ordered Access
-		Controller Index:	<controller id>
-		Command parameters:	Flags (1 octet)
-		Response parameters:	<none>
+        Opcode 0x03 - Start Ordered Access
+                Controller Index:       <controller id>
+                Command parameters:     Flags (1 octet)
+                Response parameters:    <none>
 
-		This command is used to start the CSIP Ordered Access procedure.
-		In case of an error, the error status response will be returned.
-		In case of a success, the IUT continues processing the command
-		asynchronously.
+                This command is used to start the CSIP Ordered Access procedure.
+                In case of an error, the error status response will be returned.
+                In case of a success, the IUT continues processing the command
+                asynchronously.
 
-	Opcode 0x04 - Set Coordinator Lock
+        Opcode 0x04 - Set Coordinator Lock
 
-		Controller Index:	<controller id>
-		Command parameters:     Address count (1 octet)
-					Address list (varies)
-		Response parameters:    <none>
+                Controller Index:       <controller id>
+                Command parameters:     Address count (1 octet)
+                                        Address list (varies)
+                Response parameters:    <none>
 
-		This command is used to perform lock request on set members.
-		Address list parameter should contain tuple(s) of address type
-		and address: ([(0, 'DB:F5:72:56:C9:EF'), (0, 'DB:F5:72:56:C9:EF')].
-		When Address list is not provided, lock procedure will be performed
-		on all set members. During operation, the IUT may send event:
-				CSIP Lock event
+                This command is used to perform lock request on set members.
+                Address list parameter should contain tuple(s) of address type
+                and address: ([(0, 'DB:F5:72:56:C9:EF'), (0, 'DB:F5:72:56:C9:EF')].
+                When Address list is not provided, lock procedure will be performed
+                on all set members. During operation, the IUT may send event:
+                                CSIP Lock event
 
-	Opcode 0x05 - Set Coordinator Lock Release
+        Opcode 0x05 - Set Coordinator Lock Release
 
-		Controller Index:	<controller id>
-		Command parameters:     Address count (1 octet)
-					Address list (varies)
-		Response parameters:    <none>
+                Controller Index:       <controller id>
+                Command parameters:     Address count (1 octet)
+                                        Address list (varies)
+                Response parameters:    <none>
 
-		This command is used to perform lock release on set members.
-		Address list parameter should contain tuple(s) of address type
-		and address: ([(0, 'DB:F5:72:56:C9:EF'), (0, 'DB:F5:72:56:C9:EF')].
-		When Address list is not provided, lock procedure will be performed
-		on all set members. During operation, the IUT may send event:
-				CSIP Lock event
+                This command is used to perform lock release on set members.
+                Address list parameter should contain tuple(s) of address type
+                and address: ([(0, 'DB:F5:72:56:C9:EF'), (0, 'DB:F5:72:56:C9:EF')].
+                When Address list is not provided, lock procedure will be performed
+                on all set members. During operation, the IUT may send event:
+                                CSIP Lock event
 
 Events:
-	Opcode 0x80 - Discover Completed event
+        Opcode 0x80 - Discover Completed event
 
-		Controller Index:	<controller id>
-		Event parameters:	Address Type (1 octet)
-					Address (6 octets)
-					ATT status (1 octet)
-					Set Sirk Handle (1 octet)
-					Set Size Handle (1 octet)
-					Set Lock Handle (1 octet)
-					Rank Handle (1 octet)
+                Controller Index:       <controller id>
+                Event parameters:       Address Type (1 octet)
+                                        Address (6 octets)
+                                        ATT status (1 octet)
+                                        Set Sirk Handle (1 octet)
+                                        Set Size Handle (1 octet)
+                                        Set Lock Handle (1 octet)
+                                        Rank Handle (1 octet)
 
-		This event returns handles of CSIP characteristsics.
+                This event returns handles of CSIP characteristsics.
 
-	Opcode 0x81 - Sirk event
+        Opcode 0x81 - Sirk event
 
-		Controller Index:       <controller id>
-		Event parameters:       Address Type (1 octet)
-					Address (6 octets)
-					SIRK (16 octets)
+                Controller Index:       <controller id>
+                Event parameters:       Address Type (1 octet)
+                                        Address (6 octets)
+                                        SIRK (16 octets)
 
-		This event returns SIRK (Set identity resolving key) value.
+                This event returns SIRK (Set identity resolving key) value.
 
-	Opcode 0x82 - Lock event
+        Opcode 0x82 - Lock event
 
-		Controller Index:       <controller id>
-		Event parameters:       Lock (1 octet)
+                Controller Index:       <controller id>
+                Event parameters:       Lock (1 octet)
 
-		This event returns Set Member Lock value.
-
+                This event returns Set Member Lock value.

--- a/doc/btp_csis.txt
+++ b/doc/btp_csis.txt
@@ -3,65 +3,65 @@ CSIS Service (ID 17)
 
 Commands and responses:
 
-	Opcode 0x00 - Error response
+        Opcode 0x00 - Error response
 
-	Opcode 0x01 - Read Supported Commands command/response
+        Opcode 0x01 - Read Supported Commands command/response
 
-		Controller Index:	<non-controller>
-		Command parameters:	<none>
-		Response parameters:	<supported commands> (variable)
+                Controller Index:       <non-controller>
+                Command parameters:     <none>
+                Response parameters:    <supported commands> (variable)
 
-		Each bit in response is a flag indicating if command with
-		opcode matching bit number is supported. Bit set to 1 means
-		that command is supported. Bit 0 is reserved and shall always
-		be set to 0. If specific bit is not present in response (less
-		than required bytes received) it shall be assumed that command
-		is not supported.
+                Each bit in response is a flag indicating if command with
+                opcode matching bit number is supported. Bit set to 1 means
+                that command is supported. Bit 0 is reserved and shall always
+                be set to 0. If specific bit is not present in response (less
+                than required bytes received) it shall be assumed that command
+                is not supported.
 
-		In case of an error, the error response will be returned.
+                In case of an error, the error response will be returned.
 
-	Opcode 0x02: CSIS Set Member Lock
+        Opcode 0x02: CSIS Set Member Lock
 
-		Controller Index:	<controller id>
-		Command parameters:	Address_Type (1 octet)
-					Address (6 octets)
-					Lock (1 octet)
-					Force (1 octet)
-		Response parameters:	<None>
+                Controller Index:       <controller id>
+                Command parameters:     Address_Type (1 octet)
+                                        Address (6 octets)
+                                        Lock (1 octet)
+                                        Force (1 octet)
+                Response parameters:    <None>
 
-		Address Type is a byte; Address type of the PTS address.
-		Address is a 6 octet address; Address of the PTS.
-		Lock is a boolean; True to set the Lock; False to release the Lock.
-		Force is a boolean; True to force the Lock operation; False otherwise.
-		Force is only relevant when releasing the member Lock.
-		In this case it will force release the lock, regardless of who took the lock.
+                Address Type is a byte; Address type of the PTS address.
+                Address is a 6 octet address; Address of the PTS.
+                Lock is a boolean; True to set the Lock; False to release the Lock.
+                Force is a boolean; True to force the Lock operation; False otherwise.
+                Force is only relevant when releasing the member Lock.
+                In this case it will force release the lock, regardless of who took the lock.
 
-		This command is used to set the member Lock.
+                This command is used to set the member Lock.
 
-		In case of an error, the error response will be returned.
+                In case of an error, the error response will be returned.
 
-	Opcode 0x03: CSIS Get Member RSI
+        Opcode 0x03: CSIS Get Member RSI
 
-		Controller Index:	<controller id>
-		Command parameters:	Address_Type (1 octet)
-					Address (6 octets)
-		Response parameters:	RSI (6 octets)
+                Controller Index:       <controller id>
+                Command parameters:     Address_Type (1 octet)
+                                        Address (6 octets)
+                Response parameters:    RSI (6 octets)
 
-		Address Type is a byte; Address type of the PTS address.
-		Address is a 6 octet address; Address of the PTS.
+                Address Type is a byte; Address type of the PTS address.
+                Address is a 6 octet address; Address of the PTS.
 
-		RSI is a 6 octet Resolvable Set Identifier.
+                RSI is a 6 octet Resolvable Set Identifier.
 
-		This command is used to generate and return a new RSI (Resolvable Set Identifier).
+                This command is used to generate and return a new RSI (Resolvable Set Identifier).
 
-		In case of an error, the error response will be returned.
+                In case of an error, the error response will be returned.
 
-	Opcode 0x04 - CSIS Set SIRK Type
+        Opcode 0x04 - CSIS Set SIRK Type
 
-		Controller Index:       <controller id>
-		Command parameters:     SIRK Type (1 octet)
-		Response parameters:    <none>
+                Controller Index:       <controller id>
+                Command parameters:     SIRK Type (1 octet)
+                Response parameters:    <none>
 
-		This command is used to set SIRK type.
-		0 - Plain text SIRK
-		1 - Encrypted SIRK
+                This command is used to set SIRK type.
+                        0 - Plain text SIRK
+                        1 - Encrypted SIRK

--- a/doc/btp_gap.txt
+++ b/doc/btp_gap.txt
@@ -3,639 +3,647 @@ GAP Service (ID 1)
 
 Commands and responses:
 
-	Opcode 0x00 - Error response
+        Opcode 0x00 - Error response
+
+        Opcode 0x01 - Read Supported Commands command/response
 
-	Opcode 0x01 - Read Supported Commands command/response
+                Controller Index:       <non-controller>
+                Command parameters:     <none>
+                Response parameters:    <supported commands> (variable)
 
-		Controller Index:	<non-controller>
-		Command parameters:	<none>
-		Response parameters:	<supported commands> (variable)
+                Each bit in response is a flag indicating if command with
+                opcode matching bit number is supported. Bit set to 1 means
+                that command is supported. Bit 0 is reserved and shall always
+                be set to 0. If specific bit is not present in response (less
+                than required bytes received) it shall be assumed that command
+                is not supported.
 
-		Each bit in response is a flag indicating if command with
-		opcode matching bit number is supported. Bit set to 1 means
-		that command is supported. Bit 0 is reserved and shall always
-		be set to 0. If specific bit is not present in response (less
-		than required bytes received) it shall be assumed that command
-		is not supported.
+                In case of an error, the error response will be returned.
 
-		In case of an error, the error response will be returned.
+        Opcode 0x02 - Read Controller Index List command/response
 
-	Opcode 0x02 - Read Controller Index List command/response
+                Controller Index:       <non-controller>
+                Command parameters:     <none>
+                Response parameters:    Number of Controllers (1 octet)
+                                        Controller Index[i] (1 octet)
 
-		Controller Index:	<non-controller>
-		Command parameters:	<none>
-		Response parameters:	Number of Controllers (1 octet)
-					Controller Index[i] (1 octet)
+                This command returns the list of controllers.
 
-		This command returns the list of controllers.
+                In case of an error, the error response will be returned.
 
-		In case of an error, the error response will be returned.
+        Opcode 0x03 - Read Controller Information command/response
 
-	Opcode 0x03 - Read Controller Information command/response
+        Controller Index:       <controller id>
+        Command parameters:     <none>
+        Response parameters:    Address (6 Octets)
+                                Supported_Settings (4 Octets)
+                                Current_Settings (4 Octets)
+                                Class_Of_Device (3 Octets)
+                                Name (249 Octets)
+                                Short_Name (11 Octets)
 
-	Controller Index:	<controller id>
-	Command parameters:	<none>
-	Response parameters:	Address (6 Octets)
-				Supported_Settings (4 Octets)
-				Current_Settings (4 Octets)
-				Class_Of_Device (3 Octets)
-				Name (249 Octets)
-				Short_Name (11 Octets)
+                This command is used to retrieve the current state and basic
+                information of a controller. It is typically used right after
+                getting the response to the Read Controller Index List command
 
-		This command is used to retrieve the current state and basic
-		information of a controller. It is typically used right after
-		getting the response to the Read Controller Index List command
+                Current_Settings and Supported_Settings is a bitmask with
+                currently the following available bits:
+                        0       Powered
+                        1       Connectable
+                        2       Fast Connectable
+                        3       Discoverable
+                        4       Bondable
+                        5       Link Level Security (Sec. mode 3)
+                        6       Secure Simple Pairing
+                        7       Basic Rate/Enhanced Data Rate
+                        8       High Speed
+                        9       Low Energy
+                        10      Advertising
+                        11      Secure Connections
+                        12      Debug Keys
+                        13      Privacy
+                        14      Controller Configuration
+                        15      Static Address
+                        16      Secure Connections Only
+                        17      Extended Advertising
+                        18      Periodic Advertising
 
-		Current_Settings and Supported_Settings is a bitmask with
-		currently the following available bits:
+                In case of an error, the error response will be returned.
 
-			0	Powered
-			1	Connectable
-			2	Fast Connectable
-			3	Discoverable
-			4	Bondable
-			5	Link Level Security (Sec. mode 3)
-			6	Secure Simple Pairing
-			7	Basic Rate/Enhanced Data Rate
-			8	High Speed
-			9	Low Energy
-			10	Advertising
-			11	Secure Connections
-			12	Debug Keys
-			13	Privacy
-			14	Controller Configuration
-			15	Static Address
-			16	Secure Connections Only
-			17	Extended Advertising
-			18	Periodic Advertising
+        Opcode 0x04 - Reset command/response
 
-		In case of an error, the error response will be returned.
+                Controller Index:       <controller id>
+                Command parameters:     <none>
+                Response parameters:    Current_Settings (4 Octets)
 
-	Opcode 0x04 - Reset command/response
+                This allows to clean up any state data (eg. keys) and restore
+                controller to its default system state.
 
-		Controller Index:	<controller id>
-		Command parameters:	<none>
-		Response parameters:	Current_Settings (4 Octets)
+                In case of an error, the error response will be returned.
 
-		This allows to clean up any state data (eg. keys) and restore
-		controller to its default system state.
+        Opcode 0x05 - Set Powered command/response
 
-		In case of an error, the error response will be returned.
+                Controller Index:       <controller id>
+                Command parameters:     Powered (1 octet)
+                Response parameters:    Current_Settings (4 Octets)
 
-	Opcode 0x05 - Set Powered command/response
+                Valid Powered values:
+                        0x00 = Off
+                        0x01 = On
 
-		Controller Index:	<controller id>
-		Command parameters:	Powered (1 octet)
-		Response parameters:	Current_Settings (4 Octets)
+                This command is used to power on or off a controller.
 
-		Valid Powered values:	0x00 = Off
-					0x01 = On
+                In case of an error, the error response will be returned.
 
-		This command is used to power on or off a controller.
+        Opcode 0x06 - Set Connectable command/response
 
-		In case of an error, the error response will be returned.
+                Controller Index:       <controller id>
+                Command parameters:     Connectable (1 octet)
+                Response parameters:    Current_Settings (4 Octets)
 
-	Opcode 0x06 - Set Connectable command/response
+                Valid Connectable values:
+                        0x00 = Off
+                        0x01 = On
 
-		Controller Index:	<controller id>
-		Command parameters:	Connectable (1 octet)
-		Response parameters:	Current_Settings (4 Octets)
+                This command is used to set controller connectable.
 
-		Valid Connectable values:	0x00 = Off
-						0x01 = On
+                In case of an error, the error response will be returned.
 
-		This command is used to set controller connectable.
+        Opcode 0x07 - Set Fast Connectable command/response
 
-		In case of an error, the error response will be returned.
+                Controller Index:       <controller id>
+                Command parameters:     Fast Connectable (1 octet)
+                Response parameters:    Current_Settings (4 Octets)
 
-	Opcode 0x07 - Set Fast Connectable command/response
+                Valid Fast Connectable values:
+                        0x00 = Off
+                        0x01 = On
 
-		Controller Index:	<controller id>
-		Command parameters:	Fast Connectable (1 octet)
-		Response parameters:	Current_Settings (4 Octets)
+                This command is used to set controller fast connectable.
+                This command is only available for BR/EDR capable controllers.
 
-		Valid Fast Connectable values:	0x00 = Off
-						0x01 = On
+                In case of an error, the error response will be returned.
 
-		This command is used to set controller fast connectable.
-		This command is only available for BR/EDR capable controllers.
+        Opcode 0x08 - Set Discoverable command/response
 
-		In case of an error, the error response will be returned.
+                Controller Index:       <controller id>
+                Command parameters:     Discoverable (1 octet)
+                Response parameters:    Current_Settings (4 Octets)
 
-	Opcode 0x08 - Set Discoverable command/response
+                Valid Discoverable values:
+                        0x00 = Off
+                        0x01 = General Discoverable
+                        0x02 = Limited Discoverable
 
-		Controller Index:	<controller id>
-		Command parameters:	Discoverable (1 octet)
-		Response parameters:	Current_Settings (4 Octets)
+                This command is used to set controller discoverable.
 
-		Valid Discoverable values:	0x00 = Off
-						0x01 = General Discoverable
-						0x02 = Limited Discoverable
+                In case of an error, the error response will be returned.
 
-		This command is used to set controller discoverable.
+        Opcode 0x09 - Set Bondable command/response
 
-		In case of an error, the error response will be returned.
+                Controller Index:       <controller id>
+                Command parameters:     Bondable (1 octet)
+                Response parameters:    Current_Settings (4 Octets)
 
-	Opcode 0x09 - Set Bondable command/response
+                Valid Bondable values:
+                        0x00 = Off
+                        0x01 = On
 
-		Controller Index:	<controller id>
-		Command parameters:	Bondable (1 octet)
-		Response parameters:	Current_Settings (4 Octets)
+                This command is used to set controller bondable.
 
-		Valid Bondable values:	0x00 = Off
-					0x01 = On
+                In case of an error, the error response will be returned.
 
-		This command is used to set controller bondable.
+        Opcode 0x0a - Start Advertising command/response
 
-		In case of an error, the error response will be returned.
+                Controller Index:       <controller id>
+                Command parameters:     Adv_Data_Len (1 octet)
+                                        Scan_Rsp_len (1 octet)
+                                        Adv_Data (0-255 octets)
+                                        Scan_Rsp (0-255 octets)
+                                        Duration (4 octets)
+                                        Own_Addr_Type (1 octet)
+                Return Parameters:      Current_Settings (4 Octets)
 
-	Opcode 0x0a - Start Advertising command/response
+                Valid Own_Addr_Type parameter values:
+                        0x00 = Identity Address
+                        0x01 = Resolvable Private Address
+                        0x02 = Non-resolvabe Private Address
 
-		Controller Index:	<controller id>
-		Command parameters:	Adv_Data_Len (1 octet)
-					Scan_Rsp_len (1 octet)
-					Adv_Data (0-255 octets)
-					Scan_Rsp (0-255 octets)
-					Duration (4 octets)
-					Own_Addr_Type (1 octet)
-		Return Parameters:	Current_Settings (4 Octets)
+                This command is used to start advertising.
 
-		Valid Own_Addr_Type parameter values:
-					0x00 = Identity Address
-					0x01 = Resolvable Private Address
-					0x02 = Non-resolvabe Private Address
+                Adv_Data and Scan_Rsp are a list of { AD_Type, AD_Len, AD_DATA } structures.
 
-		This command is used to start advertising.
+                When Duration parameter value equals UINT32_MAX then the
+                advertising duration is disabled.
 
-		Adv_Data and Scan_Rsp are a list of { AD_Type, AD_Len, AD_DATA } structures.
+                In case of an error, the error response will be returned.
 
-		When Duration parameter value equals UINT32_MAX then the
-		advertising duration is disabled.
+        Opcode 0x0b - Stop Advertising command/response
 
-		In case of an error, the error response will be returned.
+                Controller Index:       <controller id>
+                Command parameters:     <none>
+                Return Parameters:      Current_Settings (4 Octets)
 
-	Opcode 0x0b - Stop Advertising command/response
+                This command is used to stop advertising.
 
-		Controller Index:	<controller id>
-		Command parameters:	<none>
-		Return Parameters:	Current_Settings (4 Octets)
+                In case of an error, the error response will be returned.
 
-		This command is used to stop advertising.
+        Opcode 0x0c - Start Discovery command/response
 
-		In case of an error, the error response will be returned.
+                Controller Index:       <controller id>
+                Command parameters:     Flags (1 octet)
+                Return Parameters:      <none>
 
-	Opcode 0x0c - Start Discovery command/response
+                Possible values for the Flags parameter are a bit-wise or
+                of the following bits:
+                        0 = LE scan
+                        1 = BR/EDR scan
+                        2 = Use limited discovery procedure
+                        3 = Use active scan type
+                        4 = Use observation procedure
+                        5 = Use own ID address
 
-		Controller Index:	<controller id>
-		Command parameters:	Flags (1 octet)
-		Return Parameters:	<none>
+                This command is used to start discovery.
 
-		Possible values for the Flags parameter are a bit-wise or
-		of the following bits:
-					0 = LE scan
-					1 = BR/EDR scan
-					2 = Use limited discovery procedure
-					3 = Use active scan type
-					4 = Use observation procedure
-					5 = Use own ID address
+                Observation Procedure allows to receive advertisements
+                (and scan responses) from broadcasters (that are not visible
+                during General or Limited discovery, because those are not
+                discoverable). This procedure can use either passive or active
+                scan type. If "Use observation procedure" (bit 4) is set,
+                "Use limited discovery procedure" (bit 2) is excluded.
 
-		This command is used to start discovery.
+                In case of an error, the error response will be returned.
 
-		Observation Procedure allows to receive advertisements
-		(and scan responses) from broadcasters (that are not visible
-		during General or Limited discovery, because those are not
-		discoverable). This procedure can use either passive or active
-		scan type. If "Use observation procedure" (bit 4) is set,
-		"Use limited discovery procedure" (bit 2) is excluded.
+        Opcode 0x0d - Stop Discovery command/response
 
-		In case of an error, the error response will be returned.
+                Controller Index:       <controller id>
+                Command parameters:     <none>
+                Return Parameters:      <none>
 
-	Opcode 0x0d - Stop Discovery command/response
+                This command is used to stop discovery.
 
-		Controller Index:	<controller id>
-		Command parameters:	<none>
-		Return Parameters:	<none>
+                In case of an error, the error response will be returned.
 
-		This command is used to stop discovery.
+        Opcode 0x0e - Connect command/response
 
-		In case of an error, the error response will be returned.
+                Controller Index:       <controller id>
+                Command parameters:     Address_Type (1 octet)
+                                        Address (6 octets)
+                                        Own_Addr_Type (1 octet)
+                Return Parameters:      <none>
 
-	Opcode 0x0e - Connect command/response
+                Valid Own_Addr_Type parameter values:
+                        0x00 = Identity Address
+                        0x01 = Resolvable Private Address
+                        0x02 = Non-resolvabe Private Address
 
-		Controller Index:	<controller id>
-		Command parameters:	Address_Type (1 octet)
-					Address (6 octets)
-					Own_Addr_Type (1 octet)
-		Return Parameters:	<none>
+                This command is used to create a Link Layer connection with
+                remote device.
+                Address '00:00:00:00:00:00' and type '0' will attempt to
+                use address from filter accept list.
 
-		Valid Own_Addr_Type parameter values:
-					0x00 = Identity Address
-					0x01 = Resolvable Private Address
-					0x02 = Non-resolvabe Private Address
+                In case of an error, the error response will be returned.
 
-		This command is used to create a Link Layer connection with
-		remote device.
-		Address '00:00:00:00:00:00' and type '0' will attempt to
-		use address from filter accept list.
+        Opcode 0x0f - Disconnect command/response
 
-		In case of an error, the error response will be returned.
+                Controller Index:       <controller id>
+                Command parameters:     Address_Type (1 octet)
+                                        Address (6 octets)
+                Return Parameters:      <none>
 
-	Opcode 0x0f - Disconnect command/response
+                Valid Address_Type parameter values:
+                        0x00 = Public
+                        0x01 = Random
 
-		Controller Index:	<controller id>
-		Command parameters:	Address_Type (1 octet)
-					Address (6 octets)
-		Return Parameters:	<none>
+                This command is used to terminate an existing connection or
+                to cancel pending connection attempt.
 
-		Valid Address_Type parameter values:
-					0x00 = Public
-					0x01 = Random
+                In case of an error, the error response will be returned.
 
-		This command is used to terminate an existing connection or
-		to cancel pending connection attempt.
+        Opcode 0x10 - Set IO Capability command/response
 
-		In case of an error, the error response will be returned.
+                Controller Index:       <controller id>
+                Command parameters:     IO_Capability (1 octet)
+                Return Parameters:      <none>
 
-	Opcode 0x10 - Set IO Capability command/response
+                Valid IO_Capabilities parameter values:
+                        0x00 = Display Only
+                        0x01 = Display Yes/No
+                        0x02 = Keyboard Only
+                        0x03 = No Input, No Output
+                        0x04 = Keyboard Display
 
-		Controller Index:	<controller id>
-		Command parameters:	IO_Capability (1 octet)
-		Return Parameters:	<none>
+                This command is used to set IO capability.
 
-		Valid IO_Capabilities parameter values:
-					0x00 = Display Only
-					0x01 = Display Yes/No
-					0x02 = Keyboard Only
-					0x03 = No Input, No Output
-					0x04 = Keyboard Display
+                In case of an error, the error response will be returned.
 
-		This command is used to set IO capability.
+        Opcode 0x11 - Pair command/response
 
-		In case of an error, the error response will be returned.
+                Controller Index:       <controller id>
+                Command parameters:     Address_Type (1 octet)
+                                        Address (6 octets)
+                Return Parameters:      <none>
 
-	Opcode 0x11 - Pair command/response
+                This command is used to initiate security with remote. If
+                peer is already paired IUT is expected to enable security
+                (encryption) with peer. If peer is not paired IUT shall
+                start pairing process.
 
-		Controller Index:	<controller id>
-		Command parameters:	Address_Type (1 octet)
-					Address (6 octets)
-		Return Parameters:	<none>
+                In case of an error, the error response will be returned.
 
-		This command is used to initiate security with remote. If
-		peer is already paired IUT is expected to enable security
-		(encryption) with peer. If peer is not paired IUT shall
-		start pairing process.
+        Opcode 0x12 - Unpair command/response
 
-		In case of an error, the error response will be returned.
+                Controller Index:       <controller id>
+                Command parameters:     Address_Type (1 octet)
+                                        Address (6 octets)
+                Return Parameters:      <none>
 
-	Opcode 0x12 - Unpair command/response
+                This command is used to unpair with remote.
 
-		Controller Index:	<controller id>
-		Command parameters:	Address_Type (1 octet)
-					Address (6 octets)
-		Return Parameters:	<none>
+                In case of an error, the error response will be returned.
 
-		This command is used to unpair with remote.
+        Opcode 0x13 - Passkey Entry Response command/response
 
-		In case of an error, the error response will be returned.
+                Controller Index:       <controller id>
+                Command parameters:     Address_Type (1 octet)
+                                        Address (6 octets)
+                                        Passkey (4 octets)
+                Return Parameters:      <none>
 
-	Opcode 0x13 - Passkey Entry Response command/response
+                This command is used to response with passkey for pairing
+                request.
 
-		Controller Index:	<controller id>
-		Command parameters:	Address_Type (1 octet)
-					Address (6 octets)
-					Passkey (4 octets)
-		Return Parameters:	<none>
+                In case of an error, the error response will be returned.
 
-		This command is used to response with passkey for pairing
-		request.
+        Opcode 0x14 - Passkey Confirmation Response command/response
 
-		In case of an error, the error response will be returned.
+                Controller Index:       <controller id>
+                Command parameters:     Address_Type (1 octet)
+                                        Address (6 octets)
+                                        Match (1 octet)
+                Return Parameters:      <none>
 
-	Opcode 0x14 - Passkey Confirmation Response command/response
+                This command is used to response for pairing request with
+                confirmation in accordance with initiator and responder
+                passkey.
 
-		Controller Index:	<controller id>
-		Command parameters:	Address_Type (1 octet)
-					Address (6 octets)
-					Match (1 octet)
-		Return Parameters:	<none>
+                In case of an error, the error response will be returned.
 
-		This command is used to response for pairing request with
-		confirmation in accordance with initiator and responder
-		passkey.
+        Opcode 0x15 - Start Directed advertising command/response
 
-		In case of an error, the error response will be returned.
+                Controller Index:       <controller id>
+                Command parameters:     Directed_address_Type (1 octet)
+                                        Directed_address (6 octets)
+                                        Options (2 octets)
+                Return Parameters:      Current_Settings (4 Octets)
 
-	Opcode 0x15 - Start Directed advertising command/response
+                This command is used to start directed advertising.
 
-		Controller Index:	<controller id>
-		Command parameters:	Directed_address_Type (1 octet)
-					Directed_address (6 octets)
-					Options (2 octets)
-		Return Parameters:	Current_Settings (4 Octets)
+                Available options:
+                bit 0 - High Duty - If set then High Duty cycle is used,
+                        otherwise Low Duty cycle is used for advertising
+                bit 1 - Own ID Address - If set IUT is required to advertise
+                        using ID address even if privacy is enabled
+                bit 2 - Peer RPA Address - If set IUT is expected to use peer
+                        RPA as target address (is supported by peer).
 
-		This command is used to start directed advertising.
+                Possible values for the High duty parameter are:
+                                        0 = Use low duty cycle
+                                        1 = Use high duty cycle
 
-		Available options:
-		bit 0 - High Duty - If set then High Duty cycle is used,
-			otherwise Low Duty cycle is used for advertising
-		bit 1 - Own ID Address - If set IUT is required to advertise
-			using ID address even if privacy is enabled
-		bit 2 - Peer RPA Address - If set IUT is expected to use peer
-			RPA as target address (is supported by peer).
+                In case of an error, the error response will be returned.
 
-		Possible values for the High duty parameter are:
-					0 = Use low duty cycle
-					1 = Use high duty cycle
+        Opcode 0x16 - Connection Parameters Update
 
-		In case of an error, the error response will be returned.
+                Controller Index:       <controller id>
+                Command parameters:     Address_Type (1 octet)
+                                        Address (6 octets)
+                                        Connection Interval Min (2 octets)
+                                        Connection Interval Max (2 octets)
+                                        Connection Latency (2 octets)
+                                        Supervision Timeout (2 octets)
+                Return Parameters:      <none>
 
-	Opcode 0x16 - Connection Parameters Update
+                This command is used to change connection parameters. If current
+                connection parameters do not match with the ones requested then
+                the IUT should send a Connection Parameter Update Request
+                to a peer device.
 
-		Controller Index:	<controller id>
-		Command parameters:	Address_Type (1 octet)
-					Address (6 octets)
-					Connection Interval Min (2 octets)
-					Connection Interval Max (2 octets)
-					Connection Latency (2 octets)
-					Supervision Timeout (2 octets)
-		Return Parameters:	<none>
+                In case of an error, the error response will be returned.
 
-		This command is used to change connection parameters. If current
-		connection parameters do not match with the ones requested then
-		the IUT should send a Connection Parameter Update Request
-		to a peer device.
+        Opcode 0x17 - Pairing Consent Response command/response
 
-		In case of an error, the error response will be returned.
+                Controller Index:       <controller id>
+                Command parameters:     Address_Type (1 octet)
+                                        Address (6 octets)
+                                        Consent (1 octet)
+                Return Parameters:      <none>
 
-	Opcode 0x17 - Pairing Consent Response command/response
+                This command is used to response for Pairing Consent Request event.
 
-		Controller Index:	<controller id>
-		Command parameters:	Address_Type (1 octet)
-					Address (6 octets)
-					Consent (1 octet)
-		Return Parameters:	<none>
+                In case of an error, the error response will be returned.
 
-		This command is used to response for Pairing Consent Request event.
+        Opcode 0x18 - OOB Legacy Set Data command/response
 
-		In case of an error, the error response will be returned.
+                Controller Index:       <controller id>
+                Command parameters:     OOB_data (16 octets)
+                Return Parameters:      <none>
 
-	Opcode 0x18 - OOB Legacy Set Data command/response
+                This command is used to set legacy OOB data.
 
-		Controller Index:	<controller id>
-		Command parameters:	OOB_data (16 octets)
-		Return Parameters:	<none>
+                In case of an error, the error response will be returned.
 
-		This command is used to set legacy OOB data.
+        Opcode 0x19 - OOB SC Get Local Data command/response
 
-		In case of an error, the error response will be returned.
+                Controller Index:       <controller id>
+                Command parameters:     <none>
+                Return Parameters:      Rand (16 octets)
+                                    Conf (16 octets)
 
-	Opcode 0x19 - OOB SC Get Local Data command/response
+                This command is used to get local OOB Secure Connections data.
 
-		Controller Index:	<controller id>
-		Command parameters:	<none>
-		Return Parameters:	Rand (16 octets)
-		                    Conf (16 octets)
+                In case of an error, the error response will be returned.
 
-		This command is used to get local OOB Secure Connections data.
+        Opcode 0x1a - OOB SC Set Remote Data command/response
 
-		In case of an error, the error response will be returned.
+                Controller Index:       <controller id>
+                Command parameters:      Rand (16 octets)
+                                     Conf (16 octets)
+                Return Parameters:      <none>
 
-	Opcode 0x1a - OOB SC Set Remote Data command/response
+                This command is used to set remote OOB Secure Connections data.
 
-		Controller Index:	<controller id>
-		Command parameters:	 Rand (16 octets)
-		                     Conf (16 octets)
-		Return Parameters:	<none>
+                In case of an error, the error response will be returned.
 
-		This command is used to set remote OOB Secure Connections data.
+        Opcode 0x1b - Set MITM command/response
 
-		In case of an error, the error response will be returned.
+                Controller Index:       <controller id>
+                Command parameters:      mitm (1 octet)
+                Return Parameters:      <none>
 
-	Opcode 0x1b - Set MITM command/response
+                This command is used to set MITM setting.
 
-		Controller Index:	<controller id>
-		Command parameters:	 mitm (1 octet)
-		Return Parameters:	<none>
+                In case of an error, the error response will be returned.
 
-		This command is used to set MITM setting.
+        Opcode 0x1c - Set filter accept list command/response
 
-		In case of an error, the error response will be returned.
+                Controller Index: <controller id>
 
-	Opcode 0x1c - Set filter accept list command/response
+                Command parameters:     Type_Addr_Count (1 octet)
+                                        [array] Type_Addr
 
-		Controller Index: <controller id>
+                Object Type_Addr is defined as:
+                        Address_Type (1 octet)
+                        Address (6 octets)
 
-		Command parameters:	Type_Addr_Count (1 octet)
-					[array] Type_Addr
+                This command is used to set filter accept list.
+                When set, connect with address: '00:00:00:00:00:00'
+                and type '0' to use addresses from the list.
 
-		Object Type_Addr is defined as:
-					Address_Type (1 octet)
-					Address (6 octets)
+                In case of an error, the error response will be returned.
 
-		This command is used to set filter accept list.
-		When set, connect with address: '00:00:00:00:00:00'
-		and type '0' to use addresses from the list.
+        Opcode 0x1d - Set Privacy command/response
 
-		In case of an error, the error response will be returned.
+                Controller Index:       <controller id>
+                Command parameters:      Privacy_Setting (1 octet)
+                Response parameters:    Current_Settings (4 Octets)
 
-	Opcode 0x1d - Set Privacy command/response
+                Valid Privacy_Setting values:
+                        0x00 = Off
+                        0x01 = On
 
-		Controller Index:	<controller id>
-		Command parameters:	 Privacy_Setting (1 octet)
-		Response parameters:	Current_Settings (4 Octets)
+                This command is used to set Privacy setting. This command
+                is designed for systems that allow to change privacy setting
+                during runtime of the system.
 
-		Valid Privacy_Setting values:	0x00 = Off
-						0x01 = On
+                In case of an error, the error response will be returned.
 
-		This command is used to set Privacy setting. This command
-		is designed for systems that allow to change privacy setting
-		during runtime of the system.
+        Opcode 0x1e - Set SC Only command/response
 
-		In case of an error, the error response will be returned.
+                Controller Index:       <controller id>
+                Command parameters:      SC_Only_Setting (1 octet)
+                Response parameters:    Current_Settings (4 Octets)
 
-	Opcode 0x1e - Set SC Only command/response
+                Valid SC_Only_Setting values:
+                        0x00 = Off
+                        0x01 = On
 
-		Controller Index:	<controller id>
-		Command parameters:	 SC_Only_Setting (1 octet)
-		Response parameters:	Current_Settings (4 Octets)
+                This command is used to set SC Only setting. This command
+                is designed for systems that allow to change SC Only setting
+                during runtime of the system.
 
-		Valid SC_Only_Setting values:	0x00 = Off
-						0x01 = On
+                In case of an error, the error response will be returned.
 
-		This command is used to set SC Only setting. This command
-		is designed for systems that allow to change SC Only setting
-		during runtime of the system.
+        Opcode 0x1f - Set Secure Connections command/response
 
-		In case of an error, the error response will be returned.
+                Controller Index:       <controller id>
+                Command parameters:      SC_Setting (1 octet)
+                Response parameters:    Current_Settings (4 Octets)
 
-	Opcode 0x1f - Set Secure Connections command/response
+                Valid SC_Only_Setting values:
+                        0x00 = Disable
+                        0x01 = Enable
 
-		Controller Index:	<controller id>
-		Command parameters:	 SC_Setting (1 octet)
-		Response parameters:	Current_Settings (4 Octets)
+                This command is used to enable/disable Secure Connections setting.
+                This command is designed for systems that allow to change Secure
+                Connections setting during runtime of the system.
 
-		Valid SC_Only_Setting values:	0x00 = Disable
-						0x01 = Enable
+                In case of an error, the error response will be returned.
 
-		This command is used to enable/disable Secure Connections setting.
-		This command is designed for systems that allow to change Secure
-		Connections setting during runtime of the system.
+        Opcode 0x20 - Set Minimum Encryption Key Size command/response
 
-		In case of an error, the error response will be returned.
+                Controller Index:       <controller id>
+                Command parameters:     Encryption_Key_Size (1 octet)
+                Response parameters:    <none>
 
-	Opcode 0x20 - Set Minimum Encryption Key Size command/response
+                This command is used to set minimum Encryption Key Size for
+                security procedure.
 
-		Controller Index:	<controller id>
-		Command parameters:	Encryption_Key_Size (1 octet)
-		Response parameters:	<none>
+                Possible values for Encryption_Key_Size parameter are:
+                        <0x07, 0x0f>
 
-		This command is used to set minimum Encryption Key Size for
-		security procedure.
+                In case of an error, the error response will be returned.
 
-		Possible values for Encryption_Key_Size parameter are:
-								<0x07, 0x0f>
+        Opcode 0x21 - Set Extended Advertising command/response
 
-		In case of an error, the error response will be returned.
+                Controller Index:       <controller id>
+                Command parameter:      Extended_Advertising_Setting (1 Octet)
+                Response parameters:    Current_Settings (4 Octets)
 
-	Opcode 0x21 - Set Extended Advertising command/response
+                Valid Extended_Advertising_Setting:
+                        0x00 = Disable
+                        0x01 = Enable
 
-		Controller Index:	<controller id>
-		Command parameter:	Extended_Advertising_Setting (1 Octet)
-		Response parameters:	Current_Settings (4 Octets)
+                This command is used to enable/disable Extended Advertising when
+                Start/Stop Advertising is used.
 
-		Valid Extended_Advertising_Setting: 	0x00 = Disable
-							0x01 = Enable
+                In case of an error, the error response will be returned.
 
-		This command is used to enable/disable Extended Advertising when
-		Start/Stop Advertising is used.
 
-		In case of an error, the error response will be returned.
+        Opcode 0x22 - Configure Periodic Advertising command/response
 
+                Controller Index:       <controller id>
+                Command parameters:     Flags (1 octet)
+                                        Interval Min (2 octets)
+                                        Interval Max (2 octets)
+                Return Parameters:      Current_Settings (4 Octets)
 
-	Opcode 0x22 - Configure Periodic Advertising command/response
+                This command is used to configure Periodic Advertising instance.
+                IUT is expected to have 1 Periodic Advertising instance.
 
-		Controller Index:	<controller id>
-		Command parameters:	 Flags (1 octet)
-							 Interval Min (2 octets)
-							 Interval Max (2 octets)
-		Return Parameters:	Current_Settings (4 Octets)
+                Possible values for the Flags parameter are a bit-wise OR
+                of the following bits:
+                        0 = Include TX Power
 
-		This command is used to configure Periodic Advertising instance.
-		IUT is expected to have 1 Periodic Advertising instance.
+                In case of an error, the error response will be returned.
 
-		Possible values for the Flags parameter are a bit-wise OR
-		of the following bits:
-					0 = Include TX Power
+        Opcode 0x23 - Periodic Advertising Start command/response
 
-		In case of an error, the error response will be returned.
+                Controller Index:       <controller id>
+                Command parameters:     Flags (1 octet)
+                Return Parameters:      Current_Settings (4 Octets)
 
-	Opcode 0x23 - Periodic Advertising Start command/response
+                This command is used to start advertising on Periodic Advertising
+                instance.
 
-		Controller Index:	<controller id>
-		Command parameters:	Flags (1 octet)
-		Return Parameters:	Current_Settings (4 Octets)
+                Flags are reserved for future use.
 
-		This command is used to start advertising on Periodic Advertising
-		instance.
+                In case of an error, the error response will be returned.
 
-		Flags are reserved for future use.
+        Opcode 0x24 - Periodic Advertising Stop command/response
 
-		In case of an error, the error response will be returned.
+                Controller Index:       <controller id>
+                Command parameters:     <none>
+                Return Parameters:      Current_Settings (4 Octets)
 
-	Opcode 0x24 - Periodic Advertising Stop command/response
+                This command is used to stop advertising on Periodic Advertising
+                instance.
 
-		Controller Index:	<controller id>
-		Command parameters:	<none>
-		Return Parameters:	Current_Settings (4 Octets)
+                In case of an error, the error response will be returned.
 
-		This command is used to stop advertising on Periodic Advertising
-		instance.
+        Opcode 0x25 - Periodic Advertising Set Advertising Data command/response
 
-		In case of an error, the error response will be returned.
+                Controller Index:       <controller id>
+                Command parameters:     Advertising data length (2 octets)
+                                        [array] Advertising data
+                Return Parameters:      <none>
 
-	Opcode 0x25 - Periodic Advertising Set Advertising Data command/response
+                This command is used to set advertising data for Periodic Advertising
+                instance. Data is an array of tuples in form of
+                (data length, Ad Type, data),
 
-		Controller Index:	<controller id>
-		Command parameters:	Advertising data length (2 octets)
-					[array] Advertising data
-		Return Parameters:	<none>
+                In case of an error, the error response will be returned.
 
-		This command is used to set advertising data for Periodic Advertising
-		instance. Data is an array of tuples in form of
-		(data length, Ad Type, data),
+        Opcode 0x26 - Create Periodic Advertising Sync command/response
 
-		In case of an error, the error response will be returned.
+                Controller Index:       <controller id>
+                Command parameters:     Address_Type (1 octet)
+                                        Address (6 octets)
+                                        Advertiser Set ID (1 octet)
+                                        Skip (2 octets)
+                                        Synchronization Timeout (2 octets)
+                                        Flags (1 octet)
+                Return Parameters:      <none>
 
-	Opcode 0x26 - Create Periodic Advertising Sync command/response
+                This command is used to perform Synchronization procedure with
+                periodic advertiser. Skip determines maximum number of periodic
+                advertising events that controller can skip after a successful
+                reception. Synchronization Timeout is in 10 ms units. Reports Disabled
+                determines if sync creation will lead to IUT sending reports.
 
-		Controller Index:	<controller id>
-		Command parameters:	Address_Type (1 octet)
-							Address (6 octets)
-							Advertiser Set ID (1 octet)
-							Skip (2 octets)
-							Synchronization Timeout (2 octets)
-							Flags (1 octet)
-		Return Parameters:	<none>
+                Possible values for the Flags parameter are a bit-wise OR
+                of the following bits:
+                        0 = Reports Disabled
+                        1 = Duplicate filtering enabled
 
-		This command is used to perform Synchronization procedure with
-		periodic advertiser. Skip determines maximum number of periodic
-		advertising events that controller can skip after a successful
-		reception. Synchronization Timeout is in 10 ms units. Reports Disabled
-		determines if sync creation will lead to IUT sending reports.
+                In case of an error, the error response will be returned.
 
-		Possible values for the Flags parameter are a bit-wise OR
-		of the following bits:
-					0 = Reports Disabled
-					1 = Duplicate filtering enabled
+        Opcode 0x27 - Periodic Advertising Set Transfer Info command/response
 
-		In case of an error, the error response will be returned.
+                Controller Index:       <controller id>
+                Command parameters:     Address Type (1 octet)
+                                        Address (6 octets)
+                                        Service Data (2 octets)
+                Return Parameters:      <none>
 
-	Opcode 0x27 - Periodic Advertising Set Transfer Info command/response
+                This command is used to initialize set info transfer procedure to peer
+                given by address.
 
-		Controller Index:	<controller id>
-		Command parameters:	Address Type (1 octet)
-							Address (6 octets)
-							Service Data (2 octets)
-		Return Parameters:	<none>
+                In case of an error, the error response will be returned.
 
-		This command is used to initialize set info transfer procedure to peer
-		given by address.
+        Opcode 0x28 - Periodic Advertising Transfer Start command/response
 
-		In case of an error, the error response will be returned.
+                Controller Index:       <controller id>
+                Command parameters:     Sync Handle (2 octets)
+                                        Address Type (1 octet)
+                                        Address (6 octets)
+                                        Service Data (2 octets)
+                Return Parameters:      <none>
 
-	Opcode 0x28 - Periodic Advertising Transfer Start command/response
+                This command is used to initialize periodic transfer procedure to peer
+                given by address. It is used to transfer periodic sync information
+                to synchronization identified by handle.
 
-		Controller Index:	<controller id>
-		Command parameters:	Sync Handle (2 octets)
-							Address Type (1 octet)
-							Address (6 octets)
-							Service Data (2 octets)
-		Return Parameters:	<none>
+                In case of an error, the error response will be returned.
 
-		This command is used to initialize periodic transfer procedure to peer
-		given by address. It is used to transfer periodic sync information
-		to synchronization identified by handle.
+        Opcode 0x29 - Periodic Advertising Transfer Receive command/response
 
-		In case of an error, the error response will be returned.
+                Controller Index:       <controller id>
+                Command parameters:     Address Type (1 octet)
+                                        Address (6 octets)
+                                        Skip (2 octets)
+                                        Sync timeout (2 octets)
+                                        Flags (1 octet)
+                Return Parameters:      <none>
 
-	Opcode 0x29 - Periodic Advertising Transfer Receive command/response
+                This command is used to enable reception of sync information on
+                specified connection.
 
-		Controller Index:	<controller id>
-		Command parameters: Address Type (1 octet)
-							Address (6 octets)
-							Skip (2 octets)
-							Sync timeout (2 octets)
-							Flags (1 octet)
-		Return Parameters:	<none>
+                Possible values for the Flags parameter are a bit-wise OR
+                of the following bits:
+                        0 = Reports Disabled
 
-		This command is used to enable reception of sync information on
-		specified connection.
-
-		Possible values for the Flags parameter are a bit-wise OR
-		of the following bits:
-					0 = Reports Disabled
-
-		In case of an error, the error response will be returned.
+                In case of an error, the error response will be returned.
 
         Opcode 0x30 - Set RPA Timeout command/response
 
@@ -649,188 +657,188 @@ Commands and responses:
                 In case of an error, the error response will be returned.
 
 Events:
-	Opcode 0x80 - New Settings event
+        Opcode 0x80 - New Settings event
 
-		Controller Index:	<controller id>
-		Event parameters:	Current_Settings (4 octets)
+                Controller Index:       <controller id>
+                Event parameters:       Current_Settings (4 octets)
 
-		This event indicates that one or more of the settings for a
-		controller has changed.
+                This event indicates that one or more of the settings for a
+                controller has changed.
 
-	Opcode 0x81 - Device Found event
+        Opcode 0x81 - Device Found event
 
-		Controller Index:	<controller id>
-		Event parameters:	Address_Type (1 octet)
-					Address (6 octets)
-					RSSI (1 octet)
-					Flags (1 octet)
-					EIR_Data_Length (2 Octets)
-					EIR_Data (0-65535 Octets)
+                Controller Index:       <controller id>
+                Event parameters:       Address_Type (1 octet)
+                                        Address (6 octets)
+                                        RSSI (1 octet)
+                                        Flags (1 octet)
+                                        EIR_Data_Length (2 Octets)
+                                        EIR_Data (0-65535 Octets)
 
-		Possible values for the Flags parameter are a bit-wise or
-		of the following bits:
-					0 = RSSI valid
-					1 = Adv_Data included
-					2 = Scan_Rsp included
+                Possible values for the Flags parameter are a bit-wise or
+                of the following bits:
+                        0 = RSSI valid
+                        1 = Adv_Data included
+                        2 = Scan_Rsp included
 
-		This event indicates that a device was found during device
-		discovery.
+                This event indicates that a device was found during device
+                discovery.
 
-	Opcode 0x82 - Device Connected event
+        Opcode 0x82 - Device Connected event
 
-		Controller Index:	<controller id>
-		Event parameters:	Address_Type (1 octet)
-					Address (6 octets)
-					Connection Interval (2 octets)
-					Connection Latency (2 octets)
-					Supervision Timeout (2 octets)
+                Controller Index:       <controller id>
+                Event parameters:       Address_Type (1 octet)
+                                        Address (6 octets)
+                                        Connection Interval (2 octets)
+                                        Connection Latency (2 octets)
+                                        Supervision Timeout (2 octets)
 
-		This event indicates that a device was connected.
+                This event indicates that a device was connected.
 
-	Opcode 0x83 - Device Disconnected event
+        Opcode 0x83 - Device Disconnected event
 
-		Controller Index:	<controller id>
-		Event parameters:	Address_Type (1 octet)
-					Address (6 octets)
+                Controller Index:       <controller id>
+                Event parameters:       Address_Type (1 octet)
+                                        Address (6 octets)
 
-		This event indicates that a device was disconnected.
+                This event indicates that a device was disconnected.
 
-	Opcode 0x84 - Passkey Display event
+        Opcode 0x84 - Passkey Display event
 
-		Controller Index:	<controller id>
-		Event parameters:	Address_Type (1 octet)
-					Address (6 octets)
-					Passkey (4 octets)
+                Controller Index:       <controller id>
+                Event parameters:       Address_Type (1 octet)
+                                        Address (6 octets)
+                                        Passkey (4 octets)
 
-		This event indicates that passkey was received and it needs to
-		be confirmed on remote side.
+                This event indicates that passkey was received and it needs to
+                be confirmed on remote side.
 
-	Opcode 0x85 - Passkey Enter Request event
+        Opcode 0x85 - Passkey Enter Request event
 
-		Controller Index:	<controller id>
-		Event parameters:	Address_Type (1 octet)
-					Address (6 octets)
+                Controller Index:       <controller id>
+                Event parameters:       Address_Type (1 octet)
+                                        Address (6 octets)
 
-		This event indicates that remote requests for passkey enter.
+                This event indicates that remote requests for passkey enter.
 
-	Opcode 0x86 - Passkey Confirm Request event
+        Opcode 0x86 - Passkey Confirm Request event
 
-		Controller Index:	<controller id>
-		Event parameters:	Address_Type (1 octet)
-					Address (6 octets)
-					Passkey (4 octets)
+                Controller Index:       <controller id>
+                Event parameters:       Address_Type (1 octet)
+                                        Address (6 octets)
+                                        Passkey (4 octets)
 
-		This event indicates that passkey needs to be confirmed.
+                This event indicates that passkey needs to be confirmed.
 
-	Opcode 0x87 - Identity Resolved event
+        Opcode 0x87 - Identity Resolved event
 
-		Controller Index:	<controller id>
-		Event parameters:	Address_Type (1 octet)
-					Address (6 octets)
-					Identity_Address_Type (1 octet)
-					Identity_Address (6 octets)
+                Controller Index:       <controller id>
+                Event parameters:       Address_Type (1 octet)
+                                        Address (6 octets)
+                                        Identity_Address_Type (1 octet)
+                                        Identity_Address (6 octets)
 
-		This event indicates that the remote Identity Address has been
-		resolved.
+                This event indicates that the remote Identity Address has been
+                resolved.
 
-	Opcode 0x88 - Connection Parameters Update event
+        Opcode 0x88 - Connection Parameters Update event
 
-		Controller Index:	<controller id>
-		Event parameters:	Address_Type (1 octet)
-					Address (6 octets)
-					Connection Interval (2 octets)
-					Connection Latency (2 octets)
-					Supervision Timeout (2 octets)
+                Controller Index:       <controller id>
+                Event parameters:       Address_Type (1 octet)
+                                        Address (6 octets)
+                                        Connection Interval (2 octets)
+                                        Connection Latency (2 octets)
+                                        Supervision Timeout (2 octets)
 
-		This event can be sent when the connection parameters have changed.
+                This event can be sent when the connection parameters have changed.
 
-	Opcode 0x89 - Security Level Changed event
+        Opcode 0x89 - Security Level Changed event
 
-		Controller Index:	<controller id>
-		Event parameters:	Address_Type (1 octet)
-					Address (6 octets)
-					Security Level (1 octet)
+                Controller Index:       <controller id>
+                Event parameters:       Address_Type (1 octet)
+                                        Address (6 octets)
+                                        Security Level (1 octet)
 
-		Possible values for the Security Level parameter map to those
-		defined in Core Specification in LE security mode 1:
-					1 = Unauthenticated pairing with encryption
-					2 = Authenticated pairing with encryption
-					3 = Authenticated LE Secure Connections pairing
-					with encryption using a 128-bit strength encryption key
+                Possible values for the Security Level parameter map to those
+                defined in Core Specification in LE security mode 1:
+                        1 = Unauthenticated pairing with encryption
+                        2 = Authenticated pairing with encryption
+                        3 = Authenticated LE Secure Connections pairing
+                        with encryption using a 128-bit strength encryption key
 
-		This event can be sent when the Security Level has changed.
+                This event can be sent when the Security Level has changed.
 
-	Opcode 0x8a - Pairing Consent Request event
+        Opcode 0x8a - Pairing Consent Request event
 
-		Controller Index:	<controller id>
-		Event parameters:	Address_Type (1 octet)
-					Address (6 octets)
+                Controller Index:       <controller id>
+                Event parameters:       Address_Type (1 octet)
+                                        Address (6 octets)
 
-		This event can be sent when the IUT requires a pairing consent
-		from the user.
+                This event can be sent when the IUT requires a pairing consent
+                from the user.
 
-	Opcode 0x8b - Bond Lost event
+        Opcode 0x8b - Bond Lost event
 
-		Controller Index:	<controller id>
-		Event parameters:	Address_Type (1 octet)
-							Address (6 octets)
+                Controller Index:       <controller id>
+                Event parameters:       Address_Type (1 octet)
+                                        Address (6 octets)
 
-		This event can be sent when IUT lost a bond with a peer device.
+                This event can be sent when IUT lost a bond with a peer device.
 
-	Opcode 0x8c - Pairing Failed event
+        Opcode 0x8c - Pairing Failed event
 
-		Controller Index:	<controller id>
-		Event parameters:	Address_Type (1 octet)
-							Address (6 octets)
-							Reason (1 octet)
+                Controller Index:       <controller id>
+                Event parameters:       Address_Type (1 octet)
+                                        Address (6 octets)
+                                        Reason (1 octet)
 
-		This event can be sent when IUT pairing procedure fails with
-		specified reason.
+                This event can be sent when IUT pairing procedure fails with
+                specified reason.
 
 
-	Opcode 0x8d - Periodic Sync Established event
+        Opcode 0x8d - Periodic Sync Established event
 
-		Controller Index:	<controller id>
-		Event parameters:	Address_Type (1 octet)
-							Address (6 octets)
-							Sync Handle (2 octets)
-							Status (1 octet)
+                Controller Index:       <controller id>
+                Event parameters:       Address_Type (1 octet)
+                                        Address (6 octets)
+                                        Sync Handle (2 octets)
+                                        Status (1 octet)
 
-		This event can be sent when sync is established with Periodic Advertiser.
-		Address in event is address of a peer that sync was established with.
+                This event can be sent when sync is established with Periodic Advertiser.
+                Address in event is address of a peer that sync was established with.
 
-	Opcode 0x8e - Periodic Sync Lost event
+        Opcode 0x8e - Periodic Sync Lost event
 
-		Controller Index:	<controller id>
-		Event parameters:	Sync Handle (2 octet)
-							Reason (1 octets)
+                Controller Index:       <controller id>
+                Event parameters:       Sync Handle (2 octet)
+                                        Reason (1 octets)
 
-		This event can be sent lost sync with Periodic Advertiser
+                This event can be sent lost sync with Periodic Advertiser
 
-	Opcode 0x8f - Periodic Report event
+        Opcode 0x8f - Periodic Report event
 
-		Controller Index:	<controller id>
-		Event parameters:	Sync Handle (2 octet)
-							TX_Power (1 octet)
-							RSSI (1 octet)
-							CTE Type (1 octet)
-							Data Status (1 octet)
-							Data Length (1 octet)
-							Data (variable)
+                Controller Index:       <controller id>
+                Event parameters:       Sync Handle (2 octet)
+                                        TX_Power (1 octet)
+                                        RSSI (1 octet)
+                                        CTE Type (1 octet)
+                                        Data Status (1 octet)
+                                        Data Length (1 octet)
+                                        Data (variable)
 
-		This event can be sent after IUT received Periodic Advertising report
-		on established sync.
+                This event can be sent after IUT received Periodic Advertising report
+                on established sync.
 
-	Opcode 0x90 - Periodic Transfer Received event
+        Opcode 0x90 - Periodic Transfer Received event
 
-		Controller Index:	<controller id>
-		Event parameters:	Sync Handle (2 octet)
-							TX_Power (1 octet)
-							RSSI (1 octet)
-							CTE Type (1 octet)
-							Data Status (1 octet)
-							Data Length (1 octet)
-							Data (variable)
+                Controller Index:       <controller id>
+                Event parameters:       Sync Handle (2 octet)
+                                        TX_Power (1 octet)
+                                        RSSI (1 octet)
+                                        CTE Type (1 octet)
+                                        Data Status (1 octet)
+                                        Data Length (1 octet)
+                                        Data (variable)
 
-		This event can be sent after IUT received Periodic Advertising Sync
-		Transfer was received.
+                This event can be sent after IUT received Periodic Advertising Sync
+                Transfer was received.

--- a/doc/btp_gatt.txt
+++ b/doc/btp_gatt.txt
@@ -3,729 +3,729 @@ GATT Service (ID 2, DEPRECATED)
 
 Commands and responses:
 
-	Opcode 0x00 - Error response
-
-	Opcode 0x01 - Read Supported Commands command/response
-
-		Controller Index:	<non-controller>
-		Command parameters:	<none>
-		Response parameters:	<supported commands> (variable)
-
-		Each bit in response is a flag indicating if command with
-		opcode matching bit number is supported. Bit set to 1 means
-		that command is supported. Bit 0 is reserved and shall always
-		be set to 0. If specific bit is not present in response (less
-		than required bytes received) it shall be assumed that command
-		is not supported.
-
-		In case of an error, the error response will be returned.
-
-	Opcode 0x02 - Add Service
-
-		Controller Index:	<controller id>
-		Command parameters:	Type (1 octet)
-					UUID_Length (1 octet)
-					UUID (2 or 16 octets)
-		Response parameters:	Service_ID (2 octets)
-
-		Valid Type parameter values:
-					0x00 = Primary
-					0x01 = Secondary
-
-		Valid UUID_Length parameter values:
-					0x02 = UUID16
-					0x10 = UUID128
-
-		This command is used to add new service to GATT Server.
-		Service ID of service declaration is returned in the response.
-		Attribute database shall be initiated sequentially.
-		After this issuing this command tester shall add characteristics
-		or included services this service contains.
-
-		In case of an error, the error response will be returned.
-
-	Opcode 0x03 - Add Characteristic
-
-		Controller Index:	<controller id>
-		Command parameters:	Service_ID (2 octets)
-					Properties (1 octet)
-					Permissions (1 octet)
-					UUID_Length (1 octet)
-					UUID (2 or 16 octets)
-		Response parameters:	Characteristic_ID (2 octets)
-
-		Possible values for Service_ID:
-					0x0000 = Add in sequence
-					0x0001-0xffff = Add to service
-
-		Possible response parameters:
-					0x0000 = Relative ID, will be set after
-					start_server
-					0x0001-0xffff = ID in db
-
-		Possible values for the Properties parameter are a bit-wise
-		of the following bits:
-
-			0	Broadcast
-			1	Read
-			2	Write Without Response
-			3	Write
-			4	Notify
-			5	Indicate
-			6	Authenticated Signed Writes
-			7	Extended Properties
+        Opcode 0x00 - Error response
+
+        Opcode 0x01 - Read Supported Commands command/response
+
+                Controller Index:       <non-controller>
+                Command parameters:     <none>
+                Response parameters:    <supported commands> (variable)
+
+                Each bit in response is a flag indicating if command with
+                opcode matching bit number is supported. Bit set to 1 means
+                that command is supported. Bit 0 is reserved and shall always
+                be set to 0. If specific bit is not present in response (less
+                than required bytes received) it shall be assumed that command
+                is not supported.
+
+                In case of an error, the error response will be returned.
+
+        Opcode 0x02 - Add Service
+
+                Controller Index:       <controller id>
+                Command parameters:     Type (1 octet)
+                                        UUID_Length (1 octet)
+                                        UUID (2 or 16 octets)
+                Response parameters:    Service_ID (2 octets)
+
+                Valid Type parameter values:
+                                        0x00 = Primary
+                                        0x01 = Secondary
+
+                Valid UUID_Length parameter values:
+                                        0x02 = UUID16
+                                        0x10 = UUID128
+
+                This command is used to add new service to GATT Server.
+                Service ID of service declaration is returned in the response.
+                Attribute database shall be initiated sequentially.
+                After this issuing this command tester shall add characteristics
+                or included services this service contains.
+
+                In case of an error, the error response will be returned.
+
+        Opcode 0x03 - Add Characteristic
+
+                Controller Index:       <controller id>
+                Command parameters:     Service_ID (2 octets)
+                                        Properties (1 octet)
+                                        Permissions (1 octet)
+                                        UUID_Length (1 octet)
+                                        UUID (2 or 16 octets)
+                Response parameters:    Characteristic_ID (2 octets)
+
+                Possible values for Service_ID:
+                                        0x0000 = Add in sequence
+                                        0x0001-0xffff = Add to service
+
+                Possible response parameters:
+                                        0x0000 = Relative ID, will be set after
+                                        start_server
+                                        0x0001-0xffff = ID in db
+
+                Possible values for the Properties parameter are a bit-wise
+                of the following bits:
+
+                        0       Broadcast
+                        1       Read
+                        2       Write Without Response
+                        3       Write
+                        4       Notify
+                        5       Indicate
+                        6       Authenticated Signed Writes
+                        7       Extended Properties
 
-		Possible values for the Permissions parameter are a bit-wise
-		of the following bits:
+                Possible values for the Permissions parameter are a bit-wise
+                of the following bits:
 
-			0	Read
-			1	Write
-			2	Read with Encryption
-			3	Write with Encryption
-			4	Read with Authentication
-			5	Write with Authentication
-			6	Read with Authorization
-			7	Write with Authorization
+                        0       Read
+                        1       Write
+                        2       Read with Encryption
+                        3       Write with Encryption
+                        4       Read with Authentication
+                        5       Write with Authentication
+                        6       Read with Authorization
+                        7       Write with Authorization
 
-		This command is used to add new characteristic to GATT Server.
-		Characteristic ID of characteristic declaration is returned in
-		the response.
-		Attribute's database shall be initiated sequentially.
-		After issuing this command tester can add descriptors to this
-		characteristic.
-
-		In case of an error, the error response will be returned.
+                This command is used to add new characteristic to GATT Server.
+                Characteristic ID of characteristic declaration is returned in
+                the response.
+                Attribute's database shall be initiated sequentially.
+                After issuing this command tester can add descriptors to this
+                characteristic.
+
+                In case of an error, the error response will be returned.
 
-	Opcode 0x04 - Add Descriptor
+        Opcode 0x04 - Add Descriptor
 
-		Controller Index:	<controller id>
-		Command parameters:	Characteristic_ID (2 octets)
-					Permissions (1 octet)
-					UUID_Length (1 octet)
-					UUID (2 or 16 octets)
-		Response parameters:	Descriptor_ID (2 octets)
+                Controller Index:       <controller id>
+                Command parameters:     Characteristic_ID (2 octets)
+                                        Permissions (1 octet)
+                                        UUID_Length (1 octet)
+                                        UUID (2 or 16 octets)
+                Response parameters:    Descriptor_ID (2 octets)
 
-		Possible values for Characteristic_ID:
-					0x0000 = Add in sequence
-					0x0001-0xffff = Add to characteristic
+                Possible values for Characteristic_ID:
+                                        0x0000 = Add in sequence
+                                        0x0001-0xffff = Add to characteristic
 
-		Possible response parameters:
-					0x0000 = Relative ID, will be set after
-					start_server
-					0x0001-0xffff = ID in db
+                Possible response parameters:
+                                        0x0000 = Relative ID, will be set after
+                                        start_server
+                                        0x0001-0xffff = ID in db
 
-		This command is used to add new characteristic descriptor
-		to GATT Server. The command shall be used right after
-		Add Characteristic or previous Add Descriptor command.
+                This command is used to add new characteristic descriptor
+                to GATT Server. The command shall be used right after
+                Add Characteristic or previous Add Descriptor command.
 
-		In case of an error, the error response will be returned.
+                In case of an error, the error response will be returned.
 
-	Opcode 0x05 - Add Included Service
+        Opcode 0x05 - Add Included Service
 
-		Controller Index:	<controller id>
-		Command parameters:	Service_ID (2 octets)
-		Response parameters:	Included_Service_ID (2 octets)
+                Controller Index:       <controller id>
+                Command parameters:     Service_ID (2 octets)
+                Response parameters:    Included_Service_ID (2 octets)
 
-		This command is used to add new included service declaration
-		to GATT Server. Service that is going to be included has to be
-		already added to the server. Attribute_ID of include
-		declaration is returned in the response.
+                This command is used to add new included service declaration
+                to GATT Server. Service that is going to be included has to be
+                already added to the server. Attribute_ID of include
+                declaration is returned in the response.
 
-		In case of an error, the error response will be returned.
+                In case of an error, the error response will be returned.
 
-	Opcode 0x06 - Set Characteristic/Descriptor Value
+        Opcode 0x06 - Set Characteristic/Descriptor Value
 
-		Controller Index:	<controller id>
-		Command parameters:	Attribute_ID (2 octets)
-					Value_Length (2 octet)
-					Value (1-512 octets)
-		Response parameters:	<none>
+                Controller Index:       <controller id>
+                Command parameters:     Attribute_ID (2 octets)
+                                        Value_Length (2 octet)
+                                        Value (1-512 octets)
+                Response parameters:    <none>
 
-		Possible values for Characteristic_ID:
-					0x0000 = Set last attribute in db value
-					0x0001-0xffff = Set value of attribute
-					under ID
+                Possible values for Characteristic_ID:
+                                        0x0000 = Set last attribute in db value
+                                        0x0001-0xffff = Set value of attribute
+                                        under ID
 
-		This command is used to set the value of characteristic
-		or descriptor.
+                This command is used to set the value of characteristic
+                or descriptor.
 
-		In case of an error, the error response will be returned.
+                In case of an error, the error response will be returned.
 
-	Opcode 0x07 - Start Server
+        Opcode 0x07 - Start Server
 
-		Controller Index:	<controller id>
-		Command parameters:	<none>
-		Response parameters:	Database_Attribute_Offset (2 octets)
-					Database_Attribute_Count (1 octet)
+                Controller Index:       <controller id>
+                Command parameters:     <none>
+                Response parameters:    Database_Attribute_Offset (2 octets)
+                                        Database_Attribute_Count (1 octet)
 
-		This command is used to start server with previously prepared
-		attributes database. Device database may contain predefined
-		attributes. Predefined attributes should be registered before
-		attempt to register sequential database.
-		Subsequent calls of this command shall return an error.
+                This command is used to start server with previously prepared
+                attributes database. Device database may contain predefined
+                attributes. Predefined attributes should be registered before
+                attempt to register sequential database.
+                Subsequent calls of this command shall return an error.
 
-		In case of an error, the error response will be returned.
+                In case of an error, the error response will be returned.
 
-	Opcode 0x08 - Reset Server
+        Opcode 0x08 - Reset Server
 
-		Controller Index:	<controller id>
-		Command parameters:	<none>
-		Response parameters:	<none>
+                Controller Index:       <controller id>
+                Command parameters:     <none>
+                Response parameters:    <none>
 
-		This command is used to clear the server from attributes.
+                This command is used to clear the server from attributes.
 
-		In case of an error, the error response will be returned.
+                In case of an error, the error response will be returned.
 
-	Opcode 0x09 - Set Required Encryption Key Size
+        Opcode 0x09 - Set Required Encryption Key Size
 
-		Controller Index:	<controller id>
-		Command parameters:	Attribute_ID (2 octets)
-					Encryption_Key_Size (1 octet)
-		Response parameters:	<none>
+                Controller Index:       <controller id>
+                Command parameters:     Attribute_ID (2 octets)
+                                        Encryption_Key_Size (1 octet)
+                Response parameters:    <none>
 
-		Possible values for Attribute_ID:
-					0x0000 = Set encryption key of last
-					added attribute
-					0x0001-0xffff = Set enctryption of
-					attribute under ID
+                Possible values for Attribute_ID:
+                                        0x0000 = Set encryption key of last
+                                        added attribute
+                                        0x0001-0xffff = Set enctryption of
+                                        attribute under ID
 
-		This command is used to set required Encryption Key Size of an
-		attribute. It shall be used only if encryption or authentication
-		is needed to have access to this attribute. Otherwise an error
-		shall be returned.
+                This command is used to set required Encryption Key Size of an
+                attribute. It shall be used only if encryption or authentication
+                is needed to have access to this attribute. Otherwise an error
+                shall be returned.
 
-		Possible values for Encryption_Key_Size parameter are:
-								<0x07, 0x0f>
+                Possible values for Encryption_Key_Size parameter are:
+                                                                <0x07, 0x0f>
 
-		In case of an error, the error response will be returned.
+                In case of an error, the error response will be returned.
 
-	Opcode 0x0a - Exchange MTU
+        Opcode 0x0a - Exchange MTU
 
-		Controller Index:	<controller id>
-		Command parameters:	Address_Type (1 octet)
-					Address (6 octets)
-		Response parameters:	<none>
+                Controller Index:       <controller id>
+                Command parameters:     Address_Type (1 octet)
+                                        Address (6 octets)
+                Response parameters:    <none>
 
-		This command is used by GATT Client to configure ATT protocol.
-		IUT is expected to send Exchange MTU Request to negotiate
-		MTU size.
+                This command is used by GATT Client to configure ATT protocol.
+                IUT is expected to send Exchange MTU Request to negotiate
+                MTU size.
 
-		In case of an error, the error response will be returned.
+                In case of an error, the error response will be returned.
 
-	Opcode 0x0b - Discover All Primary Services
+        Opcode 0x0b - Discover All Primary Services
 
-		Controller Index:	<controller id>
-		Command parameters:	Address_Type (1 octet)
-					Address (6 octets)
-		Response parameters:	Services_Count (1 octet)
-					[array] Service (variable)
+                Controller Index:       <controller id>
+                Command parameters:     Address_Type (1 octet)
+                                        Address (6 octets)
+                Response parameters:    Services_Count (1 octet)
+                                        [array] Service (variable)
 
-		Object Service is defined as:
-					Start_Handle (2 octets)
-					End_Group_Handle (2 octets)
-					UUID_Length (1 octet)
-					UUID (2 or 16 octets)
+                Object Service is defined as:
+                                        Start_Handle (2 octets)
+                                        End_Group_Handle (2 octets)
+                                        UUID_Length (1 octet)
+                                        UUID (2 or 16 octets)
 
-		Valid UUID_Length parameter values:
-					0x02 = UUID16
-					0x10 = UUID128
+                Valid UUID_Length parameter values:
+                                        0x02 = UUID16
+                                        0x10 = UUID128
 
-		This procedure is used by a client to discover all primary
-		services on a server.
-		Services found during discovery are returned in the response.
+                This procedure is used by a client to discover all primary
+                services on a server.
+                Services found during discovery are returned in the response.
 
-		In case of an error, the error response will be returned.
+                In case of an error, the error response will be returned.
 
-	Opcode 0x0c - Discover Primary Service by UUID
+        Opcode 0x0c - Discover Primary Service by UUID
 
-		Controller Index:	<controller id>
-		Command parameters:	Address_Type (1 octet)
-					Address (6 octets)
-					UUID_Length (1 octet)
-					UUID (2 or 16 octets)
-		Response parameters:	Services_Count (1 octet)
-					[array] Service (variable)
-
-		Object Service is defined as:
-					Start_Handle (2 octets)
-					End_Group_Handle (2 octets)
-					UUID_Length (1 octet)
-					UUID (2 or 16 octets)
+                Controller Index:       <controller id>
+                Command parameters:     Address_Type (1 octet)
+                                        Address (6 octets)
+                                        UUID_Length (1 octet)
+                                        UUID (2 or 16 octets)
+                Response parameters:    Services_Count (1 octet)
+                                        [array] Service (variable)
+
+                Object Service is defined as:
+                                        Start_Handle (2 octets)
+                                        End_Group_Handle (2 octets)
+                                        UUID_Length (1 octet)
+                                        UUID (2 or 16 octets)
 
-		Valid UUID_Length parameter values:
-					0x02 = UUID16
-					0x10 = UUID128
+                Valid UUID_Length parameter values:
+                                        0x02 = UUID16
+                                        0x10 = UUID128
 
-		This procedure is used by a client to discover primary services
-		with specific UUID on a server.
-		Services found during discovery are returned in the response.
+                This procedure is used by a client to discover primary services
+                with specific UUID on a server.
+                Services found during discovery are returned in the response.
 
-		In case of an error, the error response will be returned.
-
-	Opcode 0x0d - Find Included Services
+                In case of an error, the error response will be returned.
+
+        Opcode 0x0d - Find Included Services
 
-		Controller Index:	<controller id>
-		Command parameters:	Address_Type (1 octet)
-					Address (6 octets)
-					Service_Start_Handle (2 octets)
-					Service_End_Handle (2 octets)
-		Response parameters:	Services_Count (1 octet)
-					[array] Included_Service (variable)
-
-		Object Included_Service is defined as:
-					Included_Handle (2 octets)
-					Type (1 octet)
-					Service (7 or 21 octets)
-
-		Valid Type parameter values:
-					0x00 = Primary
-					0x01 = Secondary
-
-		Object Service is defined as:
-					Start_Handle (2 octets)
-					End_Group_Handle (2 octets)
-					UUID_Length (1 octet)
-					UUID (2 or 16 octets)
-
-		Valid UUID_Length parameter values:
-					0x02 = UUID16
-					0x10 = UUID128
-
-		This procedure is used by a client to discover service
-		relationships to other services.
-		Services found during discovery are returned in the response.
-
-	Opcode 0x0e - Discover All Characteristics of a Service
-
-		Controller Index:	<controller id>
-		Command parameters:	Address_Type (1 octet)
-					Address (6 octets)
-					Service_Start_Handle (2 octets)
-					Service_End_Handle (2 octets)
-		Response parameters:	Characteristics_Count (1 octet)
-					[array] Characteristic (variable)
-
-		Object Characteristic is defined as:
-					Characteristic_Handle (2 octets)
-					Value_Handle (2 octets)
-					Properties (1 octet)
-					UUID_Length (1 octet)
-					UUID (2 or 16 octets)
-
-		Valid UUID_Length parameter values:
-					0x02 = UUID16
-					0x10 = UUID128
-
-		This procedure is used by a client to discover all
-		characteristics within specified service range.
-		Characteristics found during discovery are returned in the
-		response.
-
-		In case of an error, the error response will be returned.
-
-	Opcode 0x0f - Discover Characteristics by UUID
-
-		Controller Index:	<controller id>
-		Command parameters:	Address_Type (1 octet)
-					Address (6 octets)
-					Start_Handle (2 octets)
-					End_Handle (2 octets)
-					UUID_Length (1 octet)
-					UUID (2 or 16 octets)
-		Response parameters:	Characteristics_Count (1 octet)
-					[array] Characteristic (variable)
-
-		Object Characteristic is defined as:
-					Characteristic_Handle (2 octets)
-					Value_Handle (2 octets)
-					Properties (1 octet)
-					UUID_Length (1 octet)
-					UUID (2 or 16 octets)
-
-		Valid UUID_Length parameter values:
-					0x02 = UUID16
-					0x10 = UUID128
-
-		This procedure is used by a client to discover characteristic
-		declarations with given UUID on a server.
-		Characteristics found during discovery are returned in the
-		response.
-
-		In case of an error, the error response will be returned.
-
-	Opcode 0x10 - Discover All Characteristic Descriptors
-
-		Controller Index:	<controller id>
-		Command parameters:	Address_Type (1 octet)
-					Address (6 octets)
-					Start_Handle (2 octets)
-					End_Handle (2 octets)
-		Response parameters:	Descriptors_Count (1 octet)
-					[array] Descriptor (variable)
-
-		Object Descriptor is defined as:
-					Descriptor_Handle (2 octets)
-					UUID_Length (1 octet)
-					UUID (2 or 16 octets)
-
-		Valid UUID_Length parameter values:
-					0x02 = UUID16
-					0x10 = UUID128
-
-		This procedure is used by a client to discover all the
-		characteristic descriptors contained within characteristic.
-		Descriptors found during discovery are returned in the
-		response.
-
-		In case of an error, the error response will be returned.
-
-	Opcode 0x11 - Read Characteristic Value/Descriptor
-
-		Controller Index:	<controller id>
-		Command parameters:	Address_Type (1 octet)
-					Address (6 octets)
-					Handle (2 octets)
-		Response parameters:	ATT_Response (1 octet)
-					Data_Length (2 octets)
-					Data (variable)
-
-		This procedure is used to read a Characteristic Value or
-		Characteristic Descriptor from a server.
-		Read results are returned in the response to this command.
-		ATT_Response shall be set to 0x00, if Read has been completed
-		successfully. Otherwise it shall be set to ATT error code
-		received.
-
-		In case of an error, the error response will be returned.
-
-	Opcode 0x12 - Read Using Characteristic UUID
-
-		Controller Index:	<controller id>
-		Command parameters:	Address_Type (1 octet)
-					Address (6 octets)
-					Start_Handle (2 octets)
-					End_Handle (2 octets)
-					UUID_Length (1 octet)
-					UUID (2 or 16 octets)
-		Response parameters:	ATT_Response (1 octet)s
-					Characteristic_Value_Count (1 octets)
-					Characteristic_Value list (variable)
-
-		Characteristic_Value:   Handle (2 octets)
-					Data_Length (1 octets)
-					Data (variable)
-
-		Valid UUID_Length parameter values:
-					0x02 = UUID16
-					0x10 = UUID128
-
-		This procedure is used to read a Characteristic Value from a
-		server when characteristic UUID is known.
-		Read results are returned in the response to this command.
-		ATT_Response shall be set to 0x00, if Read has been completed
-		successfully. Otherwise it shall be set to ATT error code
-		received.
-
-		In case of an error, the error response will be returned.
-
-	Opcode 0x13 - Read Long Characteristic Value/Descriptor
-
-		Controller Index:	<controller id>
-		Command parameters:	Address_Type (1 octet)
-					Address (6 octets)
-					Handle (2 octets)
-					Offset (2 octets)
-		Response parameters:	ATT_Response (1 octet)
-					Data_Length (2 octets)
-					Data (variable)
-
-		This procedure is used to read Long Characteristic Value or
-		Long Characteristic Descriptor from a server.
-		Read results are returned in the response to this command.
-		ATT_Response shall be set to 0x00, if Read has been completed
-		successfully. Otherwise it shall be set to ATT error code
-		received.
-
-		In case of an error, the error response will be returned.
-
-	Opcode 0x14 - Read Multiple Characteristic Values
-
-		Controller Index:	<controller id>
-		Command parameters:	Address_Type (1 octet)
-					Address (6 octets)
-					Handles_Count (1 octet)
-					Handles (variable)
-		Response parameters:	ATT_Response (1 octet)
-					Data_Length (2 octets)
-					Data (variable)
-
-		This procedure is used to read multiple Characteristic Values
-		from a server.
-		Read results are returned in the response to this command.
-		ATT_Response shall be set to 0x00, if Read has been completed
-		successfully. Otherwise it shall be set to ATT error code
-		received.
-
-		In case of an error, the error response will be returned.
-
-	Opcode 0x15 - Write Without Response
-
-		Controller Index:	<controller id>
-		Command parameters:	Address_Type (1 octet)
-					Address (6 octets)
-					Handle (2 octets)
-					Data_Length (2 octets)
-					Data (variable)
-		Response parameters:	<none>
-
-		This procedure is used to write a Characteristic Value to a
-		server. There is no acknowledgment that the write was
-		successfully performed.
-
-		In case of an error, the error response will be returned.
-
-	Opcode 0x16 - Signed Write Without Response
-
-		Controller Index:	<controller id>
-		Command parameters:	Address_Type (1 octet)
-					Address (6 octets)
-					Handle (2 octets)
-					Data_Length (2 octets)
-					Data (variable)
-		Response parameters:	<none>
-
-		This procedure is used to write a Characteristic Value to a
-		server. There is no acknowledgment that the write was
-		successfully performed. This procedure is intended to be used
-		if client and server are bonded, and connected using
-		non-encrypted link.
-
-		In case of an error, the error response will be returned.
-
-	Opcode 0x17 - Write Characteristic Value/Descriptor
-
-		Controller Index:	<controller id>
-		Command parameters:	Address_Type (1 octet)
-					Address (6 octets)
-					Handle (2 octets)
-					Data_Length (2 octets)
-					Data (variable)
-		Response parameters:	ATT_Response (1 octet)
-
-		This procedure is used to write a Characteristic Value or
-		Characteristic Descriptor to a server.
-		ATT_Response shall be set to 0x00, if Write has been completed
-		successfully. Otherwise it shall be set to ATT error code
-		received.
-
-		In case of an error, the error response will be returned.
-
-	Opcode 0x18 - Write Long Characteristic Value/Descriptor
-
-		Controller Index:	<controller id>
-		Command parameters:	Address_Type (1 octet)
-					Address (6 octets)
-					Handle (2 octets)
-					Offset (2 octets)
-					Data_Length (2 octets)
-					Data (variable)
-		Response parameters:	ATT_Response (1 octet)
-
-		This procedure is used to write a Long Characteristic Value or
-		Long Characteristic Descriptor to a server.
-		ATT_Response shall be set to 0x00, if Write has been completed
-		successfully. Otherwise it shall be set to ATT error code
-		received.
-
-		In case of an error, the error response will be returned.
-
-	Opcode 0x19 - Reliable Write
-
-		Controller Index:	<controller id>
-		Command parameters:	Address_Type (1 octet)
-					Address (6 octets)
-					Handle (2 octets)
-					Offset (2 octets)
-					Data_Length (2 octets)
-					Data (variable)
-		Response parameters:	ATT_Response (1 octet)
-
-		This procedure is used to write a Characteristic Value to
-		a server and assurance is required that the correct
-		Characteristic Value is going to be written.
-		ATT_Response shall be set to 0x00, if Write has been completed
-		successfully. Otherwise it shall be set to ATT error code
-		received.
-
-		In case of an error, the error response will be returned.
-
-	Opcode 0x1a - Configure Notifications
-
-		Controller Index:	<controller id>
-		Command parameters:	Address_Type (1 octet)
-					Address (6 octets)
-					Enable (1 octet)
-					CCC_Handle (2 octets)
-		Response parameters:	<none>
-
-		This procedure is used to configure server to notify
-		characteristic value to a client.
-
-		In case of an error, the error response will be returned.
-
-	Opcode 0x1b - Configure Indications
-
-		Controller Index:	<controller id>
-		Command parameters:	Address_Type (1 octet)
-					Address (6 octets)
-					Enable (1 octet)
-					CCC_Handle (2 octets)
-		Response parameters:	<none>
-
-		This procedure is used to configure server to indicate
-		characteristic value to a client.
-
-		In case of an error, the error response will be returned.
-
-	Opcode 0x1c - Get Attributes
-
-		Controller Index:	<controller id>
-		Command parameters:	Start Handle (2 octets)
-					End Handle (2 octets)
-					Type_Length (1 octet)
-					Type (2 or 16 octets)
-		Response parameters:	Attributes_Count (1 octet)
-					[array] Attribute (variable)
-
-		Object Attribute is defined as:
-					Handle (2 octets)
-					Permission (1 octet)
-					Type_Length (1 octet)
-					Type (2 or 16 octets)
-
-		Valid Type_Length parameter values:
-					0x02 = UUID16
-					0x10 = UUID128
-
-		This procedure is used to query GATT Server for attributes based
-		on given search pattern. Attributes can be searched using
-		Attribute Handle range and Attribute Type.
-
-		In case of an error, the error response will be returned.
-
-	Opcode 0x1d - Get Attribute Value
-
-		Controller Index:	<controller id>
-		Command parameters:	Address_Type (1 octet)
-					Address (6 octets)
-					Handle (2 octets)
-		Response parameters:	ATT_Response (1 octet)
-					Value_Length (2 octet)
-					Value (variable)
-
-		This procedure is used to query GATT Server for attribute value.
-		In case of long attribute value, multiple responses will be
-		sent. BTP_STATUS_SUCCESS response indicates the procedure is
-		finished.
-
-		In case of an error, the error response will be returned.
-
-	Opcode 0x1e - Change Database
-
-		Controller Index:	<controller id>
-		Command parameters:	Start Handle (2 octets)
-					End Handle (2 octets)
-					Operation (1 octet)
-		Response parameters:	<none>
-
-		Valid Operation values:
-					0x00 = Remove
-					0x01 = Add
-					0x02 = Any
-
-		This procedure is used to change GATT database. If handles
-		provided are zero it is up to IUT to select range that will be
-		changed. If operation is "Any" IUT may add or remove items
-		from database.
-
-		In case of an error, the error response will be returned.
-
-	Opcode 0x1f - Connect EATT channels
-
-		Controller Index:	<controller id>
-		Command parameters:	Address_Type (1 octet)
-					Address (6 octets)
-					Number_Of_Channels (1 octet)
-		Response parameters:	<none>
-
-		This procedure is used to connect EATT channels.
-		BTP_STATUS_SUCCESS response indicates the procedure is finished.
-
-		In case of an error, the error response will be returned.
-
-	Opcode 0x20 - Read Multiple Variable Length Characteristic Values
-
-		Controller Index:	<controller id>
-		Command parameters:	Address_Type (1 octet)
-					Address (6 octets)
-					Handles_Count (1 octet)
-					Handles (variable)
-		Response parameters:	ATT_Response (1 octet)
-					Total_Data_Length (2 octets)
-					Data (variable)
-
-		This procedure is used to read multiple variable length
-		Characteristic Values from a server.
-		Read results are returned in the response to this command in
-		form of {Length, Value} tuples. The Total_Data_Length is total
-		length of response data (sum of lengths of all tuples}.
-		ATT_Response shall be set to 0x00, if Read has been completed
-		successfully. Otherwise it shall be set to ATT error code
-		received.
-
-		In case of an error, the error response will be returned.
-
-	Opcode 0x21 - Multiple Variable Length Notifications
-
-		Controller Index:	<controller id>
-		Command parameters:	Address_Type (1 octet)
-					Address (6 octets)
-					Count (2 octet)
-					[array] Handles (variable)
-		Response parameters:	ATT_Response (1 octet)
-
-		Configure server to notify multiple Characteristic
-		Values to a client.
-
-		In case of error, the error response will be returned.
+                Controller Index:       <controller id>
+                Command parameters:     Address_Type (1 octet)
+                                        Address (6 octets)
+                                        Service_Start_Handle (2 octets)
+                                        Service_End_Handle (2 octets)
+                Response parameters:    Services_Count (1 octet)
+                                        [array] Included_Service (variable)
+
+                Object Included_Service is defined as:
+                                        Included_Handle (2 octets)
+                                        Type (1 octet)
+                                        Service (7 or 21 octets)
+
+                Valid Type parameter values:
+                                        0x00 = Primary
+                                        0x01 = Secondary
+
+                Object Service is defined as:
+                                        Start_Handle (2 octets)
+                                        End_Group_Handle (2 octets)
+                                        UUID_Length (1 octet)
+                                        UUID (2 or 16 octets)
+
+                Valid UUID_Length parameter values:
+                                        0x02 = UUID16
+                                        0x10 = UUID128
+
+                This procedure is used by a client to discover service
+                relationships to other services.
+                Services found during discovery are returned in the response.
+
+        Opcode 0x0e - Discover All Characteristics of a Service
+
+                Controller Index:       <controller id>
+                Command parameters:     Address_Type (1 octet)
+                                        Address (6 octets)
+                                        Service_Start_Handle (2 octets)
+                                        Service_End_Handle (2 octets)
+                Response parameters:    Characteristics_Count (1 octet)
+                                        [array] Characteristic (variable)
+
+                Object Characteristic is defined as:
+                                        Characteristic_Handle (2 octets)
+                                        Value_Handle (2 octets)
+                                        Properties (1 octet)
+                                        UUID_Length (1 octet)
+                                        UUID (2 or 16 octets)
+
+                Valid UUID_Length parameter values:
+                                        0x02 = UUID16
+                                        0x10 = UUID128
+
+                This procedure is used by a client to discover all
+                characteristics within specified service range.
+                Characteristics found during discovery are returned in the
+                response.
+
+                In case of an error, the error response will be returned.
+
+        Opcode 0x0f - Discover Characteristics by UUID
+
+                Controller Index:       <controller id>
+                Command parameters:     Address_Type (1 octet)
+                                        Address (6 octets)
+                                        Start_Handle (2 octets)
+                                        End_Handle (2 octets)
+                                        UUID_Length (1 octet)
+                                        UUID (2 or 16 octets)
+                Response parameters:    Characteristics_Count (1 octet)
+                                        [array] Characteristic (variable)
+
+                Object Characteristic is defined as:
+                                        Characteristic_Handle (2 octets)
+                                        Value_Handle (2 octets)
+                                        Properties (1 octet)
+                                        UUID_Length (1 octet)
+                                        UUID (2 or 16 octets)
+
+                Valid UUID_Length parameter values:
+                                        0x02 = UUID16
+                                        0x10 = UUID128
+
+                This procedure is used by a client to discover characteristic
+                declarations with given UUID on a server.
+                Characteristics found during discovery are returned in the
+                response.
+
+                In case of an error, the error response will be returned.
+
+        Opcode 0x10 - Discover All Characteristic Descriptors
+
+                Controller Index:       <controller id>
+                Command parameters:     Address_Type (1 octet)
+                                        Address (6 octets)
+                                        Start_Handle (2 octets)
+                                        End_Handle (2 octets)
+                Response parameters:    Descriptors_Count (1 octet)
+                                        [array] Descriptor (variable)
+
+                Object Descriptor is defined as:
+                                        Descriptor_Handle (2 octets)
+                                        UUID_Length (1 octet)
+                                        UUID (2 or 16 octets)
+
+                Valid UUID_Length parameter values:
+                                        0x02 = UUID16
+                                        0x10 = UUID128
+
+                This procedure is used by a client to discover all the
+                characteristic descriptors contained within characteristic.
+                Descriptors found during discovery are returned in the
+                response.
+
+                In case of an error, the error response will be returned.
+
+        Opcode 0x11 - Read Characteristic Value/Descriptor
+
+                Controller Index:       <controller id>
+                Command parameters:     Address_Type (1 octet)
+                                        Address (6 octets)
+                                        Handle (2 octets)
+                Response parameters:    ATT_Response (1 octet)
+                                        Data_Length (2 octets)
+                                        Data (variable)
+
+                This procedure is used to read a Characteristic Value or
+                Characteristic Descriptor from a server.
+                Read results are returned in the response to this command.
+                ATT_Response shall be set to 0x00, if Read has been completed
+                successfully. Otherwise it shall be set to ATT error code
+                received.
+
+                In case of an error, the error response will be returned.
+
+        Opcode 0x12 - Read Using Characteristic UUID
+
+                Controller Index:       <controller id>
+                Command parameters:     Address_Type (1 octet)
+                                        Address (6 octets)
+                                        Start_Handle (2 octets)
+                                        End_Handle (2 octets)
+                                        UUID_Length (1 octet)
+                                        UUID (2 or 16 octets)
+                Response parameters:    ATT_Response (1 octet)s
+                                        Characteristic_Value_Count (1 octets)
+                                        Characteristic_Value list (variable)
+
+                Characteristic_Value:   Handle (2 octets)
+                                        Data_Length (1 octets)
+                                        Data (variable)
+
+                Valid UUID_Length parameter values:
+                                        0x02 = UUID16
+                                        0x10 = UUID128
+
+                This procedure is used to read a Characteristic Value from a
+                server when characteristic UUID is known.
+                Read results are returned in the response to this command.
+                ATT_Response shall be set to 0x00, if Read has been completed
+                successfully. Otherwise it shall be set to ATT error code
+                received.
+
+                In case of an error, the error response will be returned.
+
+        Opcode 0x13 - Read Long Characteristic Value/Descriptor
+
+                Controller Index:       <controller id>
+                Command parameters:     Address_Type (1 octet)
+                                        Address (6 octets)
+                                        Handle (2 octets)
+                                        Offset (2 octets)
+                Response parameters:    ATT_Response (1 octet)
+                                        Data_Length (2 octets)
+                                        Data (variable)
+
+                This procedure is used to read Long Characteristic Value or
+                Long Characteristic Descriptor from a server.
+                Read results are returned in the response to this command.
+                ATT_Response shall be set to 0x00, if Read has been completed
+                successfully. Otherwise it shall be set to ATT error code
+                received.
+
+                In case of an error, the error response will be returned.
+
+        Opcode 0x14 - Read Multiple Characteristic Values
+
+                Controller Index:       <controller id>
+                Command parameters:     Address_Type (1 octet)
+                                        Address (6 octets)
+                                        Handles_Count (1 octet)
+                                        Handles (variable)
+                Response parameters:    ATT_Response (1 octet)
+                                        Data_Length (2 octets)
+                                        Data (variable)
+
+                This procedure is used to read multiple Characteristic Values
+                from a server.
+                Read results are returned in the response to this command.
+                ATT_Response shall be set to 0x00, if Read has been completed
+                successfully. Otherwise it shall be set to ATT error code
+                received.
+
+                In case of an error, the error response will be returned.
+
+        Opcode 0x15 - Write Without Response
+
+                Controller Index:       <controller id>
+                Command parameters:     Address_Type (1 octet)
+                                        Address (6 octets)
+                                        Handle (2 octets)
+                                        Data_Length (2 octets)
+                                        Data (variable)
+                Response parameters:    <none>
+
+                This procedure is used to write a Characteristic Value to a
+                server. There is no acknowledgment that the write was
+                successfully performed.
+
+                In case of an error, the error response will be returned.
+
+        Opcode 0x16 - Signed Write Without Response
+
+                Controller Index:       <controller id>
+                Command parameters:     Address_Type (1 octet)
+                                        Address (6 octets)
+                                        Handle (2 octets)
+                                        Data_Length (2 octets)
+                                        Data (variable)
+                Response parameters:    <none>
+
+                This procedure is used to write a Characteristic Value to a
+                server. There is no acknowledgment that the write was
+                successfully performed. This procedure is intended to be used
+                if client and server are bonded, and connected using
+                non-encrypted link.
+
+                In case of an error, the error response will be returned.
+
+        Opcode 0x17 - Write Characteristic Value/Descriptor
+
+                Controller Index:       <controller id>
+                Command parameters:     Address_Type (1 octet)
+                                        Address (6 octets)
+                                        Handle (2 octets)
+                                        Data_Length (2 octets)
+                                        Data (variable)
+                Response parameters:    ATT_Response (1 octet)
+
+                This procedure is used to write a Characteristic Value or
+                Characteristic Descriptor to a server.
+                ATT_Response shall be set to 0x00, if Write has been completed
+                successfully. Otherwise it shall be set to ATT error code
+                received.
+
+                In case of an error, the error response will be returned.
+
+        Opcode 0x18 - Write Long Characteristic Value/Descriptor
+
+                Controller Index:       <controller id>
+                Command parameters:     Address_Type (1 octet)
+                                        Address (6 octets)
+                                        Handle (2 octets)
+                                        Offset (2 octets)
+                                        Data_Length (2 octets)
+                                        Data (variable)
+                Response parameters:    ATT_Response (1 octet)
+
+                This procedure is used to write a Long Characteristic Value or
+                Long Characteristic Descriptor to a server.
+                ATT_Response shall be set to 0x00, if Write has been completed
+                successfully. Otherwise it shall be set to ATT error code
+                received.
+
+                In case of an error, the error response will be returned.
+
+        Opcode 0x19 - Reliable Write
+
+                Controller Index:       <controller id>
+                Command parameters:     Address_Type (1 octet)
+                                        Address (6 octets)
+                                        Handle (2 octets)
+                                        Offset (2 octets)
+                                        Data_Length (2 octets)
+                                        Data (variable)
+                Response parameters:    ATT_Response (1 octet)
+
+                This procedure is used to write a Characteristic Value to
+                a server and assurance is required that the correct
+                Characteristic Value is going to be written.
+                ATT_Response shall be set to 0x00, if Write has been completed
+                successfully. Otherwise it shall be set to ATT error code
+                received.
+
+                In case of an error, the error response will be returned.
+
+        Opcode 0x1a - Configure Notifications
+
+                Controller Index:       <controller id>
+                Command parameters:     Address_Type (1 octet)
+                                        Address (6 octets)
+                                        Enable (1 octet)
+                                        CCC_Handle (2 octets)
+                Response parameters:    <none>
+
+                This procedure is used to configure server to notify
+                characteristic value to a client.
+
+                In case of an error, the error response will be returned.
+
+        Opcode 0x1b - Configure Indications
+
+                Controller Index:       <controller id>
+                Command parameters:     Address_Type (1 octet)
+                                        Address (6 octets)
+                                        Enable (1 octet)
+                                        CCC_Handle (2 octets)
+                Response parameters:    <none>
+
+                This procedure is used to configure server to indicate
+                characteristic value to a client.
+
+                In case of an error, the error response will be returned.
+
+        Opcode 0x1c - Get Attributes
+
+                Controller Index:       <controller id>
+                Command parameters:     Start Handle (2 octets)
+                                        End Handle (2 octets)
+                                        Type_Length (1 octet)
+                                        Type (2 or 16 octets)
+                Response parameters:    Attributes_Count (1 octet)
+                                        [array] Attribute (variable)
+
+                Object Attribute is defined as:
+                                        Handle (2 octets)
+                                        Permission (1 octet)
+                                        Type_Length (1 octet)
+                                        Type (2 or 16 octets)
+
+                Valid Type_Length parameter values:
+                                        0x02 = UUID16
+                                        0x10 = UUID128
+
+                This procedure is used to query GATT Server for attributes based
+                on given search pattern. Attributes can be searched using
+                Attribute Handle range and Attribute Type.
+
+                In case of an error, the error response will be returned.
+
+        Opcode 0x1d - Get Attribute Value
+
+                Controller Index:       <controller id>
+                Command parameters:     Address_Type (1 octet)
+                                        Address (6 octets)
+                                        Handle (2 octets)
+                Response parameters:    ATT_Response (1 octet)
+                                        Value_Length (2 octet)
+                                        Value (variable)
+
+                This procedure is used to query GATT Server for attribute value.
+                In case of long attribute value, multiple responses will be
+                sent. BTP_STATUS_SUCCESS response indicates the procedure is
+                finished.
+
+                In case of an error, the error response will be returned.
+
+        Opcode 0x1e - Change Database
+
+                Controller Index:       <controller id>
+                Command parameters:     Start Handle (2 octets)
+                                        End Handle (2 octets)
+                                        Operation (1 octet)
+                Response parameters:    <none>
+
+                Valid Operation values:
+                                        0x00 = Remove
+                                        0x01 = Add
+                                        0x02 = Any
+
+                This procedure is used to change GATT database. If handles
+                provided are zero it is up to IUT to select range that will be
+                changed. If operation is "Any" IUT may add or remove items
+                from database.
+
+                In case of an error, the error response will be returned.
+
+        Opcode 0x1f - Connect EATT channels
+
+                Controller Index:       <controller id>
+                Command parameters:     Address_Type (1 octet)
+                                        Address (6 octets)
+                                        Number_Of_Channels (1 octet)
+                Response parameters:    <none>
+
+                This procedure is used to connect EATT channels.
+                BTP_STATUS_SUCCESS response indicates the procedure is finished.
+
+                In case of an error, the error response will be returned.
+
+        Opcode 0x20 - Read Multiple Variable Length Characteristic Values
+
+                Controller Index:       <controller id>
+                Command parameters:     Address_Type (1 octet)
+                                        Address (6 octets)
+                                        Handles_Count (1 octet)
+                                        Handles (variable)
+                Response parameters:    ATT_Response (1 octet)
+                                        Total_Data_Length (2 octets)
+                                        Data (variable)
+
+                This procedure is used to read multiple variable length
+                Characteristic Values from a server.
+                Read results are returned in the response to this command in
+                form of {Length, Value} tuples. The Total_Data_Length is total
+                length of response data (sum of lengths of all tuples}.
+                ATT_Response shall be set to 0x00, if Read has been completed
+                successfully. Otherwise it shall be set to ATT error code
+                received.
+
+                In case of an error, the error response will be returned.
+
+        Opcode 0x21 - Multiple Variable Length Notifications
+
+                Controller Index:       <controller id>
+                Command parameters:     Address_Type (1 octet)
+                                        Address (6 octets)
+                                        Count (2 octet)
+                                        [array] Handles (variable)
+                Response parameters:    ATT_Response (1 octet)
+
+                Configure server to notify multiple Characteristic
+                Values to a client.
+
+                In case of error, the error response will be returned.
 
 Events:
-	Opcode 0x80 - Notification/Indication Received
+        Opcode 0x80 - Notification/Indication Received
 
-		Controller Index:	<controller id>
-		Event parameters:	Address_Type (1 octet)
-					Address (6 octets)
-					Type (1 octet)
-					Handle (2 octets)
-					Data_Length (2 octets)
-					Data (variable)
+                Controller Index:       <controller id>
+                Event parameters:       Address_Type (1 octet)
+                                        Address (6 octets)
+                                        Type (1 octet)
+                                        Handle (2 octets)
+                                        Data_Length (2 octets)
+                                        Data (variable)
 
-		Valid Type parameter values:
-					0x01 = Notification
-					0x02 = Indication
+                Valid Type parameter values:
+                                        0x01 = Notification
+                                        0x02 = Indication
 
-		This event indicates that IUT has received notification
-		or notification.
+                This event indicates that IUT has received notification
+                or notification.
 
-	Opcode 0x81 - Attribute Value Changed
+        Opcode 0x81 - Attribute Value Changed
 
-		Controller Index:	<controller id>
-		Event parameters:	Attribute_ID (2 octets)
-					Data_Length (2 octet)
-					Data (1-512 octets)
+                Controller Index:       <controller id>
+                Event parameters:       Attribute_ID (2 octets)
+                                        Data_Length (2 octet)
+                                        Data (1-512 octets)
 
-		This event command is used to indicate attribute
-		(characteristic or descriptor) value changed.
-		Event is triggered when ATT Write operation to Tester GATT
-		Server has been performed successfully.
+                This event command is used to indicate attribute
+                (characteristic or descriptor) value changed.
+                Event is triggered when ATT Write operation to Tester GATT
+                Server has been performed successfully.
 

--- a/doc/btp_gatt_client.txt
+++ b/doc/btp_gatt_client.txt
@@ -3,590 +3,590 @@ GATT Client Service (ID 6)
 
 Commands and responses:
 
-	Opcode 0x00 - Error response
+        Opcode 0x00 - Error response
 
-	Opcode 0x01 - Read Supported Commands command/response
+        Opcode 0x01 - Read Supported Commands command/response
 
-		Controller Index:	<non-controller>
-		Command parameters:	<none>
-		Response parameters:	<supported commands> (variable)
+                Controller Index:       <non-controller>
+                Command parameters:     <none>
+                Response parameters:    <supported commands> (variable)
 
-		Each bit in response is a flag indicating if command with
-		opcode matching bit number is supported. Bit set to 1 means
-		that command is supported. Bit 0 is reserved and shall always
-		be set to 0. If specific bit is not present in response (less
-		than required bytes received) it shall be assumed that command
-		is not supported.
+                Each bit in response is a flag indicating if command with
+                opcode matching bit number is supported. Bit set to 1 means
+                that command is supported. Bit 0 is reserved and shall always
+                be set to 0. If specific bit is not present in response (less
+                than required bytes received) it shall be assumed that command
+                is not supported.
 
-		In case of an error, the error response will be returned.
+                In case of an error, the error response will be returned.
 
-	Opcode 0x02 - Exchange MTU
+        Opcode 0x02 - Exchange MTU
 
-		Controller Index:	<controller id>
-		Command parameters:	Address_Type (1 octet)
-					Address (6 octets)
-		Response parameters:	<none>
+                Controller Index:       <controller id>
+                Command parameters:     Address_Type (1 octet)
+                                        Address (6 octets)
+                Response parameters:    <none>
 
-		This command is used by GATT Client to configure ATT protocol.
-		IUT is expected to send Exchange MTU Request to negotiate
-		MTU size.
+                This command is used by GATT Client to configure ATT protocol.
+                IUT is expected to send Exchange MTU Request to negotiate
+                MTU size.
 
-		In case of an error, the error response will be returned.
+                In case of an error, the error response will be returned.
 
-	Opcode 0x03 - Discover All Primary Services
+        Opcode 0x03 - Discover All Primary Services
 
-		Controller Index:	<controller id>
-		Command parameters:	Address_Type (1 octet)
-					Address (6 octets)
-		Response parameters:	<none>
+                Controller Index:       <controller id>
+                Command parameters:     Address_Type (1 octet)
+                                        Address (6 octets)
+                Response parameters:    <none>
 
-		This procedure is used by a client to discover all primary
-		services on a server.
-		Services found during discovery are returned in the
-		Discover All Primary Services Response event.
+                This procedure is used by a client to discover all primary
+                services on a server.
+                Services found during discovery are returned in the
+                Discover All Primary Services Response event.
 
-		In case of an error, the error response will be returned.
+                In case of an error, the error response will be returned.
 
-	Opcode 0x04 - Discover Primary Service by UUID
+        Opcode 0x04 - Discover Primary Service by UUID
 
-		Controller Index:	<controller id>
-		Command parameters:	Address_Type (1 octet)
-					Address (6 octets)
-					UUID_Length (1 octet)
-					UUID (2 or 16 octets)
-		Response parameters:	<none>
+                Controller Index:       <controller id>
+                Command parameters:     Address_Type (1 octet)
+                                        Address (6 octets)
+                                        UUID_Length (1 octet)
+                                        UUID (2 or 16 octets)
+                Response parameters:    <none>
 
-		This procedure is used by a client to discover primary services
-		with specific UUID on a server.
-		Services found during discovery are returned in the Discover
-		Primary Service by UUID Response event.
-
-		In case of an error, the error response will be returned.
+                This procedure is used by a client to discover primary services
+                with specific UUID on a server.
+                Services found during discovery are returned in the Discover
+                Primary Service by UUID Response event.
+
+                In case of an error, the error response will be returned.
 
-	Opcode 0x05 - Find Included Services
+        Opcode 0x05 - Find Included Services
 
-		Controller Index:	<controller id>
-		Command parameters:	Address_Type (1 octet)
-					Address (6 octets)
-					Service_Start_Handle (2 octets)
-					Service_End_Handle (2 octets)
-		Response parameters:	<none>
+                Controller Index:       <controller id>
+                Command parameters:     Address_Type (1 octet)
+                                        Address (6 octets)
+                                        Service_Start_Handle (2 octets)
+                                        Service_End_Handle (2 octets)
+                Response parameters:    <none>
 
-		This procedure is used by a client to discover service
-		relationships to other services.
-		Services found during discovery are returned in the rFind
-		Included Services Response event.
-
-	Opcode 0x06 - Discover All Characteristics of a Service
+                This procedure is used by a client to discover service
+                relationships to other services.
+                Services found during discovery are returned in the rFind
+                Included Services Response event.
+
+        Opcode 0x06 - Discover All Characteristics of a Service
 
-		Controller Index:	<controller id>
-		Command parameters:	Address_Type (1 octet)
-					Address (6 octets)
-					Service_Start_Handle (2 octets)
-					Service_End_Handle (2 octets)
-		Response parameters:	<none>
+                Controller Index:       <controller id>
+                Command parameters:     Address_Type (1 octet)
+                                        Address (6 octets)
+                                        Service_Start_Handle (2 octets)
+                                        Service_End_Handle (2 octets)
+                Response parameters:    <none>
 
-		This procedure is used by a client to discover all
-		characteristics within specified service range.
-		Characteristics found during discovery are returned in the
-		Discover All Characteristics of a Service Response event.
+                This procedure is used by a client to discover all
+                characteristics within specified service range.
+                Characteristics found during discovery are returned in the
+                Discover All Characteristics of a Service Response event.
 
-		In case of an error, the error response will be returned.
-
-	Opcode 0x07 - Discover Characteristics by UUID
+                In case of an error, the error response will be returned.
+
+        Opcode 0x07 - Discover Characteristics by UUID
 
-		Controller Index:	<controller id>
-		Command parameters:	Address_Type (1 octet)
-					Address (6 octets)
-					Start_Handle (2 octets)
-					End_Handle (2 octets)
-					UUID_Length (1 octet)
-					UUID (2 or 16 octets)
-		Response parameters:	<none>
+                Controller Index:       <controller id>
+                Command parameters:     Address_Type (1 octet)
+                                        Address (6 octets)
+                                        Start_Handle (2 octets)
+                                        End_Handle (2 octets)
+                                        UUID_Length (1 octet)
+                                        UUID (2 or 16 octets)
+                Response parameters:    <none>
 
-		This procedure is used by a client to discover characteristic
-		declarations with given UUID on a server.
-		Characteristics found during discovery are returned in the
-		Discover Characteristics by UUID Response event.
-
-		In case of an error, the error response will be returned.
+                This procedure is used by a client to discover characteristic
+                declarations with given UUID on a server.
+                Characteristics found during discovery are returned in the
+                Discover Characteristics by UUID Response event.
+
+                In case of an error, the error response will be returned.
 
-	Opcode 0x08 - Discover All Characteristic Descriptors
+        Opcode 0x08 - Discover All Characteristic Descriptors
 
-		Controller Index:	<controller id>
-		Command parameters:	Address_Type (1 octet)
-					Address (6 octets)
-					Start_Handle (2 octets)
-					End_Handle (2 octets)
-		Response parameters:	<none>
+                Controller Index:       <controller id>
+                Command parameters:     Address_Type (1 octet)
+                                        Address (6 octets)
+                                        Start_Handle (2 octets)
+                                        End_Handle (2 octets)
+                Response parameters:    <none>
 
-		This procedure is used by a client to discover all the
-		characteristic descriptors contained within characteristic.
-		Descriptors found during discovery are returned in the
-		Discover All Characteristic Descriptors Response event.
-
-		In case of an error, the error response will be returned.
-
-	Opcode 0x09 - Read Characteristic Value/Descriptor
-
-		Controller Index:	<controller id>
-		Command parameters:	Address_Type (1 octet)
-					Address (6 octets)
-					Handle (2 octets)
-		Response parameters:	<none>
+                This procedure is used by a client to discover all the
+                characteristic descriptors contained within characteristic.
+                Descriptors found during discovery are returned in the
+                Discover All Characteristic Descriptors Response event.
+
+                In case of an error, the error response will be returned.
+
+        Opcode 0x09 - Read Characteristic Value/Descriptor
+
+                Controller Index:       <controller id>
+                Command parameters:     Address_Type (1 octet)
+                                        Address (6 octets)
+                                        Handle (2 octets)
+                Response parameters:    <none>
 
-		This procedure is used to read a Characteristic Value or
-		Characteristic Descriptor from a server.
-		Read results are returned in the Read Characteristic
-		Value/Descriptor Response event.
-
-		In case of an error, the error response will be returned.
-
-	Opcode 0x0a - Read Using Characteristic UUID
-
-		Controller Index:	<controller id>
-		Command parameters:	Address_Type (1 octet)
-					Address (6 octets)
-					Start_Handle (2 octets)
-					End_Handle (2 octets)
-					UUID_Length (1 octet)
-					UUID (2 or 16 octets)
-		Response parameters:	<none>
-
-		Valid UUID_Length parameter values:
-					0x02 = UUID16
-					0x10 = UUID128
-
-		This procedure is used to read a Characteristic Value from a
-		server when characteristic UUID is known.
-		Read results are returned in the Read Using Characteristic UUID
-		Resonse event.
-
-		In case of an error, the error response will be returned.
-
-	Opcode 0x0b - Read Long Characteristic Value/Descriptor
-
-		Controller Index:	<controller id>
-		Command parameters:	Address_Type (1 octet)
-					Address (6 octets)
-					Handle (2 octets)
-					Offset (2 octets)
-		Response parameters:	<none>
-
-		This procedure is used to read Long Characteristic Value or
-		Long Characteristic Descriptor from a server.
-		Read results are returned in the Read Long Characteristic
-		Value/Descriptor Response event.
-
-		In case of an error, the error response will be returned.
-
-	Opcode 0x0c - Read Multiple Characteristic Values
-
-		Controller Index:	<controller id>
-		Command parameters:	Address_Type (1 octet)
-					Address (6 octets)
-					Handles_Count (1 octet)
-					Handles (variable)
-		Response parameters:	<none>
-
-		This procedure is used to read multiple Characteristic Values
-		from a server.
-		Read results are returned in the Read Multiple Characteristic
-		Values Response event.
-
-		In case of an error, the error response will be returned.
-
-	Opcode 0x0d - Write Without Response
-
-		Controller Index:	<controller id>
-		Command parameters:	Address_Type (1 octet)
-					Address (6 octets)
-					Handle (2 octets)
-					Data_Length (2 octets)
-					Data (variable)
-		Response parameters:	<none>
-
-		This procedure is used to write a Characteristic Value to a
-		server. There is no acknowledgment that the write was
-		successfully performed.
-
-		In case of an error, the error response will be returned.
-
-	Opcode 0x0e - Signed Write Without Response
-
-		Controller Index:	<controller id>
-		Command parameters:	Address_Type (1 octet)
-					Address (6 octets)
-					Handle (2 octets)
-					Data_Length (2 octets)
-					Data (variable)
-		Response parameters:	<none>
-
-		This procedure is used to write a Characteristic Value to a
-		server. There is no acknowledgment that the write was
-		successfully performed. This procedure is intended to be used
-		if client and server are bonded, and connected using
-		non-encrypted link.
-
-		In case of an error, the error response will be returned.
-
-	Opcode 0x0f - Write Characteristic Value/Descriptor
-
-		Controller Index:	<controller id>
-		Command parameters:	Address_Type (1 octet)
-					Address (6 octets)
-					Handle (2 octets)
-					Data_Length (2 octets)
-					Data (variable)
-		Response parameters:	<none>
-
-		This procedure is used to write a Characteristic Value or
-		Characteristic Descriptor to a server.
-		Write status is returned in Write Characteristic
-		Value/Descriptor Response event.
-
-		In case of an error, the error response will be returned.
-
-	Opcode 0x10 - Write Long Characteristic Value/Descriptor
-
-		Controller Index:	<controller id>
-		Command parameters:	Address_Type (1 octet)
-					Address (6 octets)
-					Handle (2 octets)
-					Offset (2 octets)
-					Data_Length (2 octets)
-					Data (variable)
-		Response parameters:	<none>
-
-		This procedure is used to write a Long Characteristic Value or
-		Long Characteristic Descriptor to a server.
-		Write status is returned in Write Long Characteristic
-		Value/Descriptor Response event.
-
-		In case of an error, the error response will be returned.
-
-	Opcode 0x11 - Reliable Write
-
-		Controller Index:	<controller id>
-		Command parameters:	Address_Type (1 octet)
-					Address (6 octets)
-					Handle (2 octets)
-					Offset (2 octets)
-					Data_Length (2 octets)
-					Data (variable)
-		Response parameters:	<none>
-
-		This procedure is used to write a Characteristic Value to
-		a server and assurance is required that the correct
-		Characteristic Value is going to be written.
-		Write status is returned in the Reliable Write Response event.
-
-		In case of an error, the error response will be returned.
-
-	Opcode 0x12 - Configure Notifications
-
-		Controller Index:	<controller id>
-		Command parameters:	Address_Type (1 octet)
-					Address (6 octets)
-					Enable (1 octet)
-					CCC_Handle (2 octets)
-		Response parameters:	<none>
-
-		This procedure is used to configure server to notify
-		characteristic value to a client. Configuration status is
-		returned in Configure Notifications Response event.
-
-		In case of an error, the error response will be returned.
-
-	Opcode 0x13 - Configure Indications
-
-		Controller Index:	<controller id>
-		Command parameters:	Address_Type (1 octet)
-					Address (6 octets)
-					Enable (1 octet)
-					CCC_Handle (2 octets)
-		Response parameters:	<none>
-
-		This procedure is used to configure server to indicate
-		characteristic value to a client. Configuration status is
-		returned in Configure Indications Response event.
-
-		In case of an error, the error response will be returned.
-
-	Opcode 0x14 - Read Multiple Variable Characteristic Values
-
-		Controller Index:	<controller id>
-		Command parameters:	Address_Type (1 octet)
-					Address (6 octets)
-					Handles_Count (1 octet)
-					Handles (variable)
-		Response parameters:	<none>
-
-		This procedure is used to read multiple variable Characteristic
-		Values from a server. Handles Count shall be > 1.
-		Read results are returned in the Read Multiple Variable
-		Characteristic Values Response event.
-
-		In case of an error, the error response will be returned.
+                This procedure is used to read a Characteristic Value or
+                Characteristic Descriptor from a server.
+                Read results are returned in the Read Characteristic
+                Value/Descriptor Response event.
+
+                In case of an error, the error response will be returned.
+
+        Opcode 0x0a - Read Using Characteristic UUID
+
+                Controller Index:       <controller id>
+                Command parameters:     Address_Type (1 octet)
+                                        Address (6 octets)
+                                        Start_Handle (2 octets)
+                                        End_Handle (2 octets)
+                                        UUID_Length (1 octet)
+                                        UUID (2 or 16 octets)
+                Response parameters:    <none>
+
+                Valid UUID_Length parameter values:
+                        0x02 = UUID16
+                        0x10 = UUID128
+
+                This procedure is used to read a Characteristic Value from a
+                server when characteristic UUID is known.
+                Read results are returned in the Read Using Characteristic UUID
+                Resonse event.
+
+                In case of an error, the error response will be returned.
+
+        Opcode 0x0b - Read Long Characteristic Value/Descriptor
+
+                Controller Index:       <controller id>
+                Command parameters:     Address_Type (1 octet)
+                                        Address (6 octets)
+                                        Handle (2 octets)
+                                        Offset (2 octets)
+                Response parameters:    <none>
+
+                This procedure is used to read Long Characteristic Value or
+                Long Characteristic Descriptor from a server.
+                Read results are returned in the Read Long Characteristic
+                Value/Descriptor Response event.
+
+                In case of an error, the error response will be returned.
+
+        Opcode 0x0c - Read Multiple Characteristic Values
+
+                Controller Index:       <controller id>
+                Command parameters:     Address_Type (1 octet)
+                                        Address (6 octets)
+                                        Handles_Count (1 octet)
+                                        Handles (variable)
+                Response parameters:    <none>
+
+                This procedure is used to read multiple Characteristic Values
+                from a server.
+                Read results are returned in the Read Multiple Characteristic
+                Values Response event.
+
+                In case of an error, the error response will be returned.
+
+        Opcode 0x0d - Write Without Response
+
+                Controller Index:       <controller id>
+                Command parameters:     Address_Type (1 octet)
+                                        Address (6 octets)
+                                        Handle (2 octets)
+                                        Data_Length (2 octets)
+                                        Data (variable)
+                Response parameters:    <none>
+
+                This procedure is used to write a Characteristic Value to a
+                server. There is no acknowledgment that the write was
+                successfully performed.
+
+                In case of an error, the error response will be returned.
+
+        Opcode 0x0e - Signed Write Without Response
+
+                Controller Index:       <controller id>
+                Command parameters:     Address_Type (1 octet)
+                                        Address (6 octets)
+                                        Handle (2 octets)
+                                        Data_Length (2 octets)
+                                        Data (variable)
+                Response parameters:    <none>
+
+                This procedure is used to write a Characteristic Value to a
+                server. There is no acknowledgment that the write was
+                successfully performed. This procedure is intended to be used
+                if client and server are bonded, and connected using
+                non-encrypted link.
+
+                In case of an error, the error response will be returned.
+
+        Opcode 0x0f - Write Characteristic Value/Descriptor
+
+                Controller Index:       <controller id>
+                Command parameters:     Address_Type (1 octet)
+                                        Address (6 octets)
+                                        Handle (2 octets)
+                                        Data_Length (2 octets)
+                                        Data (variable)
+                Response parameters:    <none>
+
+                This procedure is used to write a Characteristic Value or
+                Characteristic Descriptor to a server.
+                Write status is returned in Write Characteristic
+                Value/Descriptor Response event.
+
+                In case of an error, the error response will be returned.
+
+        Opcode 0x10 - Write Long Characteristic Value/Descriptor
+
+                Controller Index:       <controller id>
+                Command parameters:     Address_Type (1 octet)
+                                        Address (6 octets)
+                                        Handle (2 octets)
+                                        Offset (2 octets)
+                                        Data_Length (2 octets)
+                                        Data (variable)
+                Response parameters:    <none>
+
+                This procedure is used to write a Long Characteristic Value or
+                Long Characteristic Descriptor to a server.
+                Write status is returned in Write Long Characteristic
+                Value/Descriptor Response event.
+
+                In case of an error, the error response will be returned.
+
+        Opcode 0x11 - Reliable Write
+
+                Controller Index:       <controller id>
+                Command parameters:     Address_Type (1 octet)
+                                        Address (6 octets)
+                                        Handle (2 octets)
+                                        Offset (2 octets)
+                                        Data_Length (2 octets)
+                                        Data (variable)
+                Response parameters:    <none>
+
+                This procedure is used to write a Characteristic Value to
+                a server and assurance is required that the correct
+                Characteristic Value is going to be written.
+                Write status is returned in the Reliable Write Response event.
+
+                In case of an error, the error response will be returned.
+
+        Opcode 0x12 - Configure Notifications
+
+                Controller Index:       <controller id>
+                Command parameters:     Address_Type (1 octet)
+                                        Address (6 octets)
+                                        Enable (1 octet)
+                                        CCC_Handle (2 octets)
+                Response parameters:    <none>
+
+                This procedure is used to configure server to notify
+                characteristic value to a client. Configuration status is
+                returned in Configure Notifications Response event.
+
+                In case of an error, the error response will be returned.
+
+        Opcode 0x13 - Configure Indications
+
+                Controller Index:       <controller id>
+                Command parameters:     Address_Type (1 octet)
+                                        Address (6 octets)
+                                        Enable (1 octet)
+                                        CCC_Handle (2 octets)
+                Response parameters:    <none>
+
+                This procedure is used to configure server to indicate
+                characteristic value to a client. Configuration status is
+                returned in Configure Indications Response event.
+
+                In case of an error, the error response will be returned.
+
+        Opcode 0x14 - Read Multiple Variable Characteristic Values
+
+                Controller Index:       <controller id>
+                Command parameters:     Address_Type (1 octet)
+                                        Address (6 octets)
+                                        Handles_Count (1 octet)
+                                        Handles (variable)
+                Response parameters:    <none>
+
+                This procedure is used to read multiple variable Characteristic
+                Values from a server. Handles Count shall be > 1.
+                Read results are returned in the Read Multiple Variable
+                Characteristic Values Response event.
+
+                In case of an error, the error response will be returned.
 
 Events:
-	Opcode 0x80 - MTU exchanged
-
-		Controller Index:	<controller id>
-		Event parameters:	Address_Type (1 octet)
-					Address (6 octets)
-					MTU (2 octets)
-
-		This event indicates that MTU exchange was performed and new
-		MTU is in use.
-
-	Opcode 0x81 - Discover All Primary Services Response
-
-		Controller Index:	<controller id>
-		Event parameters:	Address_Type (1 octet)
-					Address (6 octets)
-					Status (1 octet)
-					Services_Count (1 octet)
-					[array] Service (variable)
-
-		Object Service is defined as:
-					Start_Handle (2 octets)
-					End_Group_Handle (2 octets)
-					UUID_Length (1 octet)
-					UUID (2 or 16 octets)
-
-		Valid UUID_Length parameter values:
-					0x02 = UUID16
-					0x10 = UUID128
-
-		If Status is non-zero Services_Count shall be set to 0.
-
-	Opcode 0x82 - Discover Primary Service by UUID Response
-
-		Controller Index:	<controller id>
-		Event parameters:	Address_Type (1 octet)
-					Address (6 octets)
-					Status (1 octet)
-					Services_Count (1 octet)
-					[array] Service (variable)
-
-		Object Service is defined as:
-					Start_Handle (2 octets)
-					End_Group_Handle (2 octets)
-					UUID_Length (1 octet)
-					UUID (2 or 16 octets)
-
-		Valid UUID_Length parameter values:
-					0x02 = UUID16
-					0x10 = UUID128
-
-		If Status is non-zero Services_Count shall be set to 0.
-
-	Opcode 0x83 - Find Included Services Response
-
-		Event parameters:	Address_Type (1 octet)
-					Address (6 octets)
-					Status (1 octet)
-					Services_Count (1 octet)
-					[array] Included_Service (variable)
-
-		Object Included_Service is defined as:
-					Included_Handle (2 octets)
-					Type (1 octet)
-					Service (7 or 21 octets)
-
-		Valid Type parameter values:
-					0x00 = Primary
-					0x01 = Secondary
-
-		Object Service is defined as:
-					Start_Handle (2 octets)
-					End_Group_Handle (2 octets)
-					UUID_Length (1 octet)
-					UUID (2 or 16 octets)
-
-		Valid UUID_Length parameter values:
-					0x02 = UUID16
-					0x10 = UUID128
-
-		If Status is non-zero Services_Count shall be set to 0.
-
-	Opcode 0x84 - Discover All Characteristics of a Service Response
-
-		Controller Index:	<controller id>
-		Event parameters:	Address_Type (1 octet)
-					Address (6 octets)
-					Status (1 octet)
-					Characteristics_Count (1 octet)
-					[array] Characteristic (variable)
-
-		Object Characteristic is defined as:
-					Characteristic_Handle (2 octets)
-					Value_Handle (2 octets)
-					Properties (1 octet)
-					UUID_Length (1 octet)
-					UUID (2 or 16 octets)
+        Opcode 0x80 - MTU exchanged
+
+                Controller Index:       <controller id>
+                Event parameters:       Address_Type (1 octet)
+                                        Address (6 octets)
+                                        MTU (2 octets)
+
+                This event indicates that MTU exchange was performed and new
+                MTU is in use.
+
+        Opcode 0x81 - Discover All Primary Services Response
+
+                Controller Index:       <controller id>
+                Event parameters:       Address_Type (1 octet)
+                                        Address (6 octets)
+                                        Status (1 octet)
+                                        Services_Count (1 octet)
+                                        [array] Service (variable)
+
+                Object Service is defined as:
+                        Start_Handle (2 octets)
+                        End_Group_Handle (2 octets)
+                        UUID_Length (1 octet)
+                        UUID (2 or 16 octets)
+
+                Valid UUID_Length parameter values:
+                        0x02 = UUID16
+                        0x10 = UUID128
+
+                If Status is non-zero Services_Count shall be set to 0.
+
+        Opcode 0x82 - Discover Primary Service by UUID Response
+
+                Controller Index:       <controller id>
+                Event parameters:       Address_Type (1 octet)
+                                        Address (6 octets)
+                                        Status (1 octet)
+                                        Services_Count (1 octet)
+                                        [array] Service (variable)
+
+                Object Service is defined as:
+                        Start_Handle (2 octets)
+                        End_Group_Handle (2 octets)
+                        UUID_Length (1 octet)
+                        UUID (2 or 16 octets)
+
+                Valid UUID_Length parameter values:
+                        0x02 = UUID16
+                        0x10 = UUID128
+
+                If Status is non-zero Services_Count shall be set to 0.
+
+        Opcode 0x83 - Find Included Services Response
+
+                Event parameters:       Address_Type (1 octet)
+                                        Address (6 octets)
+                                        Status (1 octet)
+                                        Services_Count (1 octet)
+                                        [array] Included_Service (variable)
+
+                Object Included_Service is defined as:
+                        Included_Handle (2 octets)
+                        Type (1 octet)
+                        Service (7 or 21 octets)
+
+                Valid Type parameter values:
+                        0x00 = Primary
+                        0x01 = Secondary
+
+                Object Service is defined as:
+                        Start_Handle (2 octets)
+                        End_Group_Handle (2 octets)
+                        UUID_Length (1 octet)
+                        UUID (2 or 16 octets)
+
+                Valid UUID_Length parameter values:
+                        0x02 = UUID16
+                        0x10 = UUID128
+
+                If Status is non-zero Services_Count shall be set to 0.
+
+        Opcode 0x84 - Discover All Characteristics of a Service Response
+
+                Controller Index:       <controller id>
+                Event parameters:       Address_Type (1 octet)
+                                        Address (6 octets)
+                                        Status (1 octet)
+                                        Characteristics_Count (1 octet)
+                                        [array] Characteristic (variable)
+
+                Object Characteristic is defined as:
+                        Characteristic_Handle (2 octets)
+                        Value_Handle (2 octets)
+                        Properties (1 octet)
+                        UUID_Length (1 octet)
+                        UUID (2 or 16 octets)
 
-		Valid UUID_Length parameter values:
-					0x02 = UUID16
-					0x10 = UUID128
-
-		If Status is non-zero Characteristics_Count shall be set to 0.
+                Valid UUID_Length parameter values:
+                        0x02 = UUID16
+                        0x10 = UUID128
+
+                If Status is non-zero Characteristics_Count shall be set to 0.
 
-	Opcode 0x85 - Discover Characteristics by UUID Response
+        Opcode 0x85 - Discover Characteristics by UUID Response
 
-		Controller Index:	<controller id>
-		Event parameters:	Address_Type (1 octet)
-					Address (6 octets)
-					Status (1 octet)
-					Characteristics_Count (1 octet)
-					[array] Characteristic (variable)
+                Controller Index:       <controller id>
+                Event parameters:       Address_Type (1 octet)
+                                        Address (6 octets)
+                                        Status (1 octet)
+                                        Characteristics_Count (1 octet)
+                                        [array] Characteristic (variable)
 
-		Object Characteristic is defined as:
-					Characteristic_Handle (2 octets)
-					Value_Handle (2 octets)
-					Properties (1 octet)
-					UUID_Length (1 octet)
-					UUID (2 or 16 octets)
+                Object Characteristic is defined as:
+                        Characteristic_Handle (2 octets)
+                        Value_Handle (2 octets)
+                        Properties (1 octet)
+                        UUID_Length (1 octet)
+                        UUID (2 or 16 octets)
 
-		Valid UUID_Length parameter values:
-					0x02 = UUID16
-					0x10 = UUID128
+                Valid UUID_Length parameter values:
+                        0x02 = UUID16
+                        0x10 = UUID128
 
-		If Status is non-zero Characteristics_Count shall be set to 0.
+                If Status is non-zero Characteristics_Count shall be set to 0.
 
-	Opcode 0x86 - Discover All Characteristic Descriptors Response
+        Opcode 0x86 - Discover All Characteristic Descriptors Response
 
-		Controller Index:	<controller id>
-		Event parameters:	Address_Type (1 octet)
-					Address (6 octets)
-					Status (1 octet)
-					Descriptors_Count (1 octet)
-					[array] Descriptor (variable)
+                Controller Index:       <controller id>
+                Event parameters:       Address_Type (1 octet)
+                                        Address (6 octets)
+                                        Status (1 octet)
+                                        Descriptors_Count (1 octet)
+                                        [array] Descriptor (variable)
 
-		Object Descriptor is defined as:
-					Descriptor_Handle (2 octets)
-					UUID_Length (1 octet)
-					UUID (2 or 16 octets)
+                Object Descriptor is defined as:
+                        Descriptor_Handle (2 octets)
+                        UUID_Length (1 octet)
+                        UUID (2 or 16 octets)
 
-		Valid UUID_Length parameter values:
-					0x02 = UUID16
-					0x10 = UUID128
+                Valid UUID_Length parameter values:
+                        0x02 = UUID16
+                        0x10 = UUID128
 
-		If Status is non-zero Descriptors_Count shall be set to 0.
+                If Status is non-zero Descriptors_Count shall be set to 0.
 
-	Opcode 0x87 - Read Characteristic Value/Descriptor Response
+        Opcode 0x87 - Read Characteristic Value/Descriptor Response
 
-		Controller Index:	<controller id>
-		Event parameters:	Address_Type (1 octet)
-					Address (6 octets)
-					Status (1 octet)
-					Data_Length (2 octets)
-					Data (variable)
+                Controller Index:       <controller id>
+                Event parameters:       Address_Type (1 octet)
+                                        Address (6 octets)
+                                        Status (1 octet)
+                                        Data_Length (2 octets)
+                                        Data (variable)
 
-		If Status is non-zero Data_Length shall be set to 0.
+                If Status is non-zero Data_Length shall be set to 0.
 
-	Opcode 0x88 - Read Using Characteristic UUID Response
+        Opcode 0x88 - Read Using Characteristic UUID Response
 
-		Controller Index:	<controller id>
-		Event parameters:	Address_Type (1 octet)
-					Address (6 octets)
-					Status (1 octet)
-					Data_Length (2 octets)
-					Value_Len (1 octet)
-					Data (variable)
+                Controller Index:       <controller id>
+                Event parameters:       Address_Type (1 octet)
+                                        Address (6 octets)
+                                        Status (1 octet)
+                                        Data_Length (2 octets)
+                                        Value_Len (1 octet)
+                                        Data (variable)
 
-		Data is array of handle-value pairs defined as:
-					Handle (2 octets)
-					Value (Value_Len octets)
+                Data is array of handle-value pairs defined as:
+                        Handle (2 octets)
+                        Value (Value_Len octets)
 
-		If Status is non-zero Data_Length shall be set to 0.
+                If Status is non-zero Data_Length shall be set to 0.
 
-	Opcode 0x89 - Read Long Characteristic Value/Descriptor Response
+        Opcode 0x89 - Read Long Characteristic Value/Descriptor Response
 
-		Controller Index:	<controller id>
-		Event parameters:	Address_Type (1 octet)
-					Address (6 octets)
-					Status (1 octet)
-					Data_Length (2 octets)
-					Data (variable)
+                Controller Index:       <controller id>
+                Event parameters:       Address_Type (1 octet)
+                                        Address (6 octets)
+                                        Status (1 octet)
+                                        Data_Length (2 octets)
+                                        Data (variable)
 
-		If Status is non-zero Data_Length shall be set to 0.
+                If Status is non-zero Data_Length shall be set to 0.
 
-	Opcode 0x8a - Read Multiple Characteristic Values Response
+        Opcode 0x8a - Read Multiple Characteristic Values Response
 
-		Controller Index:	<controller id>
-		Event parameters:	Address_Type (1 octet)
-					Address (6 octets)
-					Status (1 octet)
-					Data_Length (2 octets)
-					Data (variable)
+                Controller Index:       <controller id>
+                Event parameters:       Address_Type (1 octet)
+                                        Address (6 octets)
+                                        Status (1 octet)
+                                        Data_Length (2 octets)
+                                        Data (variable)
 
-		If Status is non-zero Data_Length shall be set to 0.
+                If Status is non-zero Data_Length shall be set to 0.
 
-	Opcode 0x8b - Write Characteristic Value/Descriptor Response
+        Opcode 0x8b - Write Characteristic Value/Descriptor Response
 
-		Controller Index:	<controller id>
-		Event parameters:	Address_Type (1 octet)
-					Address (6 octets)
-					Status (1 octet)
+                Controller Index:       <controller id>
+                Event parameters:       Address_Type (1 octet)
+                                        Address (6 octets)
+                                        Status (1 octet)
 
-	Opcode 0x8c - Write Long Characteristic Value/Descriptor Response
+        Opcode 0x8c - Write Long Characteristic Value/Descriptor Response
 
-		Controller Index:	<controller id>
-		Event parameters:	Address_Type (1 octet)
-					Address (6 octets)
-					Status (1 octet)
+                Controller Index:       <controller id>
+                Event parameters:       Address_Type (1 octet)
+                                        Address (6 octets)
+                                        Status (1 octet)
 
-	Opcode 0x8d - Reliable Write Response
+        Opcode 0x8d - Reliable Write Response
 
-		Controller Index:	<controller id>
-		Event parameters:	Address_Type (1 octet)
-					Address (6 octets)
-					Status (1 octet)
+                Controller Index:       <controller id>
+                Event parameters:       Address_Type (1 octet)
+                                        Address (6 octets)
+                                        Status (1 octet)
 
-	Opcode 0x8e - Configure Notifications Response
+        Opcode 0x8e - Configure Notifications Response
 
-		Controller Index:	<controller id>
-		Event parameters:	Address_Type (1 octet)
-					Address (6 octets)
-					Status (1 octet)
+                Controller Index:       <controller id>
+                Event parameters:       Address_Type (1 octet)
+                                        Address (6 octets)
+                                        Status (1 octet)
 
-	Opcode 0x8f - Configure Indications Response
+        Opcode 0x8f - Configure Indications Response
 
-		Controller Index:	<controller id>
-		Event parameters:	Address_Type (1 octet)
-					Address (6 octets)
-					Status (1 octet)
+                Controller Index:       <controller id>
+                Event parameters:       Address_Type (1 octet)
+                                        Address (6 octets)
+                                        Status (1 octet)
 
-	Opcode 0x90 - Notification/Indication Received
+        Opcode 0x90 - Notification/Indication Received
 
-		Controller Index:	<controller id>
-		Event parameters:	Address_Type (1 octet)
-					Address (6 octets)
-					Type (1 octet)
-					Handle (2 octets)
-					Data_Length (2 octets)
-					Data (variable)
+                Controller Index:       <controller id>
+                Event parameters:       Address_Type (1 octet)
+                                        Address (6 octets)
+                                        Type (1 octet)
+                                        Handle (2 octets)
+                                        Data_Length (2 octets)
+                                        Data (variable)
 
-		Valid Type parameter values:
-					0x01 = Notification
-					0x02 = Indication
+                Valid Type parameter values:
+                        0x01 = Notification
+                        0x02 = Indication
 
-		This event indicates that IUT has received notification
-		or indication.
+                This event indicates that IUT has received notification
+                or indication.
 
-	Opcode 0x91 - Read Multiple Variable Characteristic Values Response
+        Opcode 0x91 - Read Multiple Variable Characteristic Values Response
 
-		Controller Index:	<controller id>
-		Event parameters:	Address_Type (1 octet)
-					Address (6 octets)
-					Status (1 octet)
-					Data_Length (2 octets)
-					Data (variable)
+                Controller Index:       <controller id>
+                Event parameters:       Address_Type (1 octet)
+                                        Address (6 octets)
+                                        Status (1 octet)
+                                        Data_Length (2 octets)
+                                        Data (variable)
 
-		Data is array of length-value pairs defined as:
-					Value_Len (2 octets)
-					Value (Value_Len octets)
+                Data is array of length-value pairs defined as:
+                        Value_Len (2 octets)
+                        Value (Value_Len octets)
 
-		If Status is non-zero Data_Length shall be set to 0.
+                If Status is non-zero Data_Length shall be set to 0.

--- a/doc/btp_gatt_server.txt
+++ b/doc/btp_gatt_server.txt
@@ -5,99 +5,99 @@ services and characteristics required by tests supported by IUT.
 
 Commands and responses:
 
-	Opcode 0x01 - Read Supported Commands command/response
+        Opcode 0x01 - Read Supported Commands command/response
 
-		Controller Index:	<non-controller>
-		Command parameters:	<none>
-		Response parameters:	<supported commands> (variable)
+                Controller Index:       <non-controller>
+                Command parameters:     <none>
+                Response parameters:    <supported commands> (variable)
 
-		Each bit in response is a flag indicating if command with
-		opcode matching bit number is supported. Bit set to 1 means
-		that command is supported. Bit 0 is reserved and shall always
-		be set to 0. If specific bit is not present in response (less
-		than required bytes received) it shall be assumed that command
-		is not supported.
+                Each bit in response is a flag indicating if command with
+                opcode matching bit number is supported. Bit set to 1 means
+                that command is supported. Bit 0 is reserved and shall always
+                be set to 0. If specific bit is not present in response (less
+                than required bytes received) it shall be assumed that command
+                is not supported.
 
-		In case of an error, the error response will be returned.
+                In case of an error, the error response will be returned.
 
-	Opcode 0x02 - Get Attributes
+        Opcode 0x02 - Get Attributes
 
-		Controller Index:	<controller id>
-		Command parameters:	Start Handle (2 octets)
-					End Handle (2 octets)
-					Type_Length (1 octet)
-					Type (2 or 16 octets)
-		Response parameters:	Attributes_Count (1 octet)
-					[array] Attribute (variable)
+                Controller Index:       <controller id>
+                Command parameters:     Start Handle (2 octets)
+                                        End Handle (2 octets)
+                                        Type_Length (1 octet)
+                                        Type (2 or 16 octets)
+                Response parameters:    Attributes_Count (1 octet)
+                                        [array] Attribute (variable)
 
-		Object Attribute is defined as:
-					Handle (2 octets)
-					Permission (1 octet)
-					Type_Length (1 octet)
-					Type (2 or 16 octets)
+                Object Attribute is defined as:
+                                        Handle (2 octets)
+                                        Permission (1 octet)
+                                        Type_Length (1 octet)
+                                        Type (2 or 16 octets)
 
-		Valid Type_Length parameter values:
-					0x02 = UUID16
-					0x10 = UUID128
+                Valid Type_Length parameter values:
+                        0x02 = UUID16
+                        0x10 = UUID128
 
-		This procedure is used to query GATT Server for attributes based
-		on given search pattern. Attributes can be searched using
-		Attribute Handle range and Attribute Type.
+                This procedure is used to query GATT Server for attributes based
+                on given search pattern. Attributes can be searched using
+                Attribute Handle range and Attribute Type.
 
-		In case of an error, the error response will be returned.
+                In case of an error, the error response will be returned.
 
-	Opcode 0x03 - Get Attribute Value
+        Opcode 0x03 - Get Attribute Value
 
-		Controller Index:	<controller id>
-		Command parameters:	Address_Type (1 octet)
-					Address (6 octets)
-					Handle (2 octets)
-		Response parameters:	Value_Length (2 octet)
-					Value (variable)
+                Controller Index:       <controller id>
+                Command parameters:     Address_Type (1 octet)
+                                        Address (6 octets)
+                                        Handle (2 octets)
+                Response parameters:    Value_Length (2 octet)
+                                        Value (variable)
 
-		This procedure is used to query GATT Server for attribute value.
+                This procedure is used to query GATT Server for attribute value.
 
-		In case of an error, the error response will be returned.
+                In case of an error, the error response will be returned.
 
-	Opcode 0x04 - Set Characteristic/Descriptor Value
+        Opcode 0x04 - Set Characteristic/Descriptor Value
 
-		Controller Index:	<controller id>
-		Command parameters:	Address_Type (1 octet)
-					Address (6 octets)
-					Handle (2 octets)
-					Value_Length (2 octet)
-					Value (variable)
-		Response parameters:	<none>
+                Controller Index:       <controller id>
+                Command parameters:     Address_Type (1 octet)
+                                        Address (6 octets)
+                                        Handle (2 octets)
+                                        Value_Length (2 octet)
+                                        Value (variable)
+                Response parameters:    <none>
 
-		This command is used to set the value of characteristic
-		or descriptor.
+                This command is used to set the value of characteristic
+                or descriptor.
 
-		In case of an error, the error response will be returned.
+                In case of an error, the error response will be returned.
 
-	Opcode 0x05 - Change Database
+        Opcode 0x05 - Change Database
 
-		Controller Index:	<controller id>
-		Command parameters:	<none>
-		Response parameters:	<none>
+                Controller Index:       <controller id>
+                Command parameters:     <none>
+                Response parameters:    <none>
 
-		This procedure is used to change content of database that will
-		result in peer doing database re-discovery. Details of how
-		database is changed is IUT specific.
+                This procedure is used to change content of database that will
+                result in peer doing database re-discovery. Details of how
+                database is changed is IUT specific.
 
-		In case of an error, the error response will be returned.
+                In case of an error, the error response will be returned.
 
 Events:
 
-	Opcode 0x81 - Attribute Value Changed
+        Opcode 0x81 - Attribute Value Changed
 
-		Controller Index:	<controller id>
-		Event parameters:	Address_Type (1 octet)
-					Address (6 octets)
-					Handle (2 octets)
-					Data_Length (2 octet)
-					Data (variable)
+                Controller Index:       <controller id>
+                Event parameters:       Address_Type (1 octet)
+                                        Address (6 octets)
+                                        Handle (2 octets)
+                                        Data_Length (2 octet)
+                                        Data (variable)
 
-		This event command is used to indicate attribute
-		(characteristic or descriptor) value changed.
-		Event is triggered when ATT Write operation to Tester GATT
-		Server has been performed successfully.
+                This event command is used to indicate attribute
+                (characteristic or descriptor) value changed.
+                Event is triggered when ATT Write operation to Tester GATT
+                Server has been performed successfully.

--- a/doc/btp_gmcs.txt
+++ b/doc/btp_gmcs.txt
@@ -3,85 +3,86 @@ Generic Media Control Service(ID 23)
 
 Commands and responses:
 
-	Opcode 0x00 - Error response
+        Opcode 0x00 - Error response
 
-	Opcode 0x01 - Read supported commands
-		Controller Index:       <controller id>
-		Command parameters:     <none>
-		Response parameters:    <supported commands> (variable)
+        Opcode 0x01 - Read supported commands
 
-		Each bit in response is a flag indicating if command with
-		opcode matching bit number is supported. Bit set to 1 means
-		that command is supported. Bit 0 is reserved and shall always
-		be set to 0. If specific bit is not present in response (less
-		than required bytes received) it shall be assumed that command
-		is not supported.
+                Controller Index:       <controller id>
+                Command parameters:     <none>
+                Response parameters:    <supported commands> (variable)
 
-		In case of an error, the error response will be returned.
+                Each bit in response is a flag indicating if command with
+                opcode matching bit number is supported. Bit set to 1 means
+                that command is supported. Bit 0 is reserved and shall always
+                be set to 0. If specific bit is not present in response (less
+                than required bytes received) it shall be assumed that command
+                is not supported.
 
-	Opcode 0x02 - Command Send
+                In case of an error, the error response will be returned.
 
-		Controller Index:	<controller id>
-		Command parameters:	Opcode (1 octets)
-					Use Param (1 octet)
-					Param (Varies)
-		Response parameters:    <none>
+        Opcode 0x02 - Command Send
 
-		This command is used to trigger media player action defined by
-		opcode. Use Param is boolean variable. Param variable is
-		initialized only if Use Param is True.
+                Controller Index:       <controller id>
+                Command parameters:     Opcode (1 octets)
+                                        Use Param (1 octet)
+                                        Param (Varies)
+                Response parameters:    <none>
 
-		Opcodes: 0x01 - Play
-			 0x02 - Pause
-			 0x03 - Fast Rewind
-			 0x04 - Fast Forward
-			 0x05 - Stop
-			 0x10 - Move Relative (uses Param)
-			 0x20 - Previous Segment
-			 0x21 - Next Segment
-			 0x22 - First Segment
-			 0x23 - Last Segment
-			 0x24 - Goto Segment (uses Param)
-			 0x30 - Previous Track
-			 0x30 - Previous Track
-			 0x31 - Next Track
-			 0x32 - First Track
-			 0x33 - Last Track
-			 0x34 - Goto Track (uses Param)
-			 0x40 - Previous Group
-			 0x41 - Next Group
-			 0x42 - First Group
-			 0x43 - Last Group
-			 0x44 - Goto Group (uses Param)
+                This command is used to trigger media player action defined by
+                opcode. Use Param is boolean variable. Param variable is
+                initialized only if Use Param is True.
 
-	Opcode 0x04 - Current Track Object ID Get
+                Opcodes: 0x01 - Play
+                         0x02 - Pause
+                         0x03 - Fast Rewind
+                         0x04 - Fast Forward
+                         0x05 - Stop
+                         0x10 - Move Relative (uses Param)
+                         0x20 - Previous Segment
+                         0x21 - Next Segment
+                         0x22 - First Segment
+                         0x23 - Last Segment
+                         0x24 - Goto Segment (uses Param)
+                         0x30 - Previous Track
+                         0x30 - Previous Track
+                         0x31 - Next Track
+                         0x32 - First Track
+                         0x33 - Last Track
+                         0x34 - Goto Track (uses Param)
+                         0x40 - Previous Group
+                         0x41 - Next Group
+                         0x42 - First Group
+                         0x43 - Last Group
+                         0x44 - Goto Group (uses Param)
 
-		Controller Index:	<controller id>
-		Command parameters:     <none>
-		Response parameters:    Current Track Object ID (6 octets)
+        Opcode 0x04 - Current Track Object ID Get
 
-		This command is used to read Current Track Object ID.
+                Controller Index:       <controller id>
+                Command parameters:     <none>
+                Response parameters:    Current Track Object ID (6 octets)
 
-	Opcode 0x05 - Next Track Object ID Get
+                This command is used to read Current Track Object ID.
 
-		Controller Index:	<controller id>
-		Command parameters:     <none>
-		Response parameters:    Next Track Object ID (6 octets)
+        Opcode 0x05 - Next Track Object ID Get
 
-		This command is used to read Next Track Object ID.
+                Controller Index:       <controller id>
+                Command parameters:     <none>
+                Response parameters:    Next Track Object ID (6 octets)
 
-	Opcode 0x06 - Set Inactive State
+                This command is used to read Next Track Object ID.
 
-		Controller Index:	<controller id>
-		Command parameters:     <none>
-		Response parameters:    Media Player State (1 octet)
+        Opcode 0x06 - Set Inactive State
 
-		Set media player into inactive state.
+                Controller Index:       <controller id>
+                Command parameters:     <none>
+                Response parameters:    Media Player State (1 octet)
 
-	Opcode 0x07 - Set Parent Group
+                Set media player into inactive state.
 
-		Controller Index:	<controller id>
-		Command parameters:     <none>
-		Response parameters:    <none>
+        Opcode 0x07 - Set Parent Group
 
-		Set Media Player's Current Group to be it's own Parent Group.
+                Controller Index:       <controller id>
+                Command parameters:     <none>
+                Response parameters:    <none>
+
+                Set Media Player's Current Group to be it's own Parent Group.

--- a/doc/btp_gtbs.txt
+++ b/doc/btp_gtbs.txt
@@ -3,19 +3,19 @@ GTBS Service (ID 28)
 
 Commands and responses:
 
-	Opcode 0x00 - Error response
+        Opcode 0x00 - Error response
 
-	Opcode 0x01 - Read Supported Commands command/response
+        Opcode 0x01 - Read Supported Commands command/response
 
-		Controller Index:	<controller id>
-		Command parameters:	<none>
-		Response parameters:	<supported commands> (variable)
+                Controller Index:       <controller id>
+                Command parameters:     <none>
+                Response parameters:    <supported commands> (variable)
 
-		Each bit in response is a flag indicating if command with
-		opcode matching bit number is supported. Bit set to 1 means
-		that command is supported. Bit 0 is reserved and shall always
-		be set to 0. If specific bit is not present in response (less
-		than required bytes received) it shall be assumed that command
-		is not supported.
+                Each bit in response is a flag indicating if command with
+                opcode matching bit number is supported. Bit set to 1 means
+                that command is supported. Bit 0 is reserved and shall always
+                be set to 0. If specific bit is not present in response (less
+                than required bytes received) it shall be assumed that command
+                is not supported.
 
-		In case of an error, the error response will be returned.
+                In case of an error, the error response will be returned.

--- a/doc/btp_hap.txt
+++ b/doc/btp_hap.txt
@@ -3,236 +3,236 @@ HAP Service (ID 24)
 
 Commands and responses:
 
-	Opcode 0x00 - Error response
+        Opcode 0x00 - Error response
 
-	Opcode 0x01 - Read Supported Commands command/response
+        Opcode 0x01 - Read Supported Commands command/response
 
-		Controller Index:	<controller id>
-		Command parameters:	<none>
-		Response parameters:	<supported commands> (variable)
+                Controller Index:       <controller id>
+                Command parameters:     <none>
+                Response parameters:    <supported commands> (variable)
 
-		Each bit in response is a flag indicating if command with
-		opcode matching bit number is supported. Bit set to 1 means
-		that command is supported. Bit 0 is reserved and shall always
-		be set to 0. If specific bit is not present in response (less
-		than required bytes received) it shall be assumed that command
-		is not supported.
+                Each bit in response is a flag indicating if command with
+                opcode matching bit number is supported. Bit set to 1 means
+                that command is supported. Bit 0 is reserved and shall always
+                be set to 0. If specific bit is not present in response (less
+                than required bytes received) it shall be assumed that command
+                is not supported.
 
-		In case of an error, the error response will be returned.
+                In case of an error, the error response will be returned.
 
-	Opcode 0x02: Hearing Aid (HA) role init
+        Opcode 0x02: Hearing Aid (HA) role init
 
-		Controller Index:	<controller id>
-		Command parameters:	Type (1 octet)
-					Options (2 octets)
-		Response parameters:	<none>
+                Controller Index:       <controller id>
+                Command parameters:     Type (1 octet)
+                                        Options (2 octets)
+                Response parameters:    <none>
 
-		Valid Type values:	0x00 = Binaural Hearing Aid
-					0x01 = Monaural Hearing Aid
-					0x02 = Banded Hearing Aid
+                Valid Type values:      0x00 = Binaural Hearing Aid
+                                        0x01 = Monaural Hearing Aid
+                                        0x02 = Banded Hearing Aid
 
-		Options and is a bitmask with currently the following available
-		bits:
-			0	Preset Synchronization Support
-			1	Independent Presets
-			2	Dynamic Presets
-			3	Writable Presets Support
-			4-15	RFU
+                Options and is a bitmask with currently the following available
+                bits:
+                        0       Preset Synchronization Support
+                        1       Independent Presets
+                        2       Dynamic Presets
+                        3       Writable Presets Support
+                        4-15    RFU
 
-		This command is used to set up Hearing Aid.
-		In case of an error, the error status response will be returned.
+                This command is used to set up Hearing Aid.
+                In case of an error, the error status response will be returned.
 
-	Opcode 0x03: Hearing Aid Remote Controller (HARC) role init
+        Opcode 0x03: Hearing Aid Remote Controller (HARC) role init
 
-		Controller Index:	<controller id>
-		Command parameters:	<none>
-		Response parameters:	<none>
+                Controller Index:       <controller id>
+                Command parameters:     <none>
+                Response parameters:    <none>
 
-		This command is used to set up Hearing Aid Remote Controller.
-		In case of an error, the error status response will be returned.
+                This command is used to set up Hearing Aid Remote Controller.
+                In case of an error, the error status response will be returned.
 
-	Opcode 0x04: Hearing Aid Unicast Client (HAUC) role init
+        Opcode 0x04: Hearing Aid Unicast Client (HAUC) role init
 
-		Controller Index:	<controller id>
-		Command parameters:	<none>
-		Response parameters:	<none>
+                Controller Index:       <controller id>
+                Command parameters:     <none>
+                Response parameters:    <none>
 
-		This command is used to set up Hearing Aid Unicast Client.
-		In case of an error, the error status response will be returned.
+                This command is used to set up Hearing Aid Unicast Client.
+                In case of an error, the error status response will be returned.
 
-	Opcode 0x05: Immediate Alert Client (IAC) role init
+        Opcode 0x05: Immediate Alert Client (IAC) role init
 
-		Controller Index:	<controller id>
-		Command parameters:	<none>
-		Response parameters:	<none>
+                Controller Index:       <controller id>
+                Command parameters:     <none>
+                Response parameters:    <none>
 
-		This command is used to set up Immediate Alert Client.
-		In case of an error, the error status response will be returned.
+                This command is used to set up Immediate Alert Client.
+                In case of an error, the error status response will be returned.
 
-	Opcode 0x06: Immediate Alert Client (IAC) discover
+        Opcode 0x06: Immediate Alert Client (IAC) discover
 
-		Controller Index:	<controller id>
-		Command parameters:	Address_Type (1 octet)
-					Address (6 octets)
-		Response parameters:	<none>
+                Controller Index:       <controller id>
+                Command parameters:     Address_Type (1 octet)
+                                        Address (6 octets)
+                Response parameters:    <none>
 
-		This command is used to discover Immediate Alert Service
-		on a server.
-		Discovery status is returned in the Immediate Alert Client (IAC)
-		discovery result event.
-		In case of an error, the error response will be returned.
+                This command is used to discover Immediate Alert Service
+                on a server.
+                Discovery status is returned in the Immediate Alert Client (IAC)
+                discovery result event.
+                In case of an error, the error response will be returned.
 
-	Opcode 0x07: Immediate Alert Client (IAC) set alert
+        Opcode 0x07: Immediate Alert Client (IAC) set alert
 
-		Controller Index:	<controller id>
-		Command parameters:	Address_Type (1 octet)
-					Address (6 octets)
-					Level (1 octet)
-		Response parameters:	<none>
+                Controller Index:       <controller id>
+                Command parameters:     Address_Type (1 octet)
+                                        Address (6 octets)
+                                        Level (1 octet)
+                Response parameters:    <none>
 
-		Valid Level values:	0x00 = No Alert
-					0x01 = Medium Alert
-					0x02 = High Alert
+                Valid Level values:     0x00 = No Alert
+                                        0x01 = Medium Alert
+                                        0x02 = High Alert
 
-		This command is used to set Immediate Alert Level on remote
-		server.
-		In case of an error, the error response will be returned.
+                This command is used to set Immediate Alert Level on remote
+                server.
+                In case of an error, the error response will be returned.
 
-	Opcode 0x08: Hearing Aid Unicast Client (HAUC) discover
+        Opcode 0x08: Hearing Aid Unicast Client (HAUC) discover
 
-		Controller Index:	<controller id>
-		Command parameters:	Address_Type (1 octet)
-					Address (6 octets)
-		Response parameters:	<none>
+                Controller Index:       <controller id>
+                Command parameters:     Address_Type (1 octet)
+                                        Address (6 octets)
+                Response parameters:    <none>
 
-		This command is used to discover all the Hearing Access related
-		services and characteristics on a server.
-		Discovery status is returned in the Hearing Aid Unicast Client
-		(HAUC) discovery result event.
-		In case of an error, the error response will be returned.
+                This command is used to discover all the Hearing Access related
+                services and characteristics on a server.
+                Discovery status is returned in the Hearing Aid Unicast Client
+                (HAUC) discovery result event.
+                In case of an error, the error response will be returned.
 
-	Opcode 0x09: HAP Read Presets
+        Opcode 0x09: HAP Read Presets
 
-		Controller Index:	<controller id>
-		Command parameters:	Address_Type (1 octet)
-					Address (6 octets)
-					Start_Index (1 octet)
-					Num_Presets (1 octet)
-		Response parameters:	<None>
+                Controller Index:       <controller id>
+                Command parameters:     Address_Type (1 octet)
+                                        Address (6 octets)
+                                        Start_Index (1 octet)
+                                        Num_Presets (1 octet)
+                Response parameters:    <None>
 
-		This command is used to read the selected Presets.
-		Each preset is returned in a Hearing Aid Preset Read event.
+                This command is used to read the selected Presets.
+                Each preset is returned in a Hearing Aid Preset Read event.
 
-		In case of an error, the error response will be returned.
+                In case of an error, the error response will be returned.
 
-	Opcode 0x0A: HAP Write Preset Name
+        Opcode 0x0A: HAP Write Preset Name
 
-		Controller Index:	<controller id>
-		Command parameters:	Address_Type (1 octet)
-					Address (6 octets)
-					Preset Index (1 octet)
-					Name Length (1 octet)
-					Name (<Name Length> octets)
-		Response parameters:	<None>
+                Controller Index:       <controller id>
+                Command parameters:     Address_Type (1 octet)
+                                        Address (6 octets)
+                                        Preset Index (1 octet)
+                                        Name Length (1 octet)
+                                        Name (<Name Length> octets)
+                Response parameters:    <None>
 
                 Name shall be a UTF-8 encoded string.
-		Name Length holds the number of bytes in the UTF-8 encoded name.
+                Name Length holds the number of bytes in the UTF-8 encoded name.
 
-		This command is used to change the Name of a Preset.
+                This command is used to change the Name of a Preset.
 
-		In case of an error, the error response will be returned.
+                In case of an error, the error response will be returned.
 
-	Opcode 0x0B: HAP Set Active Preset
+        Opcode 0x0B: HAP Set Active Preset
 
-		Controller Index:	<controller id>
-		Command parameters:	Address_Type (1 octet)
-					Address (6 octets)
-					Preset_Index (1 octet)
-					Synchronized_Locally (1 octet)
-		Response parameters:	<None>
+                Controller Index:       <controller id>
+                Command parameters:     Address_Type (1 octet)
+                                        Address (6 octets)
+                                        Preset_Index (1 octet)
+                                        Synchronized_Locally (1 octet)
+                Response parameters:    <None>
 
-		This command is used to set the Active Preset.
-		If called with a Preset Index of 0, it will de-select the Active Preset.
+                This command is used to set the Active Preset.
+                If called with a Preset Index of 0, it will de-select the Active Preset.
 
-		In case of an error, the error response will be returned.
+                In case of an error, the error response will be returned.
 
-	Opcode 0x0C: HAP Set Next Preset
+        Opcode 0x0C: HAP Set Next Preset
 
-		Controller Index:	<controller id>
-		Command parameters:	Address_Type (1 octet)
-					Address (6 octets)
-					Synchronized_Locally (1)
-		Response parameters:	<None>
+                Controller Index:       <controller id>
+                Command parameters:     Address_Type (1 octet)
+                                        Address (6 octets)
+                                        Synchronized_Locally (1)
+                Response parameters:    <None>
 
-		This command is used to set the Active Preset.
+                This command is used to set the Active Preset.
 
-		In case of an error, the error response will be returned.
+                In case of an error, the error response will be returned.
 
-	Opcode 0x0C: HAP Set Previous Preset
+        Opcode 0x0C: HAP Set Previous Preset
 
-		Controller Index:	<controller id>
-		Command parameters:	Address_Type (1 octet)
-					Address (6 octets)
-					Synchronized_Locally (1)
-		Response parameters:	<None>
+                Controller Index:       <controller id>
+                Command parameters:     Address_Type (1 octet)
+                                        Address (6 octets)
+                                        Synchronized_Locally (1)
+                Response parameters:    <None>
 
-		This command is used to set the Active Preset.
+                This command is used to set the Active Preset.
 
-		In case of an error, the error response will be returned.
+                In case of an error, the error response will be returned.
 
 Events:
-	Opcode 0x80 - Immediate Alert Client (IAC) discovery result
+        Opcode 0x80 - Immediate Alert Client (IAC) discovery result
 
-		Controller Index:	<controller id>
-		Event parameters:	Address_Type (1 octet)
-					Address (6 octets)
-					ATT_Error (1 octet)
+                Controller Index:       <controller id>
+                Event parameters:       Address_Type (1 octet)
+                                        Address (6 octets)
+                                        ATT_Error (1 octet)
 
-	Opcode 0x81 - Hearing Aid Unicast Client (HAUC) discovery result
+        Opcode 0x81 - Hearing Aid Unicast Client (HAUC) discovery result
 
-		Controller Index:	<controller id>
-		Event parameters:	Address_Type (1 octet)
-					Address (6 octets)
-					Status (1 octet)
-					Type (1 octet)
-					HAS_Hearing_Aid_Features_Handle (2 octets)
-					HAS_Control_Point_Handle (2 octets)
-					HAS_Active_Preset_Index_Handle (2 octets)
+                Controller Index:       <controller id>
+                Event parameters:       Address_Type (1 octet)
+                                        Address (6 octets)
+                                        Status (1 octet)
+                                        Type (1 octet)
+                                        HAS_Hearing_Aid_Features_Handle (2 octets)
+                                        HAS_Control_Point_Handle (2 octets)
+                                        HAS_Active_Preset_Index_Handle (2 octets)
 
-		Valid Type values:	0x00 = Binaural Hearing Aid
-					0x01 = Monaural Hearing Aid
-					0x02 = Banded Hearing Aid
+                Valid Type values:      0x00 = Binaural Hearing Aid
+                                        0x01 = Monaural Hearing Aid
+                                        0x02 = Banded Hearing Aid
 
-	Opcode 0x82 - Hearing Aid Preset Read event
-		Controller Index:	<controller id>
-		Event parameters:	Address_Type (1 octet)
-					Address (6 octets)
-					Preset_Index (1 octet)
-					Properties (1 octet)
-					Name_Length (1 octet)
-					Name (<Name Length> octets)
+        Opcode 0x82 - Hearing Aid Preset Read event
+                Controller Index:       <controller id>
+                Event parameters:       Address_Type (1 octet)
+                                        Address (6 octets)
+                                        Preset_Index (1 octet)
+                                        Properties (1 octet)
+                                        Name_Length (1 octet)
+                                        Name (<Name Length> octets)
 
-		Properties:             bit 0: The name of the preset is writable
-					bit 1: The preset is available
+                Properties:             bit 0: The name of the preset is writable
+                                        bit 1: The preset is available
 
                 Name shall be a UTF-8 encoded string.
-		Name Length holds the number of bytes in the UTF-8 encoded name.
+                Name Length holds the number of bytes in the UTF-8 encoded name.
 
-	Opcode 0x83 - Hearing Aid Preset Changed event
-		Controller Index:	<controller id>
-		Event parameters:	Address_Type (1 octet)
-					Address (6 octets)
-					Change_Id (1 octet)
-					Is_Last (1 octet)
-					Preset_Index (1 octet)
-					Prev_Index (1 octet)        - for Generic Update
-					Properties (1 octet)        - for Generic Update
-					Name_Length (1 octet)       - for Generic Update
-					Name (<Name Length> octets) - for Generic Update
+        Opcode 0x83 - Hearing Aid Preset Changed event
+                Controller Index:       <controller id>
+                Event parameters:       Address_Type (1 octet)
+                                        Address (6 octets)
+                                        Change_Id (1 octet)
+                                        Is_Last (1 octet)
+                                        Preset_Index (1 octet)
+                                        Prev_Index (1 octet)        - for Generic Update
+                                        Properties (1 octet)        - for Generic Update
+                                        Name_Length (1 octet)       - for Generic Update
+                                        Name (<Name Length> octets) - for Generic Update
 
-		Change_Id values:       0x00 = Generic Update
-					0x01 = Preset Record Deleted
-					0x02 = Preset Record Available
-					0x03 = Preset Record Unavailable
+                Change_Id values:       0x00 = Generic Update
+                                        0x01 = Preset Record Deleted
+                                        0x02 = Preset Record Available
+                                        0x03 = Preset Record Unavailable
 
 

--- a/doc/btp_has.txt
+++ b/doc/btp_has.txt
@@ -3,105 +3,104 @@ HAS Service (ID 15)
 
 Commands and responses:
 
-	Opcode 0x00 - Error response
+        Opcode 0x00 - Error response
 
-	Opcode 0x01 - Read Supported Commands command/response
+        Opcode 0x01 - Read Supported Commands command/response
 
-		Controller Index:	<controller id>
-		Command parameters:	<none>
-		Response parameters:	<supported commands> (variable)
+                Controller Index:       <controller id>
+                Command parameters:     <none>
+                Response parameters:    <supported commands> (variable)
 
-		Each bit in response is a flag indicating if command with
-		opcode matching bit number is supported. Bit set to 1 means
-		that command is supported. Bit 0 is reserved and shall always
-		be set to 0. If specific bit is not present in response (less
-		than required bytes received) it shall be assumed that command
-		is not supported.
+                Each bit in response is a flag indicating if command with
+                opcode matching bit number is supported. Bit set to 1 means
+                that command is supported. Bit 0 is reserved and shall always
+                be set to 0. If specific bit is not present in response (less
+                than required bytes received) it shall be assumed that command
+                is not supported.
 
-		In case of an error, the error response will be returned.
+                In case of an error, the error response will be returned.
 
-	Opcode 0x02: HAS Set Active Preset Index
+        Opcode 0x02: HAS Set Active Preset Index
 
-		Controller Index:	<controller id>
-		Command parameters:	Address_Type (1 octet)
-					Address (6 octets)
-					Preset Index (1 octet)
-		Response parameters:	<None>
+                Controller Index:       <controller id>
+                Command parameters:     Address_Type (1 octet)
+                                        Address (6 octets)
+                                        Preset Index (1 octet)
+                Response parameters:    <None>
 
-		This command is used to set the Active Preset. 
-		If called with a Preset Index of 0, it will de-select the Active Preset.
-		
-		In case of an error, the error response will be returned.
+                This command is used to set the Active Preset. 
+                If called with a Preset Index of 0, it will de-select the Active Preset.
+                
+                In case of an error, the error response will be returned.
 
-	Opcode 0x03: HAS Set Preset Name
+        Opcode 0x03: HAS Set Preset Name
 
-		Controller Index:	<controller id>
-		Command parameters:	Address_Type (1 octet)
-					Address (6 octets)
-					Preset Index (1 octet)
-					Name Length (1 octet)
-					Name (<Name Length> octets)
-		Response parameters:	<None>
+                Controller Index:       <controller id>
+                Command parameters:     Address_Type (1 octet)
+                                        Address (6 octets)
+                                        Preset Index (1 octet)
+                                        Name Length (1 octet)
+                                        Name (<Name Length> octets)
+                Response parameters:    <None>
 
-        Name shall be a UTF-8 encoded string. 
-		Name Length holds the number of bytes in the UTF-8 encoded name. 
+                Name Length holds the number of bytes in the UTF-8 encoded name. 
 
-		This command is used to change the Name of a Preset.
+                This command is used to change the Name of a Preset.
 
-		In case of an error, the error response will be returned.
+                In case of an error, the error response will be returned.
 
-	Opcode 0x04: HAS Remove Preset
+        Opcode 0x04: HAS Remove Preset
 
-		Controller Index:	<controller id>
-		Command parameters:	Address_Type (1 octet)
-					Address (6 octets)
-					Preset Index (1 octet)
-		Response parameters:	<None>
+                Controller Index:       <controller id>
+                Command parameters:     Address_Type (1 octet)
+                                        Address (6 octets)
+                                        Preset Index (1 octet)
+                Response parameters:    <None>
 
-		Passing Preset Index := 0 will remove all active Presets.
+                Passing Preset Index := 0 will remove all active Presets.
 
-		This command is used to delete a specific Preset or all Presets.
+                This command is used to delete a specific Preset or all Presets.
 
-		In case of an error, the error response will be returned.
+                In case of an error, the error response will be returned.
 
-	Opcode 0x05: HAS Add Preset
+        Opcode 0x05: HAS Add Preset
 
-		Controller Index:	<controller id>
-		Command parameters:	Address_Type (1 octet)
-					Address (6 octets)
-					Preset Index (1 octet)
-					Preset Properties (1 octet)
-					Name Length (1 octet)
-					Name (<Name Length> octets)
-		Response parameters:	<None>
+                Controller Index:       <controller id>
+                Command parameters:     Address_Type (1 octet)
+                                        Address (6 octets)
+                                        Preset Index (1 octet)
+                                        Preset Properties (1 octet)
+                                        Name Length (1 octet)
+                                        Name (<Name Length> octets)
+                Response parameters:    <None>
 
-		Preset Properties is a bit-field, with the following interpretation: 
-		Preset Properties:
-				1 - Preset will be Writable (N.U.)
-				2 - Preset will be Available
+                Preset Properties is a bit-field, with the following interpretation: 
+                Preset Properties:
+                                1 - Preset will be Writable (N.U.)
+                                2 - Preset will be Available
 
         Name shall be a UTF-8 encoded string (nul-termination not needed). 
-		Name Length holds the number of bytes in the UTF-8 encoded name. 
+                Name Length holds the number of bytes in the UTF-8 encoded name. 
 
-		This command is used to add a new Preset.
+                This command is used to add a new Preset.
 
-		In case of an error, the error response will be returned.
+                In case of an error, the error response will be returned.
 
-	Opcode 0x06: HAS Set Preset Properties (available/unavailable)
+        Opcode 0x06: HAS Set Preset Properties (available/unavailable)
 
-		Controller Index:	<controller id>
-		Command parameters:	Address_Type (1 octet)
-					Address (6 octets)
-					Preset Index (1 octet)
-					Preset Properties (1 octet)
-		Response parameters:	<None>
+                Controller Index:       <controller id>
+                Command parameters:     Address_Type (1 octet)
+                                        Address (6 octets)
+                                        Preset Index (1 octet)
+                                        Preset Properties (1 octet)
+                Response parameters:    <None>
 
-		Preset Properties is a bit-field, with the following interpretation: 
-		Preset Properties:
-				1 - Preset will be Writable (N.U.)
-				2 - Preset will be Available
+                Preset Properties is a bit-field, with the following interpretation: 
+                Preset Properties:
+                                1 - Preset will be Writable (N.U.)
+                                2 - Preset will be Available
 
-		This command is used to change a Preset's available/unavailable property.
+                This command is used to change a Preset's available/unavailable property.
 
-		In case of an error, the error response will be returned.
+                In case of an error, the error response will be returned.
 

--- a/doc/btp_ias.txt
+++ b/doc/btp_ias.txt
@@ -2,7 +2,7 @@ Immediate Alert Service (ID 9)
 =============================
 
 Events:
-	Opcode 0x80 - Alert level action Event
+        Opcode 0x80 - Alert level action Event
 
-		Controller Index:	<controller id>
-		Event parameters:	Alert level (1 octet)
+                Controller Index:       <controller id>
+                Event parameters:       Alert level (1 octet)

--- a/doc/btp_l2cap.txt
+++ b/doc/btp_l2cap.txt
@@ -3,227 +3,227 @@ L2CAP Service (ID 3)
 
 Commands and responses:
 
-	Opcode 0x00 - Error response
+        Opcode 0x00 - Error response
 
-	Opcode 0x01 - Read Supported Commands command/response
+        Opcode 0x01 - Read Supported Commands command/response
 
-		Controller Index:	<controller id>
-		Command parameters:	<none>
-		Response parameters:	<supported commands> (variable)
+                Controller Index:       <controller id>
+                Command parameters:     <none>
+                Response parameters:    <supported commands> (variable)
 
-		Each bit in response is a flag indicating if command with
-		opcode matching bit number is supported. Bit set to 1 means
-		that command is supported. Bit 0 is reserved and shall always
-		be set to 0. If specific bit is not present in response (less
-		than required bytes received) it shall be assumed that command
-		is not supported.
+                Each bit in response is a flag indicating if command with
+                opcode matching bit number is supported. Bit set to 1 means
+                that command is supported. Bit 0 is reserved and shall always
+                be set to 0. If specific bit is not present in response (less
+                than required bytes received) it shall be assumed that command
+                is not supported.
 
-		In case of an error, the error response will be returned.
+                In case of an error, the error response will be returned.
 
-	Opcode 0x02 - Connect command/response
+        Opcode 0x02 - Connect command/response
 
-		Controller Index:	<controller id>
-		Command parameters:	Address_Type (1 octet)
-					Address (6 octets)
-					PSM (2 octets)
-					MTU (2 octets)
-					Num (1 octet)
-					Options (1 octet)
-		Response parameters:	Num (1 octet)
-					Chan_IDs (1 octet x num of channels created)
+                Controller Index:       <controller id>
+                Command parameters:     Address_Type (1 octet)
+                                        Address (6 octets)
+                                        PSM (2 octets)
+                                        MTU (2 octets)
+                                        Num (1 octet)
+                                        Options (1 octet)
+                Response parameters:    Num (1 octet)
+                                        Chan_IDs (1 octet x num of channels created)
 
-		This command is used to create an L2CAP channel.
-		Chan_ID is returned in the response to this command to allow
-		cancellation of this connection request using Disconnect
-		command.
-		Connected Event (or Disconnected Event in case of an error)
-		shall be expected after issuing this command.
+                This command is used to create an L2CAP channel.
+                Chan_ID is returned in the response to this command to allow
+                cancellation of this connection request using Disconnect
+                command.
+                Connected Event (or Disconnected Event in case of an error)
+                shall be expected after issuing this command.
 
-		if Num > 1 then Enhanced Credit Based L2CAP channels shall be created.
-		Return value will contain a list of Chan_IDs that were created by
-		this command.
+                if Num > 1 then Enhanced Credit Based L2CAP channels shall be created.
+                Return value will contain a list of Chan_IDs that were created by
+                this command.
 
-		Available options:
-		bit 0 - ECFC - If set then Enhanced Credit Based L2CAP channel
-			shall be created even if Num == 1. This is used to
-			create single Enhanced CFC channel. This flag must be
-			set to 1 when Num > 1.
-		bit 1 - Hold Credit - If set IUT is required to hold returning at
-			least 1 credit until Credits command is received.
+                Available options:
+                bit 0 - ECFC - If set then Enhanced Credit Based L2CAP channel
+                        shall be created even if Num == 1. This is used to
+                        create single Enhanced CFC channel. This flag must be
+                        set to 1 when Num > 1.
+                bit 1 - Hold Credit - If set IUT is required to hold returning at
+                        least 1 credit until Credits command is received.
 
-		In case of an error, the error response will be returned.
+                In case of an error, the error response will be returned.
 
-	Opcode 0x03 - Disconnect command
+        Opcode 0x03 - Disconnect command
 
-		Controller Index:	<controller id>
-		Command parameters:	Chan_ID (1 octet)
-		Response parameters:	<none>
+                Controller Index:       <controller id>
+                Command parameters:     Chan_ID (1 octet)
+                Response parameters:    <none>
 
-		This command is used to close an L2CAP channel.
-		Chan_ID is the internal application number that identifies
-		L2CAP channel.
-		Disconnected Event shall be expected after issuing this command.
+                This command is used to close an L2CAP channel.
+                Chan_ID is the internal application number that identifies
+                L2CAP channel.
+                Disconnected Event shall be expected after issuing this command.
 
-		In case of an error, the error response will be returned.
+                In case of an error, the error response will be returned.
 
-	Opcode 0x04 - Send Data command
+        Opcode 0x04 - Send Data command
 
-		Controller Index:	<controller id>
-		Command parameters:	Chan_ID (1 octet)
-					Data_Length (2 octets)
-					Data (Data_Length octets)
-		Response parameters:	<none>
+                Controller Index:       <controller id>
+                Command parameters:     Chan_ID (1 octet)
+                                        Data_Length (2 octets)
+                                        Data (Data_Length octets)
+                Response parameters:    <none>
 
-		This command is used to send data over L2CAP channel.
-		Chan_ID is the internal application number that identifies
-		L2CAP channel.
+                This command is used to send data over L2CAP channel.
+                Chan_ID is the internal application number that identifies
+                L2CAP channel.
 
-		In case of an error, the error response will be returned.
+                In case of an error, the error response will be returned.
 
-	Opcode 0x05 - Listen command
+        Opcode 0x05 - Listen command
 
-		Controller Index:	<controller id>
-		Command parameters:	PSM (2 octets)
-					Transport (1 octet)
-					MTU (2 octets)
-					Security_Type (1 octet)
-					Key_Size (1 octet)
-					Response (2 octets)
-		Response parameters:	<none>
+                Controller Index:       <controller id>
+                Command parameters:     PSM (2 octets)
+                                        Transport (1 octet)
+                                        MTU (2 octets)
+                                        Security_Type (1 octet)
+                                        Key_Size (1 octet)
+                                        Response (2 octets)
+                Response parameters:    <none>
 
-		Valid Transport parameter values:
-					0x00 = BR/EDR
-					0x01 = LE
+                Valid Transport parameter values:
+                                        0x00 = BR/EDR
+                                        0x01 = LE
 
-		This command is used to register L2CAP PSM and listen for
-		incoming data.
+                This command is used to register L2CAP PSM and listen for
+                incoming data.
 
-		The MTU parameter is used to specify initial MTU for channels.
+                The MTU parameter is used to specify initial MTU for channels.
 
-		Security_Type defines if security is required for establishing
-		connection. Key_Size defines authentication key size required for
-		security of connection.
+                Security_Type defines if security is required for establishing
+                connection. Key_Size defines authentication key size required for
+                security of connection.
 
-		Response parameter can be used to specify a response value used in
-		L2CAP Connection Response to send non-success responses like
-		Insufficient Authentication. If device bases its security requirements
-		for creating L2CAP connection on PSM, this value should be 0x00.
+                Response parameter can be used to specify a response value used in
+                L2CAP Connection Response to send non-success responses like
+                Insufficient Authentication. If device bases its security requirements
+                for creating L2CAP connection on PSM, this value should be 0x00.
 
-		Valid Response values:
-					0x00 = Success
-					0x01 = Insufficient authentication
-					0x02 = Insufficient authorization
-					0x03 = Insufficient encryption key size
-					0x04 = Insufficient encryption
+                Valid Response values:
+                        0x00 = Success
+                        0x01 = Insufficient authentication
+                        0x02 = Insufficient authorization
+                        0x03 = Insufficient encryption key size
+                        0x04 = Insufficient encryption
 
-		In case of an error, the error response will be returned.
+                In case of an error, the error response will be returned.
 
-	Opcode 0x06 - Accept Connection Request
+        Opcode 0x06 - Accept Connection Request
 
-		Controller Index:	<controller id>
-		Command parameters:	Chan_ID (1 octet)
-					Result (2 octets)
-		Return Parameters:	<none>
+                Controller Index:       <controller id>
+                Command parameters:     Chan_ID (1 octet)
+                                        Result (2 octets)
+                Return Parameters:      <none>
 
-		This command is used to accept/reject incoming connection
-		request. Connection can be rejected with non-zero Result value
-		(refer to the L2CAP <LE Credit Based> Connection Result values).
-		Connected Event shall be expected after issuing this command.
+                This command is used to accept/reject incoming connection
+                request. Connection can be rejected with non-zero Result value
+                (refer to the L2CAP <LE Credit Based> Connection Result values).
+                Connected Event shall be expected after issuing this command.
 
-		In case of an error, the error response will be returned.
+                In case of an error, the error response will be returned.
 
-	Opcode 0x07 - Reconfigure Request
+        Opcode 0x07 - Reconfigure Request
 
-		Controller Index:	<controller id>
-		Command parameters:	Address_Type (1 octet)
-					Address (6 octets)
-					MTU (2 octets)
-					Num (1 octet)
-					Channels (1 octet x number of channels)
-		Return Parameters:	<none>
+                Controller Index:       <controller id>
+                Command parameters:     Address_Type (1 octet)
+                                        Address (6 octets)
+                                        MTU (2 octets)
+                                        Num (1 octet)
+                                        Channels (1 octet x number of channels)
+                Return Parameters:      <none>
 
-		This command is used to reconfigure Enhanced L2CAP Channels.
+                This command is used to reconfigure Enhanced L2CAP Channels.
 
-		In case of an error, the error response will be returned.
+                In case of an error, the error response will be returned.
 
-	Opcode 0x08 - Credits
+        Opcode 0x08 - Credits
 
-		Controller Index:	<controller id>
-		Command parameters:	Chan_ID (1 octet)
-		Return Parameters:	<none>
+                Controller Index:       <controller id>
+                Command parameters:     Chan_ID (1 octet)
+                Return Parameters:      <none>
 
-		This command is used to instruct IUT to return credits on
-		specified channel.
+                This command is used to instruct IUT to return credits on
+                specified channel.
 
-		In case of an error, the error response will be returned.
+                In case of an error, the error response will be returned.
 
 Events:
-	Opcode 0x80 - Connection Request Event
+        Opcode 0x80 - Connection Request Event
 
-		Controller Index:	<controller id>
-		Event parameters:	Chan_ID (1 octet)
-					PSM (2 octets)
-					Address_Type (1 octet)
-					Address (6 octets)
+                Controller Index:       <controller id>
+                Event parameters:       Chan_ID (1 octet)
+                                        PSM (2 octets)
+                                        Address_Type (1 octet)
+                                        Address (6 octets)
 
-		This event indicates incoming request for L2CAP connection.
-		Connection Request needs to be accepted/rejected with result
-		code using Accept Connection Request command.
+                This event indicates incoming request for L2CAP connection.
+                Connection Request needs to be accepted/rejected with result
+                code using Accept Connection Request command.
 
-	Opcode 0x81 - Connected Event
+        Opcode 0x81 - Connected Event
 
-		Controller Index:	<controller id>
-		Event parameters:	Chan_ID (1 octet)
-					PSM (2 octets)
-					Peer MTU (2 octets)
-					Peer MPS (2 octets)
-					Our MTU (2 octets)
-					Our MPS (2 octets)
-					Address_Type (1 octet)
-					Address (6 octets)
+                Controller Index:       <controller id>
+                Event parameters:       Chan_ID (1 octet)
+                                        PSM (2 octets)
+                                        Peer MTU (2 octets)
+                                        Peer MPS (2 octets)
+                                        Our MTU (2 octets)
+                                        Our MPS (2 octets)
+                                        Address_Type (1 octet)
+                                        Address (6 octets)
 
-		This event indicates new L2CAP connection.
-		Chan_ID is the internal application number that identifies
-		L2CAP channel.
+                This event indicates new L2CAP connection.
+                Chan_ID is the internal application number that identifies
+                L2CAP channel.
 
-	Opcode 0x82 - Disconnected Event
+        Opcode 0x82 - Disconnected Event
 
-		Controller Index:	<controller id>
-		Event parameters:	Result (2 octets)
-					Chan_ID (1 octet)
-					PSM (2 octets)
-					Address_Type (1 octet)
-					Address (6 octets)
+                Controller Index:       <controller id>
+                Event parameters:       Result (2 octets)
+                                        Chan_ID (1 octet)
+                                        PSM (2 octets)
+                                        Address_Type (1 octet)
+                                        Address (6 octets)
 
-		This event indicates L2CAP disconnection.
-		Result value is returned in the response, if remote rejected
-		connection request only. Otherwise it shall be set to zero.
-		Please refer to the Core Specification for possible
-		L2CAP <LE Credit Based> Connection Result values.
-		Chan_ID is the internal application number that identifies
-		L2CAP channel.
+                This event indicates L2CAP disconnection.
+                Result value is returned in the response, if remote rejected
+                connection request only. Otherwise it shall be set to zero.
+                Please refer to the Core Specification for possible
+                L2CAP <LE Credit Based> Connection Result values.
+                Chan_ID is the internal application number that identifies
+                L2CAP channel.
 
-	Opcode 0x83 - Data Received Event
+        Opcode 0x83 - Data Received Event
 
-		Controller Index:	<controller id>
-		Event parameters:	Chan_ID (1 octet)
-					Data_Length (2 octets)
-					Data (Data_Length octets)
+                Controller Index:       <controller id>
+                Event parameters:       Chan_ID (1 octet)
+                                        Data_Length (2 octets)
+                                        Data (Data_Length octets)
 
-		This event forwards data received over L2CAP channel.
-		Chan_ID is the internal application number that identifies
-		L2CAP channel.
+                This event forwards data received over L2CAP channel.
+                Chan_ID is the internal application number that identifies
+                L2CAP channel.
 
-	Opcode 0x84 - Reconfigured Event
+        Opcode 0x84 - Reconfigured Event
 
-		Controller Index:	<controller id>
-		Event parameters:	Chan_ID (1 octet)
-					Peer MTU (2 octets)
-					Peer MPS (2 octets)
-					Our MTU (2 octets)
-					Our MPS (2 octets)
+                Controller Index:       <controller id>
+                Event parameters:       Chan_ID (1 octet)
+                                        Peer MTU (2 octets)
+                                        Peer MPS (2 octets)
+                                        Our MTU (2 octets)
+                                        Our MPS (2 octets)
 
-		This event indicates new that an L2CAP Channel has been reconfigured.
-		Chan_ID is the internal application number that identifies
-		L2CAP channel.
+                This event indicates new that an L2CAP Channel has been reconfigured.
+                Chan_ID is the internal application number that identifies
+                L2CAP channel.
 

--- a/doc/btp_mcp.txt
+++ b/doc/btp_mcp.txt
@@ -3,574 +3,575 @@ Microphone Control Service(ID 22)
 
 Commands and responses:
 
-	Opcode 0x00 - Error response
+        Opcode 0x00 - Error response
 
-	Opcode 0x01 - Read supported commands
-		Controller Index:       <controller id>
-		Command parameters:     <none>
-		Response parameters:    <supported commands> (variable)
+        Opcode 0x01 - Read supported commands
 
-		Each bit in response is a flag indicating if command with
-		opcode matching bit number is supported. Bit set to 1 means
-		that command is supported. Bit 0 is reserved and shall always
-		be set to 0. If specific bit is not present in response (less
-		than required bytes received) it shall be assumed that command
-		is not supported.
+                Controller Index:       <controller id>
+                Command parameters:     <none>
+                Response parameters:    <supported commands> (variable)
 
-		In case of an error, the error response will be returned.
+                Each bit in response is a flag indicating if command with
+                opcode matching bit number is supported. Bit set to 1 means
+                that command is supported. Bit 0 is reserved and shall always
+                be set to 0. If specific bit is not present in response (less
+                than required bytes received) it shall be assumed that command
+                is not supported.
 
-	Opcode 0x02 - Discovery
+                In case of an error, the error response will be returned.
 
-		Controller Index:	<controller id>
-		Command parameters:     Address_Type (1 octet)
-					Address (6 octets)
-		Response parameters: <none>
+        Opcode 0x02 - Discovery
 
-		This command is used to discover primary service, included
-		service(s) and all characteristics related to them. During
-		discovery, the IUT may send events:
-				MCP Discovered Event
+                Controller Index:       <controller id>
+                Command parameters:     Address_Type (1 octet)
+                                        Address (6 octets)
+                Response parameters: <none>
 
-		In case of an error, the error response will be returned.
+                This command is used to discover primary service, included
+                service(s) and all characteristics related to them. During
+                discovery, the IUT may send events:
+                        MCP Discovered Event
 
-	Opcode 0x03 - Track Duration Read
+                In case of an error, the error response will be returned.
 
-		Controller Index:	<controller id>
-		Command parameters:     Address_Type (1 octet)
-					Address (6 octets)
-		Response parameters:    <none>
+        Opcode 0x03 - Track Duration Read
 
-		This command is used to read Track Duration characteristic.
-		During read operation, the IUT may send event:
-				Track Duration Event
+                Controller Index:       <controller id>
+                Command parameters:     Address_Type (1 octet)
+                                        Address (6 octets)
+                Response parameters:    <none>
 
-	Opcode 0x04 - Track Position Read
+                This command is used to read Track Duration characteristic.
+                During read operation, the IUT may send event:
+                        Track Duration Event
 
-		Controller Index:	<controller id>
-		Command parameters:     Address_Type (1 octet)
-					Address (6 octets)
-		Response parameters:    <none>
+        Opcode 0x04 - Track Position Read
 
-		This command is used to read Track Position characteristic.
-		During read operation, the IUT may send event:
-				Track Position Event
+                Controller Index:       <controller id>
+                Command parameters:     Address_Type (1 octet)
+                                        Address (6 octets)
+                Response parameters:    <none>
 
-	Opcode 0x05 - Track Position Set
+                This command is used to read Track Position characteristic.
+                During read operation, the IUT may send event:
+                        Track Position Event
 
-		Controller Index:	<controller id>
-		Command parameters:     Address_Type (1 octet)
-					Address (6 octets)
-					Position (4 octets)
-		Response parameters:    <none>
+        Opcode 0x05 - Track Position Set
 
-		This command is used to set Track Position characteristic.
-		During operation, the IUT may send event:
-				Track Position Event
+                Controller Index:       <controller id>
+                Command parameters:     Address_Type (1 octet)
+                                        Address (6 octets)
+                                        Position (4 octets)
+                Response parameters:    <none>
 
-	Opcode 0x06 - Playback Speed Read
+                This command is used to set Track Position characteristic.
+                During operation, the IUT may send event:
+                        Track Position Event
 
-		Controller Index:	<controller id>
-		Command parameters:     Address_Type (1 octet)
-					Address (6 octets)
-		Response parameters:    <none>
+        Opcode 0x06 - Playback Speed Read
 
-		This command is used to read Playback Speed characteristic.
-		During operation, the IUT may send event:
-				Playback Speed Event
+                Controller Index:       <controller id>
+                Command parameters:     Address_Type (1 octet)
+                                        Address (6 octets)
+                Response parameters:    <none>
 
-	Opcode 0x07 - Playback Speed Set
+                This command is used to read Playback Speed characteristic.
+                During operation, the IUT may send event:
+                        Playback Speed Event
 
-		Controller Index:	<controller id>
-		Command parameters:     Address_Type (1 octet)
-					Address (6 octets)
-					Speed (1 octet)
-		Response parameters:    <none>
+        Opcode 0x07 - Playback Speed Set
 
-		This command is used to set Playback Speed.
-		During operation, the IUT may send event:
-				Playback Speed Event
+                Controller Index:       <controller id>
+                Command parameters:     Address_Type (1 octet)
+                                        Address (6 octets)
+                                        Speed (1 octet)
+                Response parameters:    <none>
 
-	Opcode 0x08 - Seeking Speed Read
+                This command is used to set Playback Speed.
+                During operation, the IUT may send event:
+                        Playback Speed Event
 
-		Controller Index:	<controller id>
-		Command parameters:     Address_Type (1 octet)
-					Address (6 octets)
-		Response parameters:    <none>
+        Opcode 0x08 - Seeking Speed Read
 
-		This command is used to read Seeking characteristic.
-		During operation, the IUT may send event:
-				Seeking Speed Event
+                Controller Index:       <controller id>
+                Command parameters:     Address_Type (1 octet)
+                                        Address (6 octets)
+                Response parameters:    <none>
 
-	Opcode 0x09 - Icon Object ID Read
+                This command is used to read Seeking characteristic.
+                During operation, the IUT may send event:
+                        Seeking Speed Event
 
-		Controller Index:	<controller id>
-		Command parameters:     Address_Type (1 octet)
-					Address (6 octets)
-		Response parameters:    <none>
+        Opcode 0x09 - Icon Object ID Read
 
-		This command is used to read Icon Object ID characteristic.
-		During operation, the IUT may send event:
-				Icon Object ID event
+                Controller Index:       <controller id>
+                Command parameters:     Address_Type (1 octet)
+                                        Address (6 octets)
+                Response parameters:    <none>
 
-	Opcode 0x0a - Next Track Object ID Read
+                This command is used to read Icon Object ID characteristic.
+                During operation, the IUT may send event:
+                        Icon Object ID event
 
-		Controller Index:	<controller id>
-		Command parameters:     Address_Type (1 octet)
-					Address (6 octets)
-		Response parameters:    <none>
+        Opcode 0x0a - Next Track Object ID Read
 
-		This command is used to read Next Track Object ID characteristic.
-		During operation, the IUT may send event:
-				Next Track Object ID event
+                Controller Index:       <controller id>
+                Command parameters:     Address_Type (1 octet)
+                                        Address (6 octets)
+                Response parameters:    <none>
 
-	Opcode 0x0b - Next Track Object ID Set
+                This command is used to read Next Track Object ID characteristic.
+                During operation, the IUT may send event:
+                        Next Track Object ID event
 
-		Controller Index:	<controller id>
-		Command parameters:     Address_Type (1 octet)
-					Address (6 octets)
-					ID (8 octets)
-		Response parameters:    <none>
+        Opcode 0x0b - Next Track Object ID Set
 
-		This command is used to set Next Track Object ID.
-		During operation, the IUT may send event:
-				Next Track Object ID event
+                Controller Index:       <controller id>
+                Command parameters:     Address_Type (1 octet)
+                                        Address (6 octets)
+                                        ID (8 octets)
+                Response parameters:    <none>
 
-	Opcode 0x0c - Parent Group ID Read
+                This command is used to set Next Track Object ID.
+                During operation, the IUT may send event:
+                        Next Track Object ID event
 
-		Controller Index:	<controller id>
-		Command parameters:     Address_Type (1 octet)
-					Address (6 octets)
-		Response parameters:    <none>
+        Opcode 0x0c - Parent Group ID Read
 
-		This command is used to read Parent Group Object ID characteristic.
-		During operation, the IUT may send event:
-				Parent Group Object ID event
+                Controller Index:       <controller id>
+                Command parameters:     Address_Type (1 octet)
+                                        Address (6 octets)
+                Response parameters:    <none>
 
-	Opcode 0x0d - Current Group ID Read
+                This command is used to read Parent Group Object ID characteristic.
+                During operation, the IUT may send event:
+                        Parent Group Object ID event
 
-		Controller Index:	<controller id>
-		Command parameters:     Address_Type (1 octet)
-					Address (6 octets)
-		Response parameters:    <none>
+        Opcode 0x0d - Current Group ID Read
 
-		This command is used to read Current Group Object ID characteristic.
-		During operation, the IUT may send event:
-				Current Group Object ID event
+                Controller Index:       <controller id>
+                Command parameters:     Address_Type (1 octet)
+                                        Address (6 octets)
+                Response parameters:    <none>
 
-	Opcode 0x0e - Current Group ID Set
+                This command is used to read Current Group Object ID characteristic.
+                During operation, the IUT may send event:
+                        Current Group Object ID event
 
-		Controller Index:	<controller id>
-		Command parameters:     Address_Type (1 octet)
-					Address (6 octets)
-					ID (8 octets)
-		Response parameters:    <none>
+        Opcode 0x0e - Current Group ID Set
 
-		This command is used to set Current Group Object ID.
-		During operation, the IUT may send event:
-				Current Group Object ID event
+                Controller Index:       <controller id>
+                Command parameters:     Address_Type (1 octet)
+                                        Address (6 octets)
+                                        ID (8 octets)
+                Response parameters:    <none>
 
-	Opcode 0x0f - Playing Order Read
+                This command is used to set Current Group Object ID.
+                During operation, the IUT may send event:
+                        Current Group Object ID event
 
-		Controller Index:	<controller id>
-		Command parameters:     Address_Type (1 octet)
-					Address (6 octets)
-		Response parameters:    <none>
+        Opcode 0x0f - Playing Order Read
 
-		This command is used to read Playing Order characteristic.
-		During operation, the IUT may send event:
-				Playing Order event
+                Controller Index:       <controller id>
+                Command parameters:     Address_Type (1 octet)
+                                        Address (6 octets)
+                Response parameters:    <none>
 
-	Opcode 0x10 - Playing Order Set
+                This command is used to read Playing Order characteristic.
+                During operation, the IUT may send event:
+                        Playing Order event
 
-		Controller Index:	<controller id>
-		Command parameters:     Address_Type (1 octet)
-					Address (6 octets)
-					Order (1 octets)
-		Response parameters:    <none>
+        Opcode 0x10 - Playing Order Set
 
-		This command is used to set Playing Order.
-		During operation, the IUT may send event:
-				Playing Order event
+                Controller Index:       <controller id>
+                Command parameters:     Address_Type (1 octet)
+                                        Address (6 octets)
+                                        Order (1 octets)
+                Response parameters:    <none>
 
-	Opcode 0x11 - Playing Orders Supported Read
-
-		Controller Index:	<controller id>
-		Command parameters:     Address_Type (1 octet)
-					Address (6 octets)
-		Response parameters:    <none>
-
-		This command is used to read Playing Orders Supported characteristic.
-		During operation, the IUT may send event:
-				Playing Orders Supported event
-
-	Opcode 0x12 - Media State Read
-
-		Controller Index:	<controller id>
-		Command parameters:     Address_Type (1 octet)
-					Address (6 octets)
-		Response parameters:    <none>
-
-		This command is used to read Media State characteristic.
-		During operation, the IUT may send event:
-				Media State event
-
-	Opcode 0x13 - Opcodes Supported Read
-
-		Controller Index:	<controller id>
-		Command parameters:     Address_Type (1 octet)
-					Address (6 octets)
-		Response parameters:    <none>
-
-		This command is used to read Media Control Point Opcodes
-		Supported characteristic. During operation, the IUT may send event:
-				Opcodes Supported event
-
-	Opcode 0x14 - Content Control ID Read
-
-		Controller Index:	<controller id>
-		Command parameters:     Address_Type (1 octet)
-					Address (6 octets)
-		Response parameters:    <none>
-
-		This command is used to read Content Control ID characteristic.
-		During operation, the IUT may send event:
-				Content Control ID event
-
-	Opcode 0x15 - Segments Object ID Read
-
-		Controller Index:	<controller id>
-		Command parameters:     Address_Type (1 octet)
-					Address (6 octets)
-		Response parameters:    <none>
-
-		This command is used to read Segments Control ID characteristic.
-		During operation, the IUT may send event:
-				Segments Object ID event
-
-	Opcode 0x16 - Current Track Object ID Read
-
-		Controller Index:	<controller id>
-		Command parameters:     Address_Type (1 octet)
-					Address (6 octets)
-		Response parameters:    <none>
-
-		This command is used to read Current Track Object ID characteristic.
-		During operation, the IUT may send event:
-				Current Track Object ID event
-
-	Opcode 0x17 - Current Track Object ID Set
-
-		Controller Index:	<controller id>
-		Command parameters:     Address_Type (1 octet)
-					Address (6 octets)
-					ID (8 octets)
-		Response parameters:    <none>
-
-		This command is used to set Current Track Object ID.
-		During operation, the IUT may send event:
-				Current Track Object ID event
-
-	Opcode 0x18 - Command Send
-
-		Controller Index:	<controller id>
-		Command parameters:     Address_Type (1 octet)
-					Address (6 octets)
-					Opcode (1 octets)
-					Use Param (1 octet)
-					Param (4 octets)
-		Response parameters:    <none>
-
-		This command is used to write to Media Control Point characteristic
-		to perform operation defined by opcode.
-
-		Opcodes: 0x01 - Play
-			 0x02 - Pause
-			 0x03 - Fast Rewind
-			 0x04 - Fast Forward
-			 0x05 - Stop
-			 0x10 - Move Relative (uses Param)
-			 0x20 - Previous Segment
-			 0x21 - Next Segment
-			 0x22 - First Segment
-			 0x23 - Last Segment
-			 0x24 - Goto Segment (uses Param)
-			 0x30 - Previous Track
-			 0x30 - Previous Track
-			 0x31 - Next Track
-			 0x32 - First Track
-			 0x33 - Last Track
-			 0x34 - Goto Track (uses Param)
-			 0x40 - Previous Group
-			 0x41 - Next Group
-			 0x42 - First Group
-			 0x43 - Last Group
-			 0x44 - Goto Group (uses Param)
-
-		During operation, the IUT may send event:
-				MCP Command event
-
-	Opcode 0x19 - Search Command Send
-
-		Controller Index:	<controller id>
-		Command parameters:     Address_Type (1 octet)
-					Address (6 octets)
-					Search type (1 octet)
-					Param Length (1 octet)
-					Param (Varies)
-		Response parameters:    <none>
-
-		This command is used to write to Search Control Point characteristic
-		to perform search operation defined search type opcode.
-
-		Search Types: 0x01 - Track Name
-			      0x02 - Artist Name
-			      0x03 - Album Name
-			      0x04 - Group Name
-			      0x05 - Earliest Year
-			      0x06 - Latest Year
-			      0x07 - Genre
-			      0x08 - Only Tracks (no Param)
-			      0x09 - Only Groups (no Param)
-
-		During operation, the IUT may send event:
-				MCP Search event
+                This command is used to set Playing Order.
+                During operation, the IUT may send event:
+                        Playing Order event
+
+        Opcode 0x11 - Playing Orders Supported Read
+
+                Controller Index:       <controller id>
+                Command parameters:     Address_Type (1 octet)
+                                        Address (6 octets)
+                Response parameters:    <none>
+
+                This command is used to read Playing Orders Supported characteristic.
+                During operation, the IUT may send event:
+                        Playing Orders Supported event
+
+        Opcode 0x12 - Media State Read
+
+                Controller Index:       <controller id>
+                Command parameters:     Address_Type (1 octet)
+                                        Address (6 octets)
+                Response parameters:    <none>
+
+                This command is used to read Media State characteristic.
+                During operation, the IUT may send event:
+                        Media State event
+
+        Opcode 0x13 - Opcodes Supported Read
+
+                Controller Index:       <controller id>
+                Command parameters:     Address_Type (1 octet)
+                                        Address (6 octets)
+                Response parameters:    <none>
+
+                This command is used to read Media Control Point Opcodes
+                Supported characteristic. During operation, the IUT may send event:
+                        Opcodes Supported event
+
+        Opcode 0x14 - Content Control ID Read
+
+                Controller Index:       <controller id>
+                Command parameters:     Address_Type (1 octet)
+                                        Address (6 octets)
+                Response parameters:    <none>
+
+                This command is used to read Content Control ID characteristic.
+                During operation, the IUT may send event:
+                        Content Control ID event
+
+        Opcode 0x15 - Segments Object ID Read
+
+                Controller Index:       <controller id>
+                Command parameters:     Address_Type (1 octet)
+                                        Address (6 octets)
+                Response parameters:    <none>
+
+                This command is used to read Segments Control ID characteristic.
+                During operation, the IUT may send event:
+                        Segments Object ID event
+
+        Opcode 0x16 - Current Track Object ID Read
+
+                Controller Index:       <controller id>
+                Command parameters:     Address_Type (1 octet)
+                                        Address (6 octets)
+                Response parameters:    <none>
+
+                This command is used to read Current Track Object ID characteristic.
+                During operation, the IUT may send event:
+                        Current Track Object ID event
+
+        Opcode 0x17 - Current Track Object ID Set
+
+                Controller Index:       <controller id>
+                Command parameters:     Address_Type (1 octet)
+                                        Address (6 octets)
+                                        ID (8 octets)
+                Response parameters:    <none>
+
+                This command is used to set Current Track Object ID.
+                During operation, the IUT may send event:
+                        Current Track Object ID event
+
+        Opcode 0x18 - Command Send
+
+                Controller Index:       <controller id>
+                Command parameters:     Address_Type (1 octet)
+                                        Address (6 octets)
+                                        Opcode (1 octets)
+                                        Use Param (1 octet)
+                                        Param (4 octets)
+                Response parameters:    <none>
+
+                This command is used to write to Media Control Point characteristic
+                to perform operation defined by opcode.
+
+                Opcodes: 0x01 - Play
+                         0x02 - Pause
+                         0x03 - Fast Rewind
+                         0x04 - Fast Forward
+                         0x05 - Stop
+                         0x10 - Move Relative (uses Param)
+                         0x20 - Previous Segment
+                         0x21 - Next Segment
+                         0x22 - First Segment
+                         0x23 - Last Segment
+                         0x24 - Goto Segment (uses Param)
+                         0x30 - Previous Track
+                         0x30 - Previous Track
+                         0x31 - Next Track
+                         0x32 - First Track
+                         0x33 - Last Track
+                         0x34 - Goto Track (uses Param)
+                         0x40 - Previous Group
+                         0x41 - Next Group
+                         0x42 - First Group
+                         0x43 - Last Group
+                         0x44 - Goto Group (uses Param)
+
+                During operation, the IUT may send event:
+                        MCP Command event
+
+        Opcode 0x19 - Search Command Send
+
+                Controller Index:       <controller id>
+                Command parameters:     Address_Type (1 octet)
+                                        Address (6 octets)
+                                        Search type (1 octet)
+                                        Param Length (1 octet)
+                                        Param (Varies)
+                Response parameters:    <none>
+
+                This command is used to write to Search Control Point characteristic
+                to perform search operation defined search type opcode.
+
+                Search Types: 0x01 - Track Name
+                              0x02 - Artist Name
+                              0x03 - Album Name
+                              0x04 - Group Name
+                              0x05 - Earliest Year
+                              0x06 - Latest Year
+                              0x07 - Genre
+                              0x08 - Only Tracks (no Param)
+                              0x09 - Only Groups (no Param)
+
+                During operation, the IUT may send event:
+                        MCP Search event
 
 
 Events:
-	Opcode 0x80 - Discovered Event
+        Opcode 0x80 - Discovered Event
 
-		Controller Index:	<controller id>
-		Event parameters:	Address_Type (1 octet)
-					Address (6 octets)
-					Status (1 octet)
-					Player Name handle (2 octets)
-					Icon Object ID handle (2 octets)
-					Icon Url handle (2 octets)
-					Track Changed handle (2 octets)
-					Track Title handle (2 octets)
-					Track Duration handle (2 octets)
-					Track Position handle (2 octets)
-					Playback Speed handle (2 octets)
-					Seeking Speed handle (2 octets)
-					Segments Object ID handle (2 octets)
-					Current Track Object ID handle (2 octets)
-					Next Track Object ID handle (2 octets)
-					Current Group Object ID handle (2 octets)
-					Parent Group Object ID handle (2 octets)
-					Playing Order handle (2 octets)
-					Playing Orders Supported handle (2 octets)
-					Media State handle (2 octets)
-					Control Point handle (2 octets)
-					Opcodes Supported handle (2 octets)
-					Search Control Point handle (2 octets)
-					Search Result Object ID handle (2 octets)
-					Content Control ID handle (2 octets)
-					OTS Feature handle (2 octets)
-					Object Name handle (2 octets)
-					Object Type handle (2 octets)
-					Object Modified handle (2 octets)
-					Object ID handle (2 octets)
-					Object Action Control Point handle (2 octets)
-					Object List Control Point handle (2 octets)
+                Controller Index:       <controller id>
+                Event parameters:       Address_Type (1 octet)
+                                        Address (6 octets)
+                                        Status (1 octet)
+                                        Player Name handle (2 octets)
+                                        Icon Object ID handle (2 octets)
+                                        Icon Url handle (2 octets)
+                                        Track Changed handle (2 octets)
+                                        Track Title handle (2 octets)
+                                        Track Duration handle (2 octets)
+                                        Track Position handle (2 octets)
+                                        Playback Speed handle (2 octets)
+                                        Seeking Speed handle (2 octets)
+                                        Segments Object ID handle (2 octets)
+                                        Current Track Object ID handle (2 octets)
+                                        Next Track Object ID handle (2 octets)
+                                        Current Group Object ID handle (2 octets)
+                                        Parent Group Object ID handle (2 octets)
+                                        Playing Order handle (2 octets)
+                                        Playing Orders Supported handle (2 octets)
+                                        Media State handle (2 octets)
+                                        Control Point handle (2 octets)
+                                        Opcodes Supported handle (2 octets)
+                                        Search Control Point handle (2 octets)
+                                        Search Result Object ID handle (2 octets)
+                                        Content Control ID handle (2 octets)
+                                        OTS Feature handle (2 octets)
+                                        Object Name handle (2 octets)
+                                        Object Type handle (2 octets)
+                                        Object Modified handle (2 octets)
+                                        Object ID handle (2 octets)
+                                        Object Action Control Point handle (2 octets)
+                                        Object List Control Point handle (2 octets)
 
-		This event returns handles of GMCS and OTS characteristics.
+                This event returns handles of GMCS and OTS characteristics.
 
-	Opcode 0x81 - Track Duration event
+        Opcode 0x81 - Track Duration event
 
-		Controller Index:	<controller id>
-		Event parameters:	Address_Type (1 octet)
-					Address (6 octets)
-					Status (1 octet)
-					Track Duration (4 octets)
+                Controller Index:       <controller id>
+                Event parameters:       Address_Type (1 octet)
+                                        Address (6 octets)
+                                        Status (1 octet)
+                                        Track Duration (4 octets)
 
-		This event returns Track Duration information.
+                This event returns Track Duration information.
 
-	Opcode 0x82 - Track Position event
+        Opcode 0x82 - Track Position event
 
-		Controller Index:	<controller id>
-		Event parameters:	Address_Type (1 octet)
-					Address (6 octets)
-					Status (1 octet)
-					Track Position (4 octets)
+                Controller Index:       <controller id>
+                Event parameters:       Address_Type (1 octet)
+                                        Address (6 octets)
+                                        Status (1 octet)
+                                        Track Position (4 octets)
 
-		This event returns Track Position information.
+                This event returns Track Position information.
 
-	Opcode 0x83 - Playback Speed event
+        Opcode 0x83 - Playback Speed event
 
-		Controller Index:	<controller id>
-		Event parameters:	Address_Type (1 octet)
-					Address (6 octets)
-					Status (1 octet)
-					Playback Speed (1 octets)
+                Controller Index:       <controller id>
+                Event parameters:       Address_Type (1 octet)
+                                        Address (6 octets)
+                                        Status (1 octet)
+                                        Playback Speed (1 octets)
 
-		This event returns Playback Speed information.
+                This event returns Playback Speed information.
 
-	Opcode 0x84 - Seeking Speed event
+        Opcode 0x84 - Seeking Speed event
 
-		Controller Index:	<controller id>
-		Event parameters:	Address_Type (1 octet)
-					Address (6 octets)
-					Status (1 octet)
-					Seeking Speed (1 octets)
+                Controller Index:       <controller id>
+                Event parameters:       Address_Type (1 octet)
+                                        Address (6 octets)
+                                        Status (1 octet)
+                                        Seeking Speed (1 octets)
 
-		This event returns Seeking Speed information.
+                This event returns Seeking Speed information.
 
-	Opcode 0x85 - Icon Object ID event
+        Opcode 0x85 - Icon Object ID event
 
-		Controller Index:	<controller id>
-		Event parameters:	Address_Type (1 octet)
-					Address (6 octets)
-					Status (1 octet)
-					Icon Object ID (8 octets)
+                Controller Index:       <controller id>
+                Event parameters:       Address_Type (1 octet)
+                                        Address (6 octets)
+                                        Status (1 octet)
+                                        Icon Object ID (8 octets)
 
-		This event returns Icon Object ID information.
+                This event returns Icon Object ID information.
 
-	Opcode 0x86 - Next Track Object ID event
+        Opcode 0x86 - Next Track Object ID event
 
-		Controller Index:	<controller id>
-		Event parameters:	Address_Type (1 octet)
-					Address (6 octets)
-					Status (1 octet)
-					Next Track Object ID (8 octets)
+                Controller Index:       <controller id>
+                Event parameters:       Address_Type (1 octet)
+                                        Address (6 octets)
+                                        Status (1 octet)
+                                        Next Track Object ID (8 octets)
 
-		This event returns Next Track Object ID information.
+                This event returns Next Track Object ID information.
 
-	Opcode 0x87 - Parent Group Object ID event
+        Opcode 0x87 - Parent Group Object ID event
 
-		Controller Index:	<controller id>
-		Event parameters:	Address_Type (1 octet)
-					Address (6 octets)
-					Status (1 octet)
-					Parent Group Object ID (8 octets)
+                Controller Index:       <controller id>
+                Event parameters:       Address_Type (1 octet)
+                                        Address (6 octets)
+                                        Status (1 octet)
+                                        Parent Group Object ID (8 octets)
 
-		This event returns Parent Group Object ID information.
+                This event returns Parent Group Object ID information.
 
-	Opcode 0x88 - Current Group Object ID event
+        Opcode 0x88 - Current Group Object ID event
 
-		Controller Index:	<controller id>
-		Event parameters:	Address_Type (1 octet)
-					Address (6 octets)
-					Status (1 octet)
-					Current Group Object ID (8 octets)
+                Controller Index:       <controller id>
+                Event parameters:       Address_Type (1 octet)
+                                        Address (6 octets)
+                                        Status (1 octet)
+                                        Current Group Object ID (8 octets)
 
-		This event returns Current Group Object ID information.
+                This event returns Current Group Object ID information.
 
-	Opcode 0x89 - Playing Order event
+        Opcode 0x89 - Playing Order event
 
-		Controller Index:	<controller id>
-		Event parameters:	Address_Type (1 octet)
-					Address (6 octets)
-					Status (1 octet)
-					Playing Order (1 octets)
+                Controller Index:       <controller id>
+                Event parameters:       Address_Type (1 octet)
+                                        Address (6 octets)
+                                        Status (1 octet)
+                                        Playing Order (1 octets)
 
-		This event returns Playing Order information.
+                This event returns Playing Order information.
 
-	Opcode 0x8a - Playing Orders Supported event
+        Opcode 0x8a - Playing Orders Supported event
 
-		Controller Index:	<controller id>
-		Event parameters:	Address_Type (1 octet)
-					Address (6 octets)
-					Status (1 octet)
-					Playing Orders Supported (1 octet)
+                Controller Index:       <controller id>
+                Event parameters:       Address_Type (1 octet)
+                                        Address (6 octets)
+                                        Status (1 octet)
+                                        Playing Orders Supported (1 octet)
 
-		This event returns Playing Orders Supported information.
+                This event returns Playing Orders Supported information.
 
-	Opcode 0x8b - Media State event
+        Opcode 0x8b - Media State event
 
-		Controller Index:	<controller id>
-		Event parameters:	Address_Type (1 octet)
-					Address (6 octets)
-					Status (1 octet)
-					Media State (1 octet)
+                Controller Index:       <controller id>
+                Event parameters:       Address_Type (1 octet)
+                                        Address (6 octets)
+                                        Status (1 octet)
+                                        Media State (1 octet)
 
-		This event returns Media State information.
+                This event returns Media State information.
 
-	Opcode 0x8c - Opcodes Supported event
+        Opcode 0x8c - Opcodes Supported event
 
-		Controller Index:	<controller id>
-		Event parameters:	Address_Type (1 octet)
-					Address (6 octets)
-					Status (1 octet)
-					Opcodes Supported (4 octets)
+                Controller Index:       <controller id>
+                Event parameters:       Address_Type (1 octet)
+                                        Address (6 octets)
+                                        Status (1 octet)
+                                        Opcodes Supported (4 octets)
 
-		This event returns Media Control Point Opcodes Supported information.
+                This event returns Media Control Point Opcodes Supported information.
 
-	Opcode 0x8d - Content Control ID event
+        Opcode 0x8d - Content Control ID event
 
-		Controller Index:	<controller id>
-		Event parameters:	Address_Type (1 octet)
-					Address (6 octets)
-					Status (1 octet)
-					Content Control ID (1 octets)
+                Controller Index:       <controller id>
+                Event parameters:       Address_Type (1 octet)
+                                        Address (6 octets)
+                                        Status (1 octet)
+                                        Content Control ID (1 octets)
 
-		This event returns Content Control ID information.
+                This event returns Content Control ID information.
 
-	Opcode 0x8e - Segments Object ID event
+        Opcode 0x8e - Segments Object ID event
 
-		Controller Index:	<controller id>
-		Event parameters:	Address_Type (1 octet)
-					Address (6 octets)
-					Status (1 octet)
-					Segments Object ID (8 octets)
+                Controller Index:       <controller id>
+                Event parameters:       Address_Type (1 octet)
+                                        Address (6 octets)
+                                        Status (1 octet)
+                                        Segments Object ID (8 octets)
 
-		This event returns Track Segments Object ID information.
+                This event returns Track Segments Object ID information.
 
-	Opcode 0x8f - Current Track Object ID event
+        Opcode 0x8f - Current Track Object ID event
 
-		Controller Index:	<controller id>
-		Event parameters:	Address_Type (1 octet)
-					Address (6 octets)
-					Status (1 octet)
-					Current Track Object ID (8 octets)
+                Controller Index:       <controller id>
+                Event parameters:       Address_Type (1 octet)
+                                        Address (6 octets)
+                                        Status (1 octet)
+                                        Current Track Object ID (8 octets)
 
-		This event returns Current Track Object ID information
+                This event returns Current Track Object ID information
 
-	Opcode 0x90 - Command event
+        Opcode 0x90 - Command event
 
-		Controller Index:	<controller id>
-		Event parameters:	Address_Type (1 octet)
-					Address (6 octets)
-					Status (1 octet)
-					Opcode (1 octet)
-					Use Param (1 octet)
-					Param (4 octets)
+                Controller Index:       <controller id>
+                Event parameters:       Address_Type (1 octet)
+                                        Address (6 octets)
+                                        Status (1 octet)
+                                        Opcode (1 octet)
+                                        Use Param (1 octet)
+                                        Param (4 octets)
 
-		This event returns Media Control Point Command information.
+                This event returns Media Control Point Command information.
 
-	Opcode 0x91 - Search event
+        Opcode 0x91 - Search event
 
-		Controller Index:	<controller id>
-		Event parameters:	Address_Type (1 octet)
-					Address (6 octets)
-					Status (1 octet)
-					Param len (1 octet)
-					Search Type (1 octet)
-					Param (varies)
+                Controller Index:       <controller id>
+                Event parameters:       Address_Type (1 octet)
+                                        Address (6 octets)
+                                        Status (1 octet)
+                                        Param len (1 octet)
+                                        Search Type (1 octet)
+                                        Param (varies)
 
-		This event returns Search Control Point command information.
+                This event returns Search Control Point command information.
 
-	Opcode 0x92 - Command Notifications event
+        Opcode 0x92 - Command Notifications event
 
-		Controller Index:	<controller id>
-		Event parameters:	Address_Type (1 octet)
-					Address (6 octets)
-					Status (1 octet)
-					Requested Opcode (1 octet)
-					Result Opcode (1 octet)
+                Controller Index:       <controller id>
+                Event parameters:       Address_Type (1 octet)
+                                        Address (6 octets)
+                                        Status (1 octet)
+                                        Requested Opcode (1 octet)
+                                        Result Opcode (1 octet)
 
-		This event returns notification information for Media Control
-		Point command.
+                This event returns notification information for Media Control
+                Point command.
 
 
-	Opcode 0x93 - Search Notifications event
+        Opcode 0x93 - Search Notifications event
 
-		Controller Index:	<controller id>
-		Event parameters:	Address_Type (1 octet)
-					Address (6 octets)
-					Status (1 octet)
-					Result Code (1 octet)
+                Controller Index:       <controller id>
+                Event parameters:       Address_Type (1 octet)
+                                        Address (6 octets)
+                                        Status (1 octet)
+                                        Result Code (1 octet)
 
-		This event returns notification information for Search Control
-		Point command.
+                This event returns notification information for Search Control
+                Point command.
 
 

--- a/doc/btp_mesh_model.txt
+++ b/doc/btp_mesh_model.txt
@@ -3,1136 +3,1136 @@ Mesh Model Service (ID 5)
 
 Commands and responses:
 
-	Opcode 0x00 - Error response
+        Opcode 0x00 - Error response
 
-	Opcode 0x01 - Read Supported Commands command/response
+        Opcode 0x01 - Read Supported Commands command/response
 
-		Controller Index:		<controller id>
-		Command parameters:		<none>
-		Response parameters:		<supported commands> (variable)
+                Controller Index:               <controller id>
+                Command parameters:             <none>
+                Response parameters:            <supported commands> (variable)
 
-		Each bit in response is a flag indicating if command with
-		opcode matching bit number is supported. Bit set to 1 means
-		that command is supported. Bit 0 is reserved and shall always
-		be set to 0. If specific bit is not present in response (less
-		than required bytes received) it shall be assumed that command
-		is not supported.
+                Each bit in response is a flag indicating if command with
+                opcode matching bit number is supported. Bit set to 1 means
+                that command is supported. Bit 0 is reserved and shall always
+                be set to 0. If specific bit is not present in response (less
+                than required bytes received) it shall be assumed that command
+                is not supported.
 
-		In case of an error, the error response will be returned.
+                In case of an error, the error response will be returned.
 
-	Opcode 0x02 - Generic OnOff State Get/Status
+        Opcode 0x02 - Generic OnOff State Get/Status
 
-		Controller Index:		<controller id>
-		Command parameters: 		<none>
-		Response parameters:		Present OnOff (1 octet)
-			 			Target OnOff (1 octet)
-						Remaining Time (4 octets)
+                Controller Index:               <controller id>
+                Command parameters:             <none>
+                Response parameters:            Present OnOff (1 octet)
+                                                Target OnOff (1 octet)
+                                                Remaining Time (4 octets)
 
-		Valid OnOff values:
-					0x00 = Off
-					0x01 = On
+                Valid OnOff values:
+                                        0x00 = Off
+                                        0x01 = On
 
-		This command is used to get the OnOff state.
+                This command is used to get the OnOff state.
 
-		In case of an error, the error response will be returned.
+                In case of an error, the error response will be returned.
 
-	Opcode 0x03 - Generic OnOff State Set/Status
+        Opcode 0x03 - Generic OnOff State Set/Status
 
-		Controller Index:		<controller id>
-		Command parameters:		Acknowledgement (1 octet)
-						OnOff (1 octet)
-						Transition Time (1 octet)
-						Delay (1 octet)
-		Response Status parameters:	Present OnOff (1 octet)
-			 			Target OnOff (1 octet)
-						Remaining Time (4 octets)
+                Controller Index:               <controller id>
+                Command parameters:             Acknowledgement (1 octet)
+                                                OnOff (1 octet)
+                                                Transition Time (1 octet)
+                                                Delay (1 octet)
+                Response Status parameters:     Present OnOff (1 octet)
+                                                Target OnOff (1 octet)
+                                                Remaining Time (4 octets)
 
-		Valid OnOff values:
-				0x00 = Off
-				0x01 = On
+                Valid OnOff values:
+                                0x00 = Off
+                                0x01 = On
 
-		Acknowledgment values:
-				True = with requesting a status response
-				False = without requesting a status response
+                Acknowledgment values:
+                                True = with requesting a status response
+                                False = without requesting a status response
 
-		This command is used to set the OnOff state.
+                This command is used to set the OnOff state.
 
-		In case of an error, the error response will be returned.
+                In case of an error, the error response will be returned.
 
-	Opcode 0x04 - Generic Level State Get/Status
+        Opcode 0x04 - Generic Level State Get/Status
 
-		Controller Index:		<controller id>
-		Command parameters: 		<none>
-		Response Status parameters:	Present Level (2 octets)
-			 			Target Level (2 octets)
-						Remaining Time (4 octets)
+                Controller Index:               <controller id>
+                Command parameters:             <none>
+                Response Status parameters:     Present Level (2 octets)
+                                                Target Level (2 octets)
+                                                Remaining Time (4 octets)
 
-		This command is used to get the Level state.
+                This command is used to get the Level state.
 
-		In case of an error, the error response will be returned.
+                In case of an error, the error response will be returned.
 
-	Opcode 0x05 - Generic Level State Set/Status
+        Opcode 0x05 - Generic Level State Set/Status
 
-		Controller Index:		<controller id>
-		Command parameters:		Acknowledgement (1 octet)
-						Level (2 octets)
-						Transition Time (1 octet)
-						Delay (1 octet)
-		Response Status parameters:	Present Level (2 octets)
-			 			Target Level (2 octets)
-						Remaining Time (4 octets)
+                Controller Index:               <controller id>
+                Command parameters:             Acknowledgement (1 octet)
+                                                Level (2 octets)
+                                                Transition Time (1 octet)
+                                                Delay (1 octet)
+                Response Status parameters:     Present Level (2 octets)
+                                                Target Level (2 octets)
+                                                Remaining Time (4 octets)
 
-		Acknowledgment values:
-					True = with requesting a status response
-					False = without requesting a status response
+                Acknowledgment values:
+                        True = with requesting a status response
+                        False = without requesting a status response
 
-		This command is used to set the Level state.
+                This command is used to set the Level state.
 
-		In case of an error, the error response will be returned.
+                In case of an error, the error response will be returned.
 
-	Opcode 0x06 - Generic Level Delta Set/Status
+        Opcode 0x06 - Generic Level Delta Set/Status
 
-		Controller Index:		<controller id>
-		Command parameters:		Acknowledgement (1 octet)
-						Delta (2 octets)
-						Transition Time (1 octet)
-						Delay (1 octet)
-		Response Status parameters:	Present Level (2 octets)
-			 			Target Level (2 octets)
-						Remaining Time (4 octets)
+                Controller Index:               <controller id>
+                Command parameters:             Acknowledgement (1 octet)
+                                                Delta (2 octets)
+                                                Transition Time (1 octet)
+                                                Delay (1 octet)
+                Response Status parameters:     Present Level (2 octets)
+                                                Target Level (2 octets)
+                                                Remaining Time (4 octets)
 
-		Acknowledgment values:
-					True = with requesting a status response
-					False = without requesting a status response
+                Acknowledgment values:
+                        True = with requesting a status response
+                        False = without requesting a status response
 
-		This command is used to change the Level state.
-		Makes the server move its level state by some delta value.
+                This command is used to change the Level state.
+                Makes the server move its level state by some delta value.
 
-		In case of an error, the error response will be returned.
+                In case of an error, the error response will be returned.
 
-	Opcode 0x07 - Generic Level Move Set/Status
+        Opcode 0x07 - Generic Level Move Set/Status
 
-		Controller Index:		<controller id>
-		Command parameters:		Acknowledgement (1 octet)
-						Move (2 octets)
-						Transition Time (1 octet)
-						Delay (1 octet)
-		Response Status parameters:	Present Level (2 octets)
-			 			Target Level (2 octets)
-						Remaining Time (4 octets)
+                Controller Index:               <controller id>
+                Command parameters:             Acknowledgement (1 octet)
+                                                Move (2 octets)
+                                                Transition Time (1 octet)
+                                                Delay (1 octet)
+                Response Status parameters:     Present Level (2 octets)
+                                                Target Level (2 octets)
+                                                Remaining Time (4 octets)
 
-		Acknowledgment values:
-					True = with requesting a status response
-					False = without requesting a status response
+                Acknowledgment values:
+                        True = with requesting a status response
+                        False = without requesting a status response
 
-		This command is used to set the Move Level state.
-		It makes the server continuously move its level state.
+                This command is used to set the Move Level state.
+                It makes the server continuously move its level state.
 
-		In case of an error, the error response will be returned.
+                In case of an error, the error response will be returned.
 
-	Opcode 0x08 - Generic Default Transition Time Get/Status
+        Opcode 0x08 - Generic Default Transition Time Get/Status
 
-		Controller Index:		<controller id>
-		Command parameters: 		<none>
-		Response Status parameters: 	Transition Time (4 octets)
+                Controller Index:               <controller id>
+                Command parameters:             <none>
+                Response Status parameters:     Transition Time (4 octets)
 
-		This command is used to get the Default Transition Time.
+                This command is used to get the Default Transition Time.
 
-		In case of an error, the error response will be returned.
+                In case of an error, the error response will be returned.
 
-	Opcode 0x09 - Generic Default Transition Time Set/Status
+        Opcode 0x09 - Generic Default Transition Time Set/Status
 
-		Controller Index:		<controller id>
-		Command parameters: 		Acknowledgement (1 octet)
-						Transition Time (1 octet)
-		Response Status parameters: 	Transition Time (4 octets)
+                Controller Index:               <controller id>
+                Command parameters:             Acknowledgement (1 octet)
+                                                Transition Time (1 octet)
+                Response Status parameters:     Transition Time (4 octets)
 
-		This command is used to set the Default Transition Time.
+                This command is used to set the Default Transition Time.
 
-		In case of an error, the error response will be returned.
+                In case of an error, the error response will be returned.
 
-	Opcode 0x0a - Generic On Power Up Get/Status
+        Opcode 0x0a - Generic On Power Up Get/Status
 
-		Controller Index:		<controller id>
-		Command parameters: 		<none>
-		Response Status parameters: 	On Power Up (1 octet)
+                Controller Index:               <controller id>
+                Command parameters:             <none>
+                Response Status parameters:     On Power Up (1 octet)
 
-		This command is used to get the OnPowerUp state.
+                This command is used to get the OnPowerUp state.
 
-		In case of an error, the error response will be returned.
+                In case of an error, the error response will be returned.
 
-	Opcode 0x0b - Generic On Power Up Set/Status
+        Opcode 0x0b - Generic On Power Up Set/Status
 
-		Controller Index:		<controller id>
-		Command parameters: 		Acknowledgement (1 octet)
-						On Power Up (1 octet)
-		Response Status parameters: 	On Power Up (1 octet)
+                Controller Index:               <controller id>
+                Command parameters:             Acknowledgement (1 octet)
+                                                On Power Up (1 octet)
+                Response Status parameters:     On Power Up (1 octet)
 
-		Acknowledgment values:
-					True = with requesting a status response
-					False = without requesting a status response
+                Acknowledgment values:
+                        True = with requesting a status response
+                        False = without requesting a status response
 
-		This command is used to set the OnPowerUp state.
+                This command is used to set the OnPowerUp state.
 
-		In case of an error, the error response will be returned.
+                In case of an error, the error response will be returned.
 
-	Opcode 0x0c - Generic Power Level Get/Status
+        Opcode 0x0c - Generic Power Level Get/Status
 
-		Controller Index:		<controller id>
-		Command parameters: 		<none>
-		Response Status parameters: 	Power Level  (2 octets)
+                Controller Index:               <controller id>
+                Command parameters:             <none>
+                Response Status parameters:     Power Level  (2 octets)
 
-		This command is used to get the Power Level.
+                This command is used to get the Power Level.
 
-		In case of an error, the error response will be returned.
+                In case of an error, the error response will be returned.
 
-	Opcode 0x0d - Generic Power Level Set/Status
+        Opcode 0x0d - Generic Power Level Set/Status
 
-		Controller Index:		<controller id>
-		Command parameters: 		Acknowledgement (1 octet)
-		                    		Power Level (2 octets)
-		                    		Transition Time (1 octet)
-		                    		Delay (1 octet)
-		Response Status parameters: 	Power Level (1 octet)
+                Controller Index:               <controller id>
+                Command parameters:             Acknowledgement (1 octet)
+                                                Power Level (2 octets)
+                                                Transition Time (1 octet)
+                                                Delay (1 octet)
+                Response Status parameters:     Power Level (1 octet)
 
-		This command is used to set the Power Level.
+                This command is used to set the Power Level.
 
-		In case of an error, the error response will be returned.
+                In case of an error, the error response will be returned.
 
-	Opcode 0x0e - Generic Power Level Last Get/Status
+        Opcode 0x0e - Generic Power Level Last Get/Status
 
-		Controller Index:		<controller id>
-		Command parameters: 		<none>
-		Response Status parameters: 	Power Level Last (2 octets)
+                Controller Index:               <controller id>
+                Command parameters:             <none>
+                Response Status parameters:     Power Level Last (2 octets)
 
-		This command is used to get last non-zero Power Level.
+                This command is used to get last non-zero Power Level.
 
-		In case of an error, the error response will be returned.
+                In case of an error, the error response will be returned.
 
-	Opcode 0x0f - Generic Power Level Default Get/Status
+        Opcode 0x0f - Generic Power Level Default Get/Status
 
-		Controller Index:		<controller id>
-		Command parameters: 		<none>
-		Response Status parameters: 	Power Default (2 octets)
+                Controller Index:               <controller id>
+                Command parameters:             <none>
+                Response Status parameters:     Power Default (2 octets)
 
-		This command is used to get the Default Power Level.
+                This command is used to get the Default Power Level.
 
-		In case of an error, the error response will be returned.
+                In case of an error, the error response will be returned.
 
-	Opcode 0x10 - Generic Power Level Default Set/Status
+        Opcode 0x10 - Generic Power Level Default Set/Status
 
-		Controller Index:		<controller id>
-		Command parameters: 		Acknowledgement (1 octet)
-						Power Default (2 octets)
-		Response Status parameters: 	Power Default (2 octets)
+                Controller Index:               <controller id>
+                Command parameters:             Acknowledgement (1 octet)
+                                                Power Default (2 octets)
+                Response Status parameters:     Power Default (2 octets)
 
-		Acknowledgment values:
-					True = with requesting a status response
-					False = without requesting a status response
+                Acknowledgment values:
+                        True = with requesting a status response
+                        False = without requesting a status response
 
-		This command is used to set the Default Power Level.
+                This command is used to set the Default Power Level.
 
-		In case of an error, the error response will be returned.
+                In case of an error, the error response will be returned.
 
-	Opcode 0x11 - Generic Power Lever Range Get/Status
+        Opcode 0x11 - Generic Power Lever Range Get/Status
 
-		Controller Index:		<controller id>
-		Command parameters: 		<none>
-		Response Status parameters: 	Status  (1 octet)
-			 			Min (2 octets)
-						Max (2 octets)
+                Controller Index:               <controller id>
+                Command parameters:             <none>
+                Response Status parameters:     Status  (1 octet)
+                                                Min (2 octets)
+                                                Max (2 octets)
 
-		This command is used to get the Power Range state.
+                This command is used to get the Power Range state.
 
-		In case of an error, the error response will be returned.
+                In case of an error, the error response will be returned.
 
-	Opcode 0x12 - Generic Power Level Range Set/Status
+        Opcode 0x12 - Generic Power Level Range Set/Status
 
-		Controller Index:		<controller id>
-		Command parameters: 		Acknowledgement (1 octet)
-						Min (2 octets)
-						Max (2 octets)
-		Response Status parameters: 	Status  (1 octet)
-			 			Min (2 octets)
-						Max (2 octets)
+                Controller Index:               <controller id>
+                Command parameters:             Acknowledgement (1 octet)
+                                                Min (2 octets)
+                                                Max (2 octets)
+                Response Status parameters:     Status  (1 octet)
+                                                Min (2 octets)
+                                                Max (2 octets)
 
-		Acknowledgment values:
-					True = with requesting a status response
-					False = without requesting a status response
+                Acknowledgment values:
+                        True = with requesting a status response
+                        False = without requesting a status response
 
-		This command is used to set the Power Range state.
+                This command is used to set the Power Range state.
 
-		In case of an error, the error response will be returned.
+                In case of an error, the error response will be returned.
 
-	Opcode 0x13 - Generic Battery Get/Status
+        Opcode 0x13 - Generic Battery Get/Status
 
-		Controller Index:		<controller id>
-		Command parameters: 		<none>
-		Response Status parameters: 	Battery Level (1 octet)
-			 			Time to Discharge (3 octets)
-						Time to Charge (3 octets)
+                Controller Index:               <controller id>
+                Command parameters:             <none>
+                Response Status parameters:     Battery Level (1 octet)
+                                                Time to Discharge (3 octets)
+                                                Time to Charge (3 octets)
 
-		This command is used to get the Battery state.
+                This command is used to get the Battery state.
 
-		In case of an error, the error response will be returned.
+                In case of an error, the error response will be returned.
 
-	Opcode 0x14 - Generic Location Global Get/Status
+        Opcode 0x14 - Generic Location Global Get/Status
 
-		Controller Index:		<controller id>
-		Command parameters: 		<none>
-		Response Status parameters: 	Global Latitude (4 octets)
-			 			Global Longitude (4 octets)
-						Global Altitude (2 octets)
+                Controller Index:               <controller id>
+                Command parameters:             <none>
+                Response Status parameters:     Global Latitude (4 octets)
+                                                Global Longitude (4 octets)
+                                                Global Altitude (2 octets)
 
-		This command is used to get the Global Location state.
+                This command is used to get the Global Location state.
 
-		In case of an error, the error response will be returned.
+                In case of an error, the error response will be returned.
 
-	Opcode 0x15 - Generic Location Local Get/Status
+        Opcode 0x15 - Generic Location Local Get/Status
 
-		Controller Index:		<controller id>
-		Command parameters: 		<none>
-		Response Status parameters: 	Local North (2 octets)
-						Local East (2 octets)
-						Local Altitude (2 octets)
-						Floor Number (1 octet)
-						Uncertainty (2 octets)
+                Controller Index:               <controller id>
+                Command parameters:             <none>
+                Response Status parameters:     Local North (2 octets)
+                                                Local East (2 octets)
+                                                Local Altitude (2 octets)
+                                                Floor Number (1 octet)
+                                                Uncertainty (2 octets)
 
-		This command is used to get the Local Location state.
+                This command is used to get the Local Location state.
 
-		In case of an error, the error response will be returned.
+                In case of an error, the error response will be returned.
 
-	Opcode 0x16 - Generic Location Global Set/Status
+        Opcode 0x16 - Generic Location Global Set/Status
 
-		Controller Index:		<controller id>
-		Command parameters: 		Acknowledgement (1 octet)
-						Global Latitude (4 octets)
-						Global Longitude (4 octets)
-						Global Altitude (2 octets)
-		Response Status parameters: 	Global Latitude (4 octets)
-			 			Global Longitude (4 octets)
-						Global Altitude (2 octets)
+                Controller Index:               <controller id>
+                Command parameters:             Acknowledgement (1 octet)
+                                                Global Latitude (4 octets)
+                                                Global Longitude (4 octets)
+                                                Global Altitude (2 octets)
+                Response Status parameters:     Global Latitude (4 octets)
+                                                Global Longitude (4 octets)
+                                                Global Altitude (2 octets)
 
-		Acknowledgment values:
-					True = with requesting a status response
-					False = without requesting a status response
+                Acknowledgment values:
+                        True = with requesting a status response
+                        False = without requesting a status response
 
-		This command is used to set the Global Location state.
+                This command is used to set the Global Location state.
 
-		In case of an error, the error response will be returned.
+                In case of an error, the error response will be returned.
 
-	Opcode 0x17 - Generic Location Local Set/Status
+        Opcode 0x17 - Generic Location Local Set/Status
 
-		Controller Index:		<controller id>
-		Command parameters: 		Acknowledgement (1 octet)
-						Local North (2 octets)
-						Local East (2 octets)
-						Local Altitude (2 octets)
-						Floor Number (1 octet)
-						Uncertainty (2 octets)
-		Response Status parameters: 	Local North (2 octets)
-			 			Local East (2 octets)
-						Local Altitude (2 octets)
-						Floor Number (1 octet)
-						Uncertainty (2 octets)
+                Controller Index:               <controller id>
+                Command parameters:             Acknowledgement (1 octet)
+                                                Local North (2 octets)
+                                                Local East (2 octets)
+                                                Local Altitude (2 octets)
+                                                Floor Number (1 octet)
+                                                Uncertainty (2 octets)
+                Response Status parameters:     Local North (2 octets)
+                                                Local East (2 octets)
+                                                Local Altitude (2 octets)
+                                                Floor Number (1 octet)
+                                                Uncertainty (2 octets)
 
-		Acknowledgment values:
-					True = with requesting a status response
-					False = without requesting a status response
+                Acknowledgment values:
+                        True = with requesting a status response
+                        False = without requesting a status response
 
-		This command is used to set the Local Location state.
+                This command is used to set the Local Location state.
 
-		In case of an error, the error response will be returned.
+                In case of an error, the error response will be returned.
 
-	Opcode 0x18 - Generic User Properties Get/Status
+        Opcode 0x18 - Generic User Properties Get/Status
 
-		Controller Index:		<controller id>
-		Command parameters: 		Kind of Property Server (1 octet)
-						Property ID (2 octets)
-		Response Status parameters: 	[array] Property IDs (variable)
+                Controller Index:               <controller id>
+                Command parameters:             Kind of Property Server (1 octet)
+                                                Property ID (2 octets)
+                Response Status parameters:     [array] Property IDs (variable)
 
-		This command is used to get the list of Properties.
+                This command is used to get the list of Properties.
 
-		In case of an error, the error response will be returned.
+                In case of an error, the error response will be returned.
 
-	Opcode 0x19 - Generic User Property Get/Status
+        Opcode 0x19 - Generic User Property Get/Status
 
-		Controller Index:		<controller id>
-		Command parameters: 		Kind of Property Server (1 octet)
-		                    		Property ID (2 octets)
-		Response Status parameters: 	Property ID (2 octets)
-			 			Acces (1 octet)
-						Property Value Size (1 octet)
-						Property Value (variable)
+                Controller Index:               <controller id>
+                Command parameters:             Kind of Property Server (1 octet)
+                                                Property ID (2 octets)
+                Response Status parameters:     Property ID (2 octets)
+                                                Acces (1 octet)
+                                                Property Value Size (1 octet)
+                                                Property Value (variable)
 
-		This command is used to get the value of a Property.
+                This command is used to get the value of a Property.
 
-		In case of an error, the error response will be returned.
+                In case of an error, the error response will be returned.
 
-	Opcode 0x1a - Generic User Property Set/Status
+        Opcode 0x1a - Generic User Property Set/Status
 
-		Controller Index:		<controller id>
-		Command parameters: 		Acknowledgement (1 octet)
-						Kind of Property Server (1 octet)
-						Property ID (2 octets)
-						Access (1 octet)
-						Property Value (variable)
-		Response Status parameters: 	Property ID (2 octets)
-			 			Access (1 octet)
-						Property Value Size (1 octet)
-						Property Value (variable)
+                Controller Index:               <controller id>
+                Command parameters:             Acknowledgement (1 octet)
+                                                Kind of Property Server (1 octet)
+                                                Property ID (2 octets)
+                                                Access (1 octet)
+                                                Property Value (variable)
+                Response Status parameters:     Property ID (2 octets)
+                                                Access (1 octet)
+                                                Property Value Size (1 octet)
+                                                Property Value (variable)
 
-		Acknowledgment values:
-					True = with requesting a status response
-					False = without requesting a status response
+                Acknowledgment values:
+                        True = with requesting a status response
+                        False = without requesting a status response
 
-		This command is used to set the user access of a property.
+                This command is used to set the user access of a property.
 
-		In case of an error, the error response will be returned.
+                In case of an error, the error response will be returned.
 
-	Opcode 0x1b - Sensor Descriptor Get/Status
+        Opcode 0x1b - Sensor Descriptor Get/Status
 
-		Controller Index:		<controller id>
-		Command parameters: 		Sensor ID (2 octets)
-		Response Status parameters: 	[array] Descriptor (variable)
+                Controller Index:               <controller id>
+                Command parameters:             Sensor ID (2 octets)
+                Response Status parameters:     [array] Descriptor (variable)
 
-		This command is used to get the descriptor for the given sensor.
+                This command is used to get the descriptor for the given sensor.
 
-		In case of an error, the error response will be returned.
+                In case of an error, the error response will be returned.
 
-	Opcode 0x1c - Sensor Get/Status
+        Opcode 0x1c - Sensor Get/Status
 
-		Controller Index:		<controller id>
-		Command parameters: 		Sensor ID (2 octets)
-		Response Status parameters: 	[array] Marshalled Sensor Data (variable)
+                Controller Index:               <controller id>
+                Command parameters:             Sensor ID (2 octets)
+                Response Status parameters:     [array] Marshalled Sensor Data (variable)
 
-		This command is used to get the sensor data from a sensor instance.
+                This command is used to get the sensor data from a sensor instance.
 
-		In case of an error, the error response will be returned.
+                In case of an error, the error response will be returned.
 
-	Opcode 0x1d - Sensor Column Get/Status
+        Opcode 0x1d - Sensor Column Get/Status
 
-		Controller Index:		<controller id>
-		Command parameters: 		Sensor ID (2 octets)
-						Raw Value (variable)
-		Response Status parameters: 	Property ID (2 octets)
-			 			Column Data (variable)
+                Controller Index:               <controller id>
+                Command parameters:             Sensor ID (2 octets)
+                                                Raw Value (variable)
+                Response Status parameters:     Property ID (2 octets)
+                                                Column Data (variable)
 
-		This command is used to get a single sensor series data entry.
+                This command is used to get a single sensor series data entry.
 
-		In case of an error, the error response will be returned.
+                In case of an error, the error response will be returned.
 
-	Opcode 0x1e - Sensor Series Get/Status
+        Opcode 0x1e - Sensor Series Get/Status
 
-		Controller Index:		<controller id>
-		Command parameters: 		Sensor ID (2 octets)
-						Raw Values (variable)
-		Response Status parameters: 	Property ID (2 octets)
-			 			Column Data (variable)
+                Controller Index:               <controller id>
+                Command parameters:             Sensor ID (2 octets)
+                                                Raw Values (variable)
+                Response Status parameters:     Property ID (2 octets)
+                                                Column Data (variable)
 
-		This command is used to get a single sensor series data entry.
+                This command is used to get a single sensor series data entry.
 
-		In case of an error, the error response will be returned.
+                In case of an error, the error response will be returned.
 
-	Opcode 0x1f - Sensor Cadence Get/Status
+        Opcode 0x1f - Sensor Cadence Get/Status
 
-		Controller Index:		<controller id>
-		Command parameters: 		Sensor ID (2 octets)
-		Response Status parameters: 	Sensor ID (2 octets)
-			 			Cadence Data (variable)
+                Controller Index:               <controller id>
+                Command parameters:             Sensor ID (2 octets)
+                Response Status parameters:     Sensor ID (2 octets)
+                                                Cadence Data (variable)
 
-		This command is used to get the Cadence state for given sensor.
+                This command is used to get the Cadence state for given sensor.
 
-		In case of an error, the error response will be returned.
+                In case of an error, the error response will be returned.
 
-	Opcode 0x20 - Sensor Cadence Set/Status
+        Opcode 0x20 - Sensor Cadence Set/Status
 
-		Controller Index:		<controller id>
-		Command parameters: 		Acknowledgement (1 octet)
-						Sensor ID (2 octets)
-						Cadence Data (variable)
-		Response Status parameters: 	Cadence Data (variable)
+                Controller Index:               <controller id>
+                Command parameters:             Acknowledgement (1 octet)
+                                                Sensor ID (2 octets)
+                                                Cadence Data (variable)
+                Response Status parameters:     Cadence Data (variable)
 
-		Acknowledgment values:
-					True = with requesting a status response
-					False = without requesting a status response
+                Acknowledgment values:
+                        True = with requesting a status response
+                        False = without requesting a status response
 
-		This command is used to set the Cadence state for given sensor.
+                This command is used to set the Cadence state for given sensor.
 
-		In case of an error, the error response will be returned.
+                In case of an error, the error response will be returned.
 
-	Opcode 0x21 - Sensor Settings Get/Status
+        Opcode 0x21 - Sensor Settings Get/Status
 
-		Controller Index		<controller id>
-		Command parameters:		Sensor ID (2 octets)
-		Response Status parameters:	Sensor ID (2 octets)
-			 			Property ID (2 octets)
+                Controller Index                <controller id>
+                Command parameters:             Sensor ID (2 octets)
+                Response Status parameters:     Sensor ID (2 octets)
+                                                Property ID (2 octets)
 
-		This command is used to get the list of settings for given sensor.
+                This command is used to get the list of settings for given sensor.
 
-		In case of an error, the error response will be returned.
+                In case of an error, the error response will be returned.
 
-	Opcode 0x22 - Sensor Setting Get/Status
+        Opcode 0x22 - Sensor Setting Get/Status
 
-		Controller Index:		<controller id>
-		Command parameters: 		Sensor ID (2 octets)
-						Setting ID (2 octets)
-		Response Status parameters:
+                Controller Index:               <controller id>
+                Command parameters:             Sensor ID (2 octets)
+                                                Setting ID (2 octets)
+                Response Status parameters:
 
-	Opcode 0x23 - Sensor Setting Set
+        Opcode 0x23 - Sensor Setting Set
 
-		Controller Index:		<controller id>
-		Command parameters: 		Acknowledgement (1 octet)
-						Sensor ID (2 octets)
-						Setting ID (2 octets)
-						Sensor Setting Raw (variable)
-		Response Status parameters:
+                Controller Index:               <controller id>
+                Command parameters:             Acknowledgement (1 octet)
+                                                Sensor ID (2 octets)
+                                                Setting ID (2 octets)
+                                                Sensor Setting Raw (variable)
+                Response Status parameters:
 
-	Opcode 0x24 - Time Get/Status
+        Opcode 0x24 - Time Get/Status
 
-		Controller Index:		<controller id>
-		Command parameters: 		<none>
-		Response Status parameters: 	TAI Seconds (5 octets)
-			 			Subsecond (1 octet)
-						Uncertainy (1 octet)
-						TAI-UTC Delta (2 octets)
-						Time Zone Offset (1 octet)
+                Controller Index:               <controller id>
+                Command parameters:             <none>
+                Response Status parameters:     TAI Seconds (5 octets)
+                                                Subsecond (1 octet)
+                                                Uncertainy (1 octet)
+                                                TAI-UTC Delta (2 octets)
+                                                Time Zone Offset (1 octet)
 
-		This command is used to get current Time Status.
+                This command is used to get current Time Status.
 
-		In case of an error, the error response will be returned.
+                In case of an error, the error response will be returned.
 
-	Opcode 0x25 - Time Set/Status
+        Opcode 0x25 - Time Set/Status
 
-		Controller Index:		<controller id>
-		Command parameters: 		TAI Seconds (6 octets)
-						Subsecond (1 octet)
-						Uncertainy (1 octet)
-						TAI-UTC Delta (2 octets)
-						Time Zone Offset (1 octet)
-		Response Status parameters: 	TAI Seconds (5 octets)
-			 			Subsecond (1 octet)
-						Uncertainy (1 octet)
-						TAI-UTC Delta (2 octets)
-						Time Zone Offset (1 octet)
+                Controller Index:               <controller id>
+                Command parameters:             TAI Seconds (6 octets)
+                                                Subsecond (1 octet)
+                                                Uncertainy (1 octet)
+                                                TAI-UTC Delta (2 octets)
+                                                Time Zone Offset (1 octet)
+                Response Status parameters:     TAI Seconds (5 octets)
+                                                Subsecond (1 octet)
+                                                Uncertainy (1 octet)
+                                                TAI-UTC Delta (2 octets)
+                                                Time Zone Offset (1 octet)
 
-		This command is used to get the Time Role state.
+                This command is used to get the Time Role state.
 
-		In case of an error, the error response will be returned.
+                In case of an error, the error response will be returned.
 
-	Opcode 0x26 - Time Role Get/Status
+        Opcode 0x26 - Time Role Get/Status
 
-		Controller Index:		<controller id>
-		Command parameters: 		<none>
-		Response Status parameters: 	Time Role (1 octet)
+                Controller Index:               <controller id>
+                Command parameters:             <none>
+                Response Status parameters:     Time Role (1 octet)
 
-		This command is used to get the Time Role state.
+                This command is used to get the Time Role state.
 
-		In case of an error, the error response will be returned.
+                In case of an error, the error response will be returned.
 
-	Opcode 0x27 - Time Role Set/Status
+        Opcode 0x27 - Time Role Set/Status
 
-		Controller Index:		<controller id>
-		Command parameters: 		Time Role (1 octet)
-		Response Status parameters: 	Time Role (1 octet)
+                Controller Index:               <controller id>
+                Command parameters:             Time Role (1 octet)
+                Response Status parameters:     Time Role (1 octet)
 
-		This command is used to set the Time Role state.
+                This command is used to set the Time Role state.
 
-		In case of an error, the error response will be returned.
+                In case of an error, the error response will be returned.
 
-	Opcode 0x28 - Time Zone Get
+        Opcode 0x28 - Time Zone Get
 
-		Controller Index:		<controller id>
-		Command parameters: 		<none>
-		Response Status parameters: 	Time Zone Offset Current (2 octets)
-			 			Time Zone Offset New (2 octets)
-						TAI of Zone Change (8 octets)
+                Controller Index:               <controller id>
+                Command parameters:             <none>
+                Response Status parameters:     Time Zone Offset Current (2 octets)
+                                                Time Zone Offset New (2 octets)
+                                                TAI of Zone Change (8 octets)
 
-		This command is used to get the Time Zone status.
+                This command is used to get the Time Zone status.
 
-		In case of an error, the error response will be returned.
+                In case of an error, the error response will be returned.
 
-	Opcode 0x29 - Time Zone Set
+        Opcode 0x29 - Time Zone Set
 
-		Controller Index:		<controller id>
-		Command parameters: 		Time Zone Offset New (2 octets)
-						TAI of Zone Change (8 octets)
-		Response Status parameters: 	Time Zone Offset New (2 octets)
-			 			TAI of Zone Change (8 octets)
+                Controller Index:               <controller id>
+                Command parameters:             Time Zone Offset New (2 octets)
+                                                TAI of Zone Change (8 octets)
+                Response Status parameters:     Time Zone Offset New (2 octets)
+                                                TAI of Zone Change (8 octets)
 
-		This command is used to set the Time Zone status.
+                This command is used to set the Time Zone status.
 
-		In case of an error, the error response will be returned.
+                In case of an error, the error response will be returned.
 
-	Opcode 0x2a - Time TAI-UTC Delta Get/Status
+        Opcode 0x2a - Time TAI-UTC Delta Get/Status
 
-		Controller Index:		<controller id>
-		Command parameters: 		<none>
-		Response Status parameters: 	TAI-UTC Delta Current (2 octets)
-			 			TAI-UTC Delta New (2 octets)
-						TAI of Delta Change (8 octets)
+                Controller Index:               <controller id>
+                Command parameters:             <none>
+                Response Status parameters:     TAI-UTC Delta Current (2 octets)
+                                                TAI-UTC Delta New (2 octets)
+                                                TAI of Delta Change (8 octets)
 
-		This command is used to get the UTC Delta change.
+                This command is used to get the UTC Delta change.
 
-		In case of an error, the error response will be returned.
+                In case of an error, the error response will be returned.
 
-	Opcode 0x2b - Time TAI-UTC Delta Set/Status
+        Opcode 0x2b - Time TAI-UTC Delta Set/Status
 
-		Controller Index:		<controller id>
-		Command parameters: 		TAI-UTC Delta New (2 octets)
-						TAI of Delta Change (8 octets)
-		Response Status parameters: 	TAI-UTC Delta New (2 octets)
-			 			TAI of Delta Change (8 octets)
+                Controller Index:               <controller id>
+                Command parameters:             TAI-UTC Delta New (2 octets)
+                                                TAI of Delta Change (8 octets)
+                Response Status parameters:     TAI-UTC Delta New (2 octets)
+                                                TAI of Delta Change (8 octets)
 
-		This command is used to set the UTC Delta change.
+                This command is used to set the UTC Delta change.
 
-		In case of an error, the error response will be returned.
+                In case of an error, the error response will be returned.
 
-	Opcode 0x2c - Light Lightness Get/Status
+        Opcode 0x2c - Light Lightness Get/Status
 
-		Controller Index:		<controller id>
-		Command parameters: 		<none>
-		Response Status parameters: 	Present Lightness (2 octets)
-			 			Target Lightness (2 octets)
-						Remaining Time (4 octets)
+                Controller Index:               <controller id>
+                Command parameters:             <none>
+                Response Status parameters:     Present Lightness (2 octets)
+                                                Target Lightness (2 octets)
+                                                Remaining Time (4 octets)
 
-		This command is used to get the Light Level.
+                This command is used to get the Light Level.
 
-		In case of an error, the error response will be returned.
+                In case of an error, the error response will be returned.
 
-	Opcode 0x2d - Light Lightness Set/Status
+        Opcode 0x2d - Light Lightness Set/Status
 
-		Controller Index:		<controller id>
-		Command parameters: 		Acknowledgement (1 octet)
-						Lightness (2 octets)
-						Transition Time (1 octet)
-						Delay (1octet)
-		Response Status parameters: 	Present Lightness (2 octets)
-						Target Lightness (2 octets)
-						Remaining Time (4 octets)
+                Controller Index:               <controller id>
+                Command parameters:             Acknowledgement (1 octet)
+                                                Lightness (2 octets)
+                                                Transition Time (1 octet)
+                                                Delay (1octet)
+                Response Status parameters:     Present Lightness (2 octets)
+                                                Target Lightness (2 octets)
+                                                Remaining Time (4 octets)
 
-		Acknowledgment values:
-				True = with requesting a status response
-				False = without requesting a status response
+                Acknowledgment values:
+                        True = with requesting a status response
+                        False = without requesting a status response
 
-		This command is used to set the Light Level.
+                This command is used to set the Light Level.
 
-		In case of an error, the error response will be returned.
+                In case of an error, the error response will be returned.
 
-	Opcode 0x2e - Light Lightness Linear Get/Status
+        Opcode 0x2e - Light Lightness Linear Get/Status
 
-		Controller Index:		<controller id>
-		Command parameters: 		<none>
-		Response Status parameters: 	Present Lightness (2 octets)
-			 			Target Lightness (2 octets)
+                Controller Index:               <controller id>
+                Command parameters:             <none>
+                Response Status parameters:     Present Lightness (2 octets)
+                                                Target Lightness (2 octets)
 
-		This command is used to get the Linear Light Level.
+                This command is used to get the Linear Light Level.
 
-		In case of an error, the error response will be returned.
+                In case of an error, the error response will be returned.
 
-	Opcode 0x2f - Light Lightness Linear Set/Status
+        Opcode 0x2f - Light Lightness Linear Set/Status
 
-		Controller Index:		<controller id>
-		Command parameters: 		Acknowledgement (1 octet)
-						Lightness Linear(2 octets)
-						Transition Time (1 octet)
-						Delay (1octet)
-		Response Status parameters: 	Present Lightness (2 octets)
-			 			Target Lightness (2 octets)
-						Remaining Time (4 octets)
+                Controller Index:               <controller id>
+                Command parameters:             Acknowledgement (1 octet)
+                                                Lightness Linear(2 octets)
+                                                Transition Time (1 octet)
+                                                Delay (1octet)
+                Response Status parameters:     Present Lightness (2 octets)
+                                                Target Lightness (2 octets)
+                                                Remaining Time (4 octets)
 
-		Acknowledgment values:
-				True = with requesting a status response
-				False = without requesting a status response
+                Acknowledgment values:
+                        True = with requesting a status response
+                        False = without requesting a status response
 
-		This command is used to set the Linear Light Level.
+                This command is used to set the Linear Light Level.
 
-		In case of an error, the error response will be returned.
+                In case of an error, the error response will be returned.
 
-	Opcode 0x30 - Light Lightness Last Get/Status
+        Opcode 0x30 - Light Lightness Last Get/Status
 
-		Controller Index:		<controller id>
-		Command parameters: 		<none>
-		Response Status parameters: 	Lightness (2 octets)
+                Controller Index:               <controller id>
+                Command parameters:             <none>
+                Response Status parameters:     Lightness (2 octets)
 
-		This command is used to get the last non-zero Light Level.
+                This command is used to get the last non-zero Light Level.
 
-		In case of an error, the error response will be returned.
+                In case of an error, the error response will be returned.
 
-	Opcode 0x31 - Light Lightness Default Get/Status
+        Opcode 0x31 - Light Lightness Default Get/Status
 
-		Controller Index:		<controller id>
-		Command parameters: 		<none>
-		Response Status parameters: 	Lightness (2 octets)
+                Controller Index:               <controller id>
+                Command parameters:             <none>
+                Response Status parameters:     Lightness (2 octets)
 
-		This command is used to get the Default Light state.
+                This command is used to get the Default Light state.
 
-		In case of an error, the error response will be returned.
+                In case of an error, the error response will be returned.
 
-	Opcode 0x32 - Light Lightness Default Set/Status
+        Opcode 0x32 - Light Lightness Default Set/Status
 
-		Controller Index:		<controller id>
-		Command parameters: 		Acknowledgement (1 octet)
-						Lightness (2 octets)
-		Response Status parameters: 	Lightness (2 octets)
+                Controller Index:               <controller id>
+                Command parameters:             Acknowledgement (1 octet)
+                                                Lightness (2 octets)
+                Response Status parameters:     Lightness (2 octets)
 
-		This command is used to set the Default Light state.
+                This command is used to set the Default Light state.
 
-		In case of an error, the error response will be returned.
+                In case of an error, the error response will be returned.
 
-	Opcode 0x33 - Light Lightness Range Get/Status
+        Opcode 0x33 - Light Lightness Range Get/Status
 
-		Controller Index:		<controller id>
-		Command parameters: 		<none>
-		Response Status parameters: 	Status Code (2 octets)
-			 			Range Min (2 octets)
-						Range Max (2 octets)
+                Controller Index:               <controller id>
+                Command parameters:             <none>
+                Response Status parameters:     Status Code (2 octets)
+                                                Range Min (2 octets)
+                                                Range Max (2 octets)
 
-		This command is used to get the Light Range state.
+                This command is used to get the Light Range state.
 
-		In case of an error, the error response will be returned.
+                In case of an error, the error response will be returned.
 
-	Opcode 0x34 - Light Lightness Range Set/Status
+        Opcode 0x34 - Light Lightness Range Set/Status
 
-		Controller Index:		<controller id>
-		Command parameters: 		Acknowledgement (1 octet)
-						Range Min (2 octets)
-						Range Max (2 octets)
-		Response Status parameters: 	Status Code (2 octets)
-			 			Range Min (2 octets)
-						Range Max (2 octets)
+                Controller Index:               <controller id>
+                Command parameters:             Acknowledgement (1 octet)
+                                                Range Min (2 octets)
+                                                Range Max (2 octets)
+                Response Status parameters:     Status Code (2 octets)
+                                                Range Min (2 octets)
+                                                Range Max (2 octets)
 
-		Acknowledgment values:
-				True = with requesting a status response
-				False = without requesting a status response
+                Acknowledgment values:
+                        True = with requesting a status response
+                        False = without requesting a status response
 
-		This command is used to set the Light Range state.
+                This command is used to set the Light Range state.
 
-		In case of an error, the error response will be returned.
+                In case of an error, the error response will be returned.
 
-	Opcode 0x35 - Light LC Mode Get/Status
+        Opcode 0x35 - Light LC Mode Get/Status
 
-		Controller Index:		<controller id>
-		Command parameters: 		<none>
-		Response Status parameters: 	Mode (1 octet)
+                Controller Index:               <controller id>
+                Command parameters:             <none>
+                Response Status parameters:     Mode (1 octet)
 
-		This command is used to get the Light Lightness Control Server’s current Mode.
+                This command is used to get the Light Lightness Control Server’s current Mode.
 
-		In case of an error, the error response will be returned.
+                In case of an error, the error response will be returned.
 
-	Opcode 0x36 - Light LC Mode Set/Status
+        Opcode 0x36 - Light LC Mode Set/Status
 
-		Controller Index:		<controller id>
-		Command parameters: 		Acknowledgement (1 octet)
-						Mode (1 octet)
-		Response Status parameters: 	Mode (1 octet)
+                Controller Index:               <controller id>
+                Command parameters:             Acknowledgement (1 octet)
+                                                Mode (1 octet)
+                Response Status parameters:     Mode (1 octet)
 
-		Acknowledgment values:
-				True = with requesting a status response
-				False = without requesting a status response
+                Acknowledgment values:
+                        True = with requesting a status response
+                        False = without requesting a status response
 
-		This command is used to set the Light Lightness Control Server’s current Mode.
+                This command is used to set the Light Lightness Control Server’s current Mode.
 
-		In case of an error, the error response will be returned.
+                In case of an error, the error response will be returned.
 
-	Opcode 0x37 - Light LC Occupancy Mode Get/Status
+        Opcode 0x37 - Light LC Occupancy Mode Get/Status
 
-		Controller Index:		<controller id>
-		Command parameters: 		<none>
-		Response Status parameters: 	Occupancy Mode (1 octet)
+                Controller Index:               <controller id>
+                Command parameters:             <none>
+                Response Status parameters:     Occupancy Mode (1 octet)
 
-		This command is used to get the Light Lightness Control Server’s Occupancy Mode.
+                This command is used to get the Light Lightness Control Server’s Occupancy Mode.
 
-		In case of an error, the error response will be returned.
+                In case of an error, the error response will be returned.
 
-	Opcode 0x38 - Light LC Occupancy Mode Set/Status
+        Opcode 0x38 - Light LC Occupancy Mode Set/Status
 
-		Controller Index:		<controller id>
-		Command parameters: 		Acknowledgement (1 octet)
-						Occupancy Mode (1 octet)
-		Response Status parameters: 	Mode (1 octet)
+                Controller Index:               <controller id>
+                Command parameters:             Acknowledgement (1 octet)
+                                                Occupancy Mode (1 octet)
+                Response Status parameters:     Mode (1 octet)
 
-		Acknowledgment values:
-				True = with requesting a status response
-				False = without requesting a status response
+                Acknowledgment values:
+                        True = with requesting a status response
+                        False = without requesting a status response
 
-		This command is used to set the Light Lightness Control Server’s Occupancy Mode.
+                This command is used to set the Light Lightness Control Server’s Occupancy Mode.
 
-		In case of an error, the error response will be returned.
+                In case of an error, the error response will be returned.
 
-	Opcode 0x39 - Light LC Light OnOff Mode Get/Status
+        Opcode 0x39 - Light LC Light OnOff Mode Get/Status
 
-		Controller Index:		<controller id>
-		Command parameters: 		<none>
-		Response Status parameters: 	Light OnOff (1 octet)
+                Controller Index:               <controller id>
+                Command parameters:             <none>
+                Response Status parameters:     Light OnOff (1 octet)
 
-		This command is used to get the Light Lightness Control Server’s current OnOff state.
+                This command is used to get the Light Lightness Control Server’s current OnOff state.
 
-		In case of an error, the error response will be returned.
+                In case of an error, the error response will be returned.
 
-	Opcode 0x3a - Light LC Light OnOff Mode Set/Status
+        Opcode 0x3a - Light LC Light OnOff Mode Set/Status
 
-		Controller Index:		<controller id>
-		Command parameters: 		Acknowledgement (1 octet)
-						Light OnOff (1 octet)
-						Transition Time (1 octet)
-						Delay (1octet)
-		Response Status parameters: 	Present Light OnOff (1 octet)
-			 			Target Light OnOff (1 octet)
-						Remaining Time (4 octets)
+                Controller Index:               <controller id>
+                Command parameters:             Acknowledgement (1 octet)
+                                                Light OnOff (1 octet)
+                                                Transition Time (1 octet)
+                                                Delay (1octet)
+                Response Status parameters:     Present Light OnOff (1 octet)
+                                                Target Light OnOff (1 octet)
+                                                Remaining Time (4 octets)
 
-		Acknowledgment values:
-				True = with requesting a status response
-				False = without requesting a status response
+                Acknowledgment values:
+                        True = with requesting a status response
+                        False = without requesting a status response
 
-		This command is used to set the Light Lightness Control Server’s current OnOff state.
+                This command is used to set the Light Lightness Control Server’s current OnOff state.
 
-		In case of an error, the error response will be returned.
+                In case of an error, the error response will be returned.
 
-	Opcode 0x3b - Light LC Property Get/Status
+        Opcode 0x3b - Light LC Property Get/Status
 
-		Controller Index:		<controller id>
-		Command parameters: 		<none>
-		Response Status parameters: 	Light OnOff (1 octet)
+                Controller Index:               <controller id>
+                Command parameters:             <none>
+                Response Status parameters:     Light OnOff (1 octet)
 
-		This command is used to get the Light Lightness Control Server property value.
+                This command is used to get the Light Lightness Control Server property value.
 
-		In case of an error, the error response will be returned.
+                In case of an error, the error response will be returned.
 
-	Opcode 0x3c - Light LC Property Set/Status
+        Opcode 0x3c - Light LC Property Set/Status
 
-		Controller Index:		<controller id>
-		Command parameters: 		Acknowledgement (1 octet)
-						Light OnOff (1 octet)
-						Transition Time (1 octet)
-						Delay (1octet)
-		Response Status parameters: 	Present Light OnOff (1 octet)
-						Target Light OnOff (1 octet)
-						Remaining Time (4 octets)
+                Controller Index:               <controller id>
+                Command parameters:             Acknowledgement (1 octet)
+                                                Light OnOff (1 octet)
+                                                Transition Time (1 octet)
+                                                Delay (1octet)
+                Response Status parameters:     Present Light OnOff (1 octet)
+                                                Target Light OnOff (1 octet)
+                                                Remaining Time (4 octets)
 
-		Acknowledgment values:
-				True = with requesting a status response
-				False = without requesting a status response
+                Acknowledgment values:
+                        True = with requesting a status response
+                        False = without requesting a status response
 
-		This command is used to set the Light Lightness Control Server property value.
+                This command is used to set the Light Lightness Control Server property value.
 
-		In case of an error, the error response will be returned.
+                In case of an error, the error response will be returned.
 
-	Opcode 0x3d - Sensor Data Set
+        Opcode 0x3d - Sensor Data Set
 
-		Controller Index:		<controller id>
-		Command parameters: 		Sensor ID (2 octets)
-						Raw Values (variable)
+                Controller Index:               <controller id>
+                Command parameters:             Sensor ID (2 octets)
+                                                Raw Values (variable)
 
-		This command is used to set Sensor Data.
+                This command is used to set Sensor Data.
 
-		In case of an error, the error response will be returned.
+                In case of an error, the error response will be returned.
 
-	Opcode 0x3e - Light CTL States Get/Status
+        Opcode 0x3e - Light CTL States Get/Status
 
-		Controller Index:		<controller id>
-		Command parameters: 		<none>
-		Response Status parameters: 	Present CTL Lightness (2 octets)
-			 			Present CTL Temperature (2 octets)
-						Target CTL Lightness (2 octets)
-						Target CTL Temperature (2 octets)
-						Remaining Time (4 octets)
+                Controller Index:               <controller id>
+                Command parameters:             <none>
+                Response Status parameters:     Present CTL Lightness (2 octets)
+                                                Present CTL Temperature (2 octets)
+                                                Target CTL Lightness (2 octets)
+                                                Target CTL Temperature (2 octets)
+                                                Remaining Time (4 octets)
 
-		This command is used to get the CTL state.
+                This command is used to get the CTL state.
 
-		In case of an error, the error response will be returned.
+                In case of an error, the error response will be returned.
 
-	Opcode 0x3f - Light CTL States Set/status
+        Opcode 0x3f - Light CTL States Set/status
 
-		Controller Index:		<controller id>
-		Command parameters: 		Acknowledgement (1 octet)
-						CTL Lightness (2 octets)
-						CTL Temperature (2 octets)
-						CTL Delta UV
-						Transition Time (1 octet)
-						Delay (1 octet)
-		Response Status parameters: 	Present CTL Lightness (2 octets)
-			 			Present CTL Temperature (2 octets)
-						Target CTL Lightness (2 octets)
-						Target CTL Temperature (2 octets)
-						Remaining Time (4 octets)
+                Controller Index:               <controller id>
+                Command parameters:             Acknowledgement (1 octet)
+                                                CTL Lightness (2 octets)
+                                                CTL Temperature (2 octets)
+                                                CTL Delta UV
+                                                Transition Time (1 octet)
+                                                Delay (1 octet)
+                Response Status parameters:     Present CTL Lightness (2 octets)
+                                                Present CTL Temperature (2 octets)
+                                                Target CTL Lightness (2 octets)
+                                                Target CTL Temperature (2 octets)
+                                                Remaining Time (4 octets)
 
-		Acknowledgment values:
-				True = with requesting a status response
-				False = without requesting a status response
+                Acknowledgment values:
+                        True = with requesting a status response
+                        False = without requesting a status response
 
-		This command is used to set the CTL state.
+                This command is used to set the CTL state.
 
-		In case of an error, the error response will be returned.
+                In case of an error, the error response will be returned.
 
-	Opcode 0x40 - Light CTL Temperature Get/Status
+        Opcode 0x40 - Light CTL Temperature Get/Status
 
-		Controller Index:		<controller id>
-		Command parameters: 		<none>
-		Response Status parameters: 	Present CTL Temperature (2 octets)
-			 			Present CTL Delta UV (2 octets)
-						Target CTL Temperature (2 octets)
-						Target CTL Delta UV (2 octets)
-						Remaining Time (4 octets)
+                Controller Index:               <controller id>
+                Command parameters:             <none>
+                Response Status parameters:     Present CTL Temperature (2 octets)
+                                                Present CTL Delta UV (2 octets)
+                                                Target CTL Temperature (2 octets)
+                                                Target CTL Delta UV (2 octets)
+                                                Remaining Time (4 octets)
 
-		This command is used to get the Light CTL Temperature state.
+                This command is used to get the Light CTL Temperature state.
 
-		In case of an error, the error response will be returned.
+                In case of an error, the error response will be returned.
 
-	Opcode 0x41 - Light CTL Temperature Set/Status
+        Opcode 0x41 - Light CTL Temperature Set/Status
 
-		Controller Index:		<controller id>
-		Command parameters: 		Acknowledgement (1 octet)
-						CTL Temperature (2 octets)
-						CTL Delta UV (2 octets)
-						Transition Time (1 octet)
-						Delay (1 octet)
-		Response Status parameters: 	Present CTL Temperature (2 octets)
-			 			Present CTL Delta UV (2 octets)
-						Target CTL Temperature (2 octets)
-						Target CTL Delta UV (2 octets)
-						Remaining Time (4 octets)
+                Controller Index:               <controller id>
+                Command parameters:             Acknowledgement (1 octet)
+                                                CTL Temperature (2 octets)
+                                                CTL Delta UV (2 octets)
+                                                Transition Time (1 octet)
+                                                Delay (1 octet)
+                Response Status parameters:     Present CTL Temperature (2 octets)
+                                                Present CTL Delta UV (2 octets)
+                                                Target CTL Temperature (2 octets)
+                                                Target CTL Delta UV (2 octets)
+                                                Remaining Time (4 octets)
 
-		Acknowledgment values:
-				True = with requesting a status response
-				False = without requesting a status response
+                Acknowledgment values:
+                        True = with requesting a status response
+                        False = without requesting a status response
 
-		This command is used to set the Light CTL Temperature state.
+                This command is used to set the Light CTL Temperature state.
 
-		In case of an error, the error response will be returned.
+                In case of an error, the error response will be returned.
 
-	Opcode 0x42 - Light CTL Default Get/Status
+        Opcode 0x42 - Light CTL Default Get/Status
 
-		Controller Index:		<controller id>
-		Command parameters: 		<none>
-		Response Status parameters: 	CTL Lightness (2 octet)
-			 			CTL Temperature (2 octet)
-						CTL Delta UV (2 octets)
+                Controller Index:               <controller id>
+                Command parameters:             <none>
+                Response Status parameters:     CTL Lightness (2 octet)
+                                                CTL Temperature (2 octet)
+                                                CTL Delta UV (2 octets)
 
-		This command is used to get the Default Light CTL state.
+                This command is used to get the Default Light CTL state.
 
-		In case of an error, the error response will be returned.
+                In case of an error, the error response will be returned.
 
-	Opcode 0x43 - Light CTL Default Set/Status
+        Opcode 0x43 - Light CTL Default Set/Status
 
-		Controller Index:		<controller id>
-		Command parameters: 		Acknowledgement (1 octet)
-						CTL Lightness (2 octets)
-						CTL Temperature (2 octets)
-						CTL Delta UV (2 octets)
-		Response Status parameters: 	CTL Lightness (2 octets)
-			 			CTL Temperature (2 octets)
-						CTL Delta UV (2 octets_
+                Controller Index:               <controller id>
+                Command parameters:             Acknowledgement (1 octet)
+                                                CTL Lightness (2 octets)
+                                                CTL Temperature (2 octets)
+                                                CTL Delta UV (2 octets)
+                Response Status parameters:     CTL Lightness (2 octets)
+                                                CTL Temperature (2 octets)
+                                                CTL Delta UV (2 octets_
 
-		Acknowledgment values:
-				True = with requesting a status response
-				False = without requesting a status response
+                Acknowledgment values:
+                        True = with requesting a status response
+                        False = without requesting a status response
 
-		This command is used to set the Default Light CTL state.
+                This command is used to set the Default Light CTL state.
 
-		In case of an error, the error response will be returned.
+                In case of an error, the error response will be returned.
 
-	Opcode 0x44 - Light CTL Temperature Range Get/Ststus
+        Opcode 0x44 - Light CTL Temperature Range Get/Ststus
 
-		Controller Index:		<controller id>
-		Command parameters: 		<none>
-		Response Status parameters:	Status Code (1 octet)
-			 			Range Min (2 octets)
-						Range Max(2 octets)
+                Controller Index:               <controller id>
+                Command parameters:             <none>
+                Response Status parameters:     Status Code (1 octet)
+                                                Range Min (2 octets)
+                                                Range Max(2 octets)
 
-		This command is used to get the Light CTL Temperature Range.
+                This command is used to get the Light CTL Temperature Range.
 
-		In case of an error, the error response will be returned.
+                In case of an error, the error response will be returned.
 
-	Opcode 0x45 - Light CTL Temperature Range Set/Status
+        Opcode 0x45 - Light CTL Temperature Range Set/Status
 
-		Controller Index:		<controller id>
-		Command parameters: 		Acknowledgement (1 octet)
-						Range Min (2 octets)
-						Range Max(2 octets)
-		Response Status parameters: 	Status Code (1 octet)
-			 			Range Min (2 octets)
-						Range Max(2 octets)
+                Controller Index:               <controller id>
+                Command parameters:             Acknowledgement (1 octet)
+                                                Range Min (2 octets)
+                                                Range Max(2 octets)
+                Response Status parameters:     Status Code (1 octet)
+                                                Range Min (2 octets)
+                                                Range Max(2 octets)
 
-		Acknowledgment values:
-				True = with requesting a status response
-				False = without requesting a status response
+                Acknowledgment values:
+                        True = with requesting a status response
+                        False = without requesting a status response
 
-		This command is used to set the Light CTL Temperature Range.
+                This command is used to set the Light CTL Temperature Range.
 
-		In case of an error, the error response will be returned.
+                In case of an error, the error response will be returned.
 
-	Opcode 0x46 - Scene State Get/Status
+        Opcode 0x46 - Scene State Get/Status
 
-		Controller Index:		<controller id>
-		Command parameters: 		<none>
-		Response Status parameters: 	Status Code (1 octet)
-			 			Current Scene (2 octets)
-						Target Scene (2 octets)
+                Controller Index:               <controller id>
+                Command parameters:             <none>
+                Response Status parameters:     Status Code (1 octet)
+                                                Current Scene (2 octets)
+                                                Target Scene (2 octets)
 
-		This command is used to get the the current state of a Scene.
+                This command is used to get the the current state of a Scene.
 
-		In case of an error, the error response will be returned.
+                In case of an error, the error response will be returned.
 
-	Opcode 0x47 - Scene Register Get/Status
+        Opcode 0x47 - Scene Register Get/Status
 
-		Controller Index:		<controller id>
-		Command parameters: 		Acknowledgement (1 octet)
-						Scene Number (2 octets)
-		Response Status parameters: 	Status Code (1 octet)
-			 			Current Scene (2 octets)
+                Controller Index:               <controller id>
+                Command parameters:             Acknowledgement (1 octet)
+                                                Scene Number (2 octets)
+                Response Status parameters:     Status Code (1 octet)
+                                                Current Scene (2 octets)
 
-		Acknowledgment values:
-				True = with requesting a status response
-				False = without requesting a status response
+                Acknowledgment values:
+                        True = with requesting a status response
+                        False = without requesting a status response
 
-		This command is used to get the the full scene register of a Scene.
+                This command is used to get the the full scene register of a Scene.
 
-		In case of an error, the error response will be returned.
+                In case of an error, the error response will be returned.
 
-	Opcode 0x48 - Scene Store Procedure
+        Opcode 0x48 - Scene Store Procedure
 
-		Controller Index:		<controller id>
-		Command parameters:		<none>
-		Response Status parameters: 	Status Code (1 octet)
-			 			Range Min (2 octets)
-						Range Max(2 octets)
+                Controller Index:               <controller id>
+                Command parameters:             <none>
+                Response Status parameters:     Status Code (1 octet)
+                                                Range Min (2 octets)
+                                                Range Max(2 octets)
 
-		This command is used to store the current state.
+                This command is used to store the current state.
 
-		In case of an error, the error response will be returned.
+                In case of an error, the error response will be returned.
 
-	Opcode 0x49 - Scene Recall/Status
+        Opcode 0x49 - Scene Recall/Status
 
-		Controller Index:		<controller id>
-		Command parameters: 		Acknowledgement (1 octet)
-						Range Min (2 octets)
-						Range Max(2 octets)
-		Response Status parameters: 	Status Code (1 octet)
-			 			Range Min (2 octets)
-						Range Max(2 octets)
+                Controller Index:               <controller id>
+                Command parameters:             Acknowledgement (1 octet)
+                                                Range Min (2 octets)
+                                                Range Max(2 octets)
+                Response Status parameters:     Status Code (1 octet)
+                                                Range Min (2 octets)
+                                                Range Max(2 octets)
 
-		Acknowledgment values:
-				True = with requesting a status response
-				False = without requesting a status response
+                Acknowledgment values:
+                        True = with requesting a status response
+                        False = without requesting a status response
 
-		This command is used to recall the scene.
+                This command is used to recall the scene.
 
-		In case of an error, the error response will be returned.
+                In case of an error, the error response will be returned.
 
     Opcode 0x5f - DFU Information Get
 
-		Controller Index:		<controller id>
-		Command parameters: 		Limit (1 octet)
+                Controller Index:               <controller id>
+                Command parameters:             Limit (1 octet)
 
-		This command is used to perform DFU image list request. Limit sets
-		maximum number of images to get.
+                This command is used to perform DFU image list request. Limit sets
+                maximum number of images to get.
 
-	Opcode 0x60 - BLOB Information Get
+        Opcode 0x60 - BLOB Information Get
 
-		Controller Index:		<controller id>
-		Command parameters: 		Address Count (1 octet)
-		                            Addresses (variable)
+                Controller Index:               <controller id>
+                Command parameters:             Address Count (1 octet)
+                                                Addresses (variable)
 
-		This command is used to get transfer capabilities for list of targets,
-		in address list.
+                This command is used to get transfer capabilities for list of
+                targets, in address list.
 
-	Opcode 0x61 - DFU Update Firmware Check
+        Opcode 0x61 - DFU Update Firmware Check
 
-		Controller Index:		<controller id>
-		Command parameters: 		Index (1 octet)
-		                            Slot Index (1 octet)
-		                            Slot Size (1 octet)
-		                            Firmware ID Length (1 octet)
-		                            Metadata Length (1 octet)
-		                            Metadata (variable)
+                Controller Index:               <controller id>
+                Command parameters:             Index (1 octet)
+                                                Slot Index (1 octet)
+                                                Slot Size (1 octet)
+                                                Firmware ID Length (1 octet)
+                                                Metadata Length (1 octet)
+                                                Metadata (variable)
 
-		This command is used to perform metadata check for given DFU image slot.
+                This command is used to perform metadata check for given DFU image slot.
 
-	Opcode 0x62 - DFU Update Firmware Get
+        Opcode 0x62 - DFU Update Firmware Get
 
-		Controller Index:		<controller id>
-		Command parameters: 		<none>
+                Controller Index:               <controller id>
+                Command parameters:             <none>
 
-		This command is used to get status of target node.
+                This command is used to get status of target node.
 
-	Opcode 0x63 - DFU Update Firmware Cancel
+        Opcode 0x63 - DFU Update Firmware Cancel
 
-		Controller Index:		<controller id>
-		Command parameters: 		<none>
+                Controller Index:               <controller id>
+                Command parameters:             <none>
 
-		This command is used to cancel ongoing DFU transfer.
+                This command is used to cancel ongoing DFU transfer.
 
-	Opcode 0x64 - DFU Update Firmware Start
+        Opcode 0x64 - DFU Update Firmware Start
 
-		Controller Index:		<controller id>
-		Command parameters: 		Address count (1 octet)
-		                            Slot Index (1 octet)
-		                            Slot Size (1 octet)
-		                            Firmware ID Length (1 octet)
-		                            Metadata Length (1 octet)
-		                            Block Size (1 octet)
-		                            Chunk Size (2 octet)
-		                            Metadata (variable)
-		                            Address (2 octets)
+                Controller Index:               <controller id>
+                Command parameters:             Address count (1 octet)
+                                                Slot Index (1 octet)
+                                                Slot Size (1 octet)
+                                                Firmware ID Length (1 octet)
+                                                Metadata Length (1 octet)
+                                                Block Size (1 octet)
+                                                Chunk Size (2 octet)
+                                                Metadata (variable)
+                                                Address (2 octets)
 
-		This command is used to start DFU distribution.
+                This command is used to start DFU distribution.
 
-	Opcode 0x65 - BLOB Server Receive
+        Opcode 0x65 - BLOB Server Receive
 
-		Controller Index:		<controller id>
-		Command parameters: 		ID (8 octet)
-		                            Timeout (1 octet)
-									TTL (1 octet)
+                Controller Index:               <controller id>
+                Command parameters:             ID (8 octet)
+                                                Timeout (1 octet)
+                                                TTL (1 octet)
 
-		This command is used to prepare BLOB Server for incoming transfer.
+                This command is used to prepare BLOB Server for incoming transfer.
 
-	Opcode 0x66 - BLOB Transfer Start
+        Opcode 0x66 - BLOB Transfer Start
 
-		Controller Index:		<controller id>
-		Command parameters: 		ID (8 octet)
-		                            Size (2 octet)
-		                            Block Size (1 octet)
-		                            Chunk Size (2 octet)
-		                            Timeout (2 octet)
-									TTL (1 octet)
+                Controller Index:               <controller id>
+                Command parameters:             ID (8 octet)
+                                                Size (2 octet)
+                                                Block Size (1 octet)
+                                                Chunk Size (2 octet)
+                                                Timeout (2 octet)
+                                                TTL (1 octet)
 
-		This command is used to perform BLOB transfer.
+                This command is used to perform BLOB transfer.
 
-	Opcode 0x67 - BLOB Transfer Cancel
+        Opcode 0x67 - BLOB Transfer Cancel
 
-		Controller Index:		<controller id>
-		Command parameters: 		<none>
+                Controller Index:               <controller id>
+                Command parameters:             <none>
 
-		This command is used to cancel ongoing transfer.
+                This command is used to cancel ongoing transfer.
 
-	Opcode 0x68 - BLOB Transfer Get
+        Opcode 0x68 - BLOB Transfer Get
 
-		Controller Index:		<controller id>
-		Command parameters: 		<none>
+                Controller Index:               <controller id>
+                Command parameters:             <none>
 
-		This command is used to get the current progress of the active transfer.
+                This command is used to get the current progress of the active transfer.
 
-	Opcode 0x69 - BLOB Server Cancel
+        Opcode 0x69 - BLOB Server Cancel
 
-		Controller Index:		<controller id>
-		Command parameters: 		<none>
+                Controller Index:               <controller id>
+                Command parameters:             <none>
 
-		This command is used to tell Client to drop the server from list of
-		targets and abandon ongoing transfer.
+                This command is used to tell Client to drop the server from list of
+                targets and abandon ongoing transfer.
 
-	Opcode 0x6a - BLOB DFU Firmware Update Apply
+        Opcode 0x6a - BLOB DFU Firmware Update Apply
 
-		Controller Index:		<controller id>
-		Command parameters: 		<none>
+                Controller Index:               <controller id>
+                Command parameters:             <none>
 
-		This command is used to tell the device acting as DFU Client to apply
-		completed DFU transfer by Server.
+                This command is used to tell the device acting as DFU Client to apply
+                completed DFU transfer by Server.
 
-	Opcode 0x6b - BLOB DFU Server Apply
+        Opcode 0x6b - BLOB DFU Server Apply
 
-		Controller Index:		<controller id>
-		Command parameters: 		<none>
+                Controller Index:               <controller id>
+                Command parameters:             <none>
 
-		This command is used to apply completed DFU transfer on device acting as
-		a Server.
+                This command is used to apply completed DFU transfer on device acting as
+                a Server.

--- a/doc/btp_mesh_node.txt
+++ b/doc/btp_mesh_node.txt
@@ -3,1486 +3,1544 @@ Mesh Node Service (ID 4)
 
 Commands and responses:
 
-	Opcode 0x00 - Error response
+        Opcode 0x00 - Error response
+
+        Opcode 0x01 - Read Supported Commands command/response
+
+                Controller Index:       <controller id>
+                Command parameters:     <none>
+                Response parameters:    <supported commands> (variable)
+
+                Each bit in response is a flag indicating if command with
+                opcode matching bit number is supported. Bit set to 1 means
+                that command is supported. Bit 0 is reserved and shall always
+                be set to 0. If specific bit is not present in response (less
+                than required bytes received) it shall be assumed that command
+                is not supported.
 
-	Opcode 0x01 - Read Supported Commands command/response
+                In case of an error, the error response will be returned.
 
-		Controller Index:	<controller id>
-		Command parameters:	<none>
-		Response parameters:	<supported commands> (variable)
+        Opcode 0x02 - Configure Provisioning command/response
+                Controller Index:       <controller id>
+                Command parameters:     UUID (16 octets)
+                                        Static Auth (32 octets)
+                                        Static Auth Length (1 octet)
+                                        Output Size (1 octet)
+                                        Output Actions (2 octets)
+                                        Input Size (1 octet)
+                                        Input Actions (2 octets)
+                Response parameters:    <none>
 
-		Each bit in response is a flag indicating if command with
-		opcode matching bit number is supported. Bit set to 1 means
-		that command is supported. Bit 0 is reserved and shall always
-		be set to 0. If specific bit is not present in response (less
-		than required bytes received) it shall be assumed that command
-		is not supported.
+                This command is used to configure provisioning options.
+
+                Output actions is a bitmask with following available bits:
+                        0       Blink
+                        1       Beep
+                        2       Vibrate
+                        3       Display number
+                        4       Display string
 
-		In case of an error, the error response will be returned.
+                Input actions is a bitmask with following available bits:
+                        0       Push
+                        1       Twist
+                        2       Enter number
+                        3       Enter string
+
+                In case of an error, the error response will be returned.
+
+        Opcode 0x03 - Provision Node command/response
+                Controller Index:       <controller id>
+                Command parameters:     Network Key (16 octets)
+                                        Network Key Index (2 octets)
+                                        Provisioning Flags (1 octet)
+                                        IV Index (4 octets)
+                                        Sequence Number (4 octets)
+                                        Primary Element Address (2 octets)
+                                        Device Key (16 octets)
+                Response parameters:    <none>
 
-	Opcode 0x02 - Configure Provisioning command/response
-		Controller Index:	<controller id>
-		Command parameters:	UUID (16 octets)
-					Static Auth (32 octets)
-					Static Auth Length (1 octet)
-					Output Size (1 octet)
-					Output Actions (2 octets)
-					Input Size (1 octet)
-					Input Actions (2 octets)
+                This command is used to provide provisioning information. It can
+                be used whenever unprovisioned beacon is advertising or not.
 
-		This command is used to configure provisioning options.
+                In case of an error, the error response will be returned.
 
-		Output actions is a bitmask with following available bits:
-			0	Blink
-			1	Beep
-			2	Vibrate
-			3	Display number
-			4	Display string
+        Opcode 0x04 - Init command/response
+                Controller Index:       <controller id>
+                Command parameters:     Composition Data (1 octet)
+                Response parameters:    <none>
 
-		Input actions is a bitmask with following available bits:
-			0	Push
-			1	Twist
-			2	Enter number
-			3	Enter string
+                This command is used to initialize the stack.
 
-		In case of an error, the error response will be returned.
+                In case of an error, the error response will be returned.
 
-	Opcode 0x03 - Provision Node command/response
-		Controller Index:	<controller id>
-		Command parameters:	Network Key (16 octets)
-					Network Key Index (2 octets)
-					Provisioning Flags (1 octet)
-					IV Index (4 octets)
-					Sequence Number (4 octets)
-					Primary Element Address (2 octets)
-					Device Key (16 octets)
+        Opcode 0x05 - Reset command/response
+                Controller Index:       <controller id>
+                Command parameters:     <none>
+                Response parameters:    <none>
 
-		This command is used to provide provisioning information. It can
-		be used whenever unprovisioned beacon is advertising or not.
+                This command is used to reset state of a provisioned node making
+                it to start sending unprovisioned beacons.
 
-		In case of an error, the error response will be returned.
+                In case of an error, the error response will be returned.
 
-	Opcode 0x04 - Init command/response
-		Controller Index:	<controller id>
-		Command parameters:	Composition Data (1 octet)
+        Opcode 0x06 - Input number command/response
+                Controller Index:       <controller id>
+                Command parameters:     Number (4 octets)
+                Response parameters:    <none>
 
-		This command is used to initialize the stack.
+                This command is used to reply with input number as a response to
+                Input action event.
 
-		In case of an error, the error response will be returned.
+                In case of an error, the error response will be returned.
 
-	Opcode 0x05 - Reset command/response
-		Controller Index:	<controller id>
-		Command parameters:	<none>
+        Opcode 0x07 - Input string command/response
+                Controller Index:       <controller id>
+                Command parameters:     String Length (1 octet)
+                                        String (variable)
+                Response parameters:    <none>
 
-		This command is used to reset state of a provisioned node making
-		it to start sending unprovisioned beacons.
+                This command is used to reply with input string as a response to
+                Input action event.
 
-		In case of an error, the error response will be returned.
+                In case of an error, the error response will be returned.
 
-	Opcode 0x06 - Input number command/response
-		Controller Index:	<controller id>
-		Command parameters:	Number (4 octets)
+        Opcode 0x08 - IV Update Test Mode
+                Controller Index:       <controller id>
+                Command parameters:     Toggle (1 octet)
+                Response parameters:    <none>
 
-		This command is used to reply with input number as a response to
-		Input action event.
+                Valid Toggle values:
+                        0x00 = Disable
+                        0x01 = Enable
 
-		In case of an error, the error response will be returned.
+                This command is used to toggle the IV Update test mode.
 
-	Opcode 0x07 - Input string command/response
-		Controller Index:	<controller id>
-		Command parameters:	String Length (1 octet)
-					String (variable)
+                In case of an error, the error response will be returned.
 
-		This command is used to reply with input string as a response to
-		Input action event.
+        Opcode 0x09 - IV Update toggle state
+                Controller Index:       <controller id>
+                Command parameters:     <none>
+                Response parameters:    <none>
 
-		In case of an error, the error response will be returned.
+                This command is used to make a IV Update state transition
+                while in IV Update test mode, ignoring the 96 hour limit.
 
-	Opcode 0x08 - IV Update Test Mode
-		Controller Index:	<controller id>
-		Command parameters:	Toggle (1 octet)
+                In case of an error, the error response will be returned.
 
-		Valid Toggle values:
-					0x00 = Disable
-					0x01 = Enable
+        Opcode 0x0a - Network Send
+                Controller Index:       <controller id>
+                Command parameters:     TTL (1 octet)
+                                        SRC (2 octets)
+                                        DST (2 octets)
+                                        Payload_Len (1 octet)
+                                        Payload (variable)
+                Response parameters:    <none>
 
-		This command is used to toggle the IV Update test mode.
+                This command is used to send network layer packet.
 
-		In case of an error, the error response will be returned.
+                In case of an error, the error response will be returned.
 
-	Opcode 0x09 - IV Update toggle state
-		Controller Index:	<controller id>
-		Command parameters:	<none>
+        Opcode 0x0b - Health Generate Faults
+                Controller Index:       <controller id>
+                Command parameters:     <none>
+                Response parameters:    Test_ID (1 octet)
+                                        Current_Faults_Count (1 octet)
+                                        Registered_Faults_Count (1 octet)
+                                        Current_Faults (variable)
+                                        Registered_Faults (variable)
 
-		This command is used to make a IV Update state transition
-		while in IV Update test mode, ignoring the 96 hour limit.
+                This command is used to generate health faults on IUT.
 
-		In case of an error, the error response will be returned.
+                In case of an error, the error response will be returned.
 
-	Opcode 0x0a - Network Send
-		Controller Index:	<controller id>
-		Command parameters:	TTL (1 octet)
-					SRC (2 octets)
-					DST (2 octets)
-					Payload_Len (1 octet)
-					Payload (variable)
+        Opcode 0x0c - Health Clear Faults
+                Controller Index:       <controller id>
+                Command parameters:     <none>
+                Response parameters:    <none>
 
-		This command is used to send network layer packet.
+                This command is used to clear fault arrays on IUT.
 
-		In case of an error, the error response will be returned.
+                In case of an error, the error response will be returned.
 
-	Opcode 0x0b - Health Generate Faults
-		Controller Index:	<controller id>
-		Command parameters:	<none>
-		Response parameters:	Test_ID (1 octet)
-					Current_Faults_Count (1 octet)
-					Registered_Faults_Count (1 octet)
-					Current_Faults (variable)
-					Registered_Faults (variable)
+        Opcode 0x0d - Low Power Node
+                Controller Index:       <controller id>
+                Command parameters:     Toggle (1 octet)
+                Response parameters:    <none>
 
-		This command is used to generate health faults on IUT.
+                Valid Toggle values:
+                        0x00 = Disable
+                        0x01 = Enable
 
-		In case of an error, the error response will be returned.
+                This command is used to toggle the Low Power feature of the
+                local device.
 
-	Opcode 0x0c - Health Clear Faults
-		Controller Index:	<controller id>
-		Command parameters:	<none>
+                In case of an error, the error response will be returned.
 
-		This command is used to clear fault arrays on IUT.
+        Opcode 0x0e - Low Power Node Poll
+                Controller Index:       <controller id>
+                Command parameters:     <none>
+                Response parameters:    <none>
 
-		In case of an error, the error response will be returned.
+                This command is used to send out a Friend Poll message.
 
-	Opcode 0x0d - Low Power Node
-		Controller Index:	<controller id>
-		Command parameters:	Toggle (1 octet)
+                In case of an error, the error response will be returned.
 
-		Valid Toggle values:
-					0x00 = Disable
-					0x01 = Enable
+        Opcode 0x0f - Model Send
+                Controller Index:       <controller id>
+                Command parameters:     TTL (2 octets)
+                                        SRC (2 octets)
+                                        DST (2 octets)
+                                        Payload_Len (1 octet)
+                                        Payload (variable)
+                Response parameters:    <none>
 
-		This command is used to toggle the Low Power feature of the
-		local device.
+                This command is used to send Mesh model message.
 
-		In case of an error, the error response will be returned.
+                In case of an error, the error response will be returned.
 
-	Opcode 0x0e - Low Power Node Poll
-		Controller Index:	<controller id>
-		Command parameters:	<none>
+        Opcode 0x10 - Low Power Node Subscribe
+                Controller Index:       <controller id>
+                Command parameters:     Address (2 octets)
+                Response parameters:    <none>
 
-		This command is used to send out a Friend Poll message.
+                This command is used to send out a Friend Subscription List
+                Add message message.
 
-		In case of an error, the error response will be returned.
+                In case of an error, the error response will be returned.
 
-	Opcode 0x0f - Model Send
-		Controller Index:	<controller id>
-		Command parameters:	TTL (2 octets)
-					SRC (2 octets)
-					DST (2 octets)
-					Payload_Len (1 octet)
-					Payload (variable)
+        Opcode 0x11 - Low Power Node Unsubscribe
+                Controller Index:       <controller id>
+                Command parameters:     Address (2 octets)
+                Response parameters:    <none>
 
-		This command is used to send Mesh model message.
+                This command is used to send out a Friend Subscription List
+                Remove message.
 
-		In case of an error, the error response will be returned.
+                In case of an error, the error response will be returned.
 
-	Opcode 0x10 - Low Power Node Subscribe
-		Controller Index:	<controller id>
-		Command parameters:	Address (2 octets)
+        Opcode 0x12 - Clear Replay Protection List Cache
+                Controller Index:       <controller id>
+                Command parameters:     <none>
+                Response parameters:    <none>
 
-		This command is used to send out a Friend Subscription List
-		Add message message.
+                This command is used to clear Replay Protection List Cache.
 
-		In case of an error, the error response will be returned.
+                In case of an error, the error response will be returned.
 
-	Opcode 0x11 - Low Power Node Unsubscribe
-		Controller Index:	<controller id>
-		Command parameters:	Address (2 octets)
+        Opcode 0x13 - Enable advertising with Node Identity
+                Controller Index:       <controller id>
+                Command parameters:     <none>
+                Response parameters:    <none>
 
-		This command is used to send out a Friend Subscription List
-		Remove message.
+                This command is used to start advertising on each subnet using
+                Node Identity for the next 60 seconds.
 
-		In case of an error, the error response will be returned.
+                In case of an error, the error response will be returned.
 
-	Opcode 0x12 - Clear Replay Protection List Cache
-		Controller Index:	<controller id>
-		Command parameters:	<none>
+        Opcode 0x14 - Config Composition Data Get
 
-		This command is used to clear Replay Protection List Cache.
+                Controller Index:       <controller id>
+                Command parameters:     Network index (2 octets)
+                                        Node address (2 octets)
+                                        Page (1 octet)
+                Response parameters:    Received Page (1 octet)
+                                        Composition Data (variable length)
 
-		In case of an error, the error response will be returned.
+                This command is used to get the Config Composition Data.
 
-	Opcode 0x13 - Enable advertising with Node Identity
-		Controller Index:	<controller id>
-		Command parameters:	<none>
+                In case of an error, the error response will be returned.
 
-		This command is used to start advertising on each subnet using
-		Node Identity for the next 60 seconds.
+        Opcode 0x15  Config Beacon Get
 
-		In case of an error, the error response will be returned.
+                Controller Index:       <controller id>
+                Command parameters:     Network index (2 octets)
+                                        Node address (2 octets)
+                Response Parameters:    Beacon Status (1 octet)
 
-	Opcode 0x14 - Config Composition Data Get
+                This command is used to send the Config Beacon Get messages.
 
-		Controller Index:       <controller id>
-		Command parameters:     Network index (2 octets)
-		                        Node address (2 octets)
-		                        Page (1 octet)
-		Response parameters:    Received Page (1 octet)
-		                        Composition Data (variable length)
+                In case of an error, the error response will be returned.
 
-		This command is used to get the Config Composition Data.
+        Opcode 0x16 - Config Beacon Set
 
-		In case of an error, the error response will be returned.
+                Controller Index:       <controller id>
+                Command parameters:     Network index (2 octets)
+                                        Node address (2 octets)
+                                        Value (1 octet)
+                Response Parameters:    Beacon Status (1 octet)
 
-	Opcode 0x15  Config Beacon Get
+                This command is used to send the Config Beacon Set messages.
 
-		Controller Index:       <controller id>
-		Command parameters:     Network index (2 octets)
-		                        Node address (2 octets)
-		Response Parameters:    Beacon Status (1 octet)
+                In case of an error, the error response will be returned.
 
-		This command is used to send the Config Beacon Get messages.
+        Opcode 0x18 - Config Default TTL Get
 
-		In case of an error, the error response will be returned.
+                Controller Index:       <controller id>
+                Command parameters:     Network index (2 octets)
+                                        Node address (2 octets)
+                Response Parameters:    TTL Status (1 octet)
 
-	Opcode 0x16 - Config Beacon Set
+                This command is used to send the Config Default TTL Get messages.
 
-		Controller Index:       <controller id>
-		Command parameters:     Network index (2 octets)
-		                        Node address (2 octets)
-		                        Value (1 octet)
-		Response Parameters: 	Beacon Status (1 octet)
+                In case of an error, the error response will be returned.
 
-		This command is used to send the Config Beacon Set messages.
+        Opcode 0x19 - Config Default TTL Set
 
-		In case of an error, the error response will be returned.
+                Controller Index:       <controller id>
+                Command parameters:     Network index (2 octets)
+                                        Node address (2 octets)
+                                        Value (1 octet)
+                Response parameters:    TTL Status (1 octet)
 
-	Opcode 0x18 - Config Default TTL Get
+                This command is used to send the Config Default TTL Set messages.
 
-		Controller Index:       <controller id>
-		Command parameters:     Network index (2 octets)
-		                        Node address (2 octets)
-		Response Parameters:    TTL Status (1 octet)
+                In case of an error, the error response will be returned.
 
-		This command is used to send the Config Default TTL Get messages.
+        Opcode 0x1a - Config GATT Proxy Get
 
-		In case of an error, the error response will be returned.
+                Controller Index:       <controller id>
+                Command parameters:     Network index (2 octets)
+                                        Node address (2 octets)
+                Response parameters:    GATT Proxy Status (1 octet)
 
-	Opcode 0x19 - Config Default TTL Set
+                This command is used to send the Config GATT Proxy Get messages.
 
-		Controller Index:       <controller id>
-		Command parameters:     Network index (2 octets)
-		                        Node address (2 octets)
-		                        Value (1 octet)
-		Response parameters: 	TTL Status (1 octet)
+                In case of an error, the error response will be returned.
 
-		This command is used to send the Config Default TTL Set messages.
+        Opcode 0x1b - Config GATT Proxy Set
 
-		In case of an error, the error response will be returned.
+                Controller Index:       <controller id>
+                Command parameters:     Network index (2 octets)
+                                        Node address (2 octets)
+                                        Value (1 octet)
+                Response parameters:    GATT Proxy Status (1 octet)
 
-	Opcode 0x1a - Config GATT Proxy Get
+                This command is used to send the Config GATT Proxy Set messages.
 
-		Controller Index:       <controller id>
-		Command parameters:     Network index (2 octets)
-		                        Node address (2 octets)
-		Response parameters: 	GATT Proxy Status (1 octet)
+                In case of an error, the error response will be returned.
 
-		This command is used to send the Config GATT Proxy Get messages.
+        Opcode 0x1c - Config Friend Get
 
-		In case of an error, the error response will be returned.
+                Controller Index:       <controller id>
+                Command parameters:     Network index (2 octets)
+                                        Node address (2 octets)
+                Response parameters:    Friend Status (1 octet)
 
-	Opcode 0x1b - Config GATT Proxy Set
+                This command is used to send the Config Friend Get messages.
 
-		Controller Index:       <controller id>
-		Command parameters:     Network index (2 octets)
-		                        Node address (2 octets)
-		                        Value (1 octet)
-		Response parameters: 	GATT Proxy Status (1 octet)
+                In case of an error, the error response will be returned.
 
-		This command is used to send the Config GATT Proxy Set messages.
+        Opcode 0x1d - Config Friend Set
 
-		In case of an error, the error response will be returned.
+                Controller Index:       <controller id>
+                Command parameters:     Network index (2 octets)
+                                        Node address (2 octets)
+                                        Value (1 octet)
+                Response parameters:    GATT Proxy Status (1 octet)
 
-	Opcode 0x1c - Config Friend Get
+                This command is used to send the Config Friend Set messages.
 
-		Controller Index:       <controller id>
-		Command parameters:     Network index (2 octets)
-		                        Node address (2 octets)
-		Response parameters: 	Friend Status (1 octet)
+                In case of an error, the error response will be returned.
 
-		This command is used to send the Config Friend Get messages.
+        Opcode 0x1e - Config Relay Get
 
-		In case of an error, the error response will be returned.
+                Controller Index:       <controller id>
+                Command parameters:     Network index (2 octets)
+                                        Node address (2 octets)
+                Response parameters:    Relay Status (1 octet)
 
-	Opcode 0x1d - Config Friend Set
+                This command is used to send the Config Relay Get messages.
 
-		Controller Index:       <controller id>
-		Command parameters:     Network index (2 octets)
-		                        Node address (2 octets)
-		                        Value (1 octet)
-		Response parameters: 	GATT Proxy Status (1 octet)
+                In case of an error, the error response will be returned.
 
-		This command is used to send the Config Friend Set messages.
+        Opcode 0x1f - Config Relay Set
 
-		In case of an error, the error response will be returned.
+                Controller Index:       <controller id>
+                Command parameters:     Network index (2 octets)
+                                        Node address (2 octets)
+                                        Value (1 octet)
+                Response parameters:    Relay Status (1 octet)
 
-	Opcode 0x1e - Config Relay Get
+                This command is used to send the Config Relay Set messages.
 
-		Controller Index:       <controller id>
-		Command parameters:     Network index (2 octets)
-		                        Node address (2 octets)
-		Response parameters: 	Relay Status (1 octet)
+                In case of an error, the error response will be returned.
 
-		This command is used to send the Config Relay Get messages.
+        Opcode 0x20 - Config Model Publication Get
 
-		In case of an error, the error response will be returned.
+                Controller Index:       <controller id>
+                Command parameters:     Network index (2 octets)
+                                        Node address (2 octets)
+                                        Element address (2 octets)
+                                        Model ID (2 octets)
+                Response parameters:    Model Publication Status (1 octet)
 
-	Opcode 0x1f - Config Relay Set
+                This command is used to send the Config Model Publication Get messages.
 
-		Controller Index:       <controller id>
-		Command parameters:     Network index (2 octets)
-		                        Node address (2 octets)
-		                        Value (1 octet)
-		Response parameters: 	Relay Status (1 octet)
+                In case of an error, the error response will be returned.
 
-		This command is used to send the Config Relay Set messages.
+        Opcode 0x21 - Config Model Publication Set
 
-		In case of an error, the error response will be returned.
+                Controller Index:       <controller id>
+                Command parameters:     Network index (2 octets)
+                                        Node address (2 octets)
+                                        Element address (2 octets)
+                                        Model ID (2 octets)
+                                        Publication destination address (2 octets)
+                                        Application index (2 octets)
+                                        Friendship credential flag (1 octet)
+                                        TTL (1 octet)
+                                        Period (1 octet)
+                                        Transmit (1 octet)
+                Response parameters:    Model Publication Status (1 octet)
 
-	Opcode 0x20 - Config Model Publication Get
+                This command is used to send the Config Model Publication Set messages.
 
-		Controller Index:       <controller id>
-		Command parameters:     Network index (2 octets)
-		                        Node address (2 octets)
-		                        Element address (2 octets)
-		                        Model ID (2 octets)
-		Response parameters: 	Model Publication Status (1 octet)
+                In case of an error, the error response will be returned.
 
-		This command is used to send the Config Model Publication Get messages.
+        Opcode 0x22 - Config Model Subscription Add
 
-		In case of an error, the error response will be returned.
+                Controller Index:       <controller id>
+                Command parameters:     Network index (2 octets)
+                                        Node address (2 octets)
+                                        Element address (2 octets)
+                                        Subscription address (2 octets)
+                                        Model ID (2 octets)
+                Response parameters:    Model Subscription Status (1 octet)
 
-	Opcode 0x21 - Config Model Publication Set
+                This command is used to send the Config Model Subscription Add messages.
 
-		Controller Index:       <controller id>
-		Command parameters:     Network index (2 octets)
-		                        Node address (2 octets)
-		                        Element address (2 octets)
-		                        Model ID (2 octets)
-		                        Publication destination address (2 octets)
-		                        Application index (2 octets)
-		                        Friendship credential flag (1 octet)
-		                        TTL (1 octet)
-		                        Period (1 octet)
-		                        Transmit (1 octet)
-		Response parameters: 	Model Publication Status (1 octet)
+                In case of an error, the error response will be returned.
 
-		This command is used to send the Config Model Publication Set messages.
+        Opcode 0x23 - Config Model Subscription Del
 
-		In case of an error, the error response will be returned.
+                Controller Index:       <controller id>
+                Command parameters:     Network index (2 octets)
+                                        Node address (2 octets)
+                                        Element address (2 octets)
+                                        Subscription address (2 octets)
+                                        Model ID (2 octets)
+                Response parameters:    Model Subscription Status (1 octet)
 
-	Opcode 0x22 - Config Model Subscription Add
+                This command is used to send the Config Model Subscription Del messages.
 
-		Controller Index:       <controller id>
-		Command parameters:     Network index (2 octets)
-		                        Node address (2 octets)
-		                        Element address (2 octets)
-		                        Subscription address (2 octets)
-                                Model ID (2 octets)
-		Response parameters: 	Model Subscription Status (1 octet)
+                In case of an error, the error response will be returned.
 
-		This command is used to send the Config Model Subscription Add messages.
+        Opcode 0x24 - Config Model Network Key Add
 
-		In case of an error, the error response will be returned.
+                Controller Index:       <controller id>
+                Command parameters:     Network index (2 octets)
+                                        Node address (2 octets)
+                                        Network key (16 octets)
+                                        Network key index (2 octets)
+                Response parameters:    Model Netkey Status (1 octet)
 
-	Opcode 0x23 - Config Model Subscription Del
+                This command is used to send the Config Model Network Key Add messages.
 
-		Controller Index:       <controller id>
-		Command parameters:     Network index (2 octets)
-		                        Node address (2 octets)
-		                        Element address (2 octets)
-		                        Subscription address (2 octets)
-		                        Model ID (2 octets)
-		Response parameters: 	Model Subscription Status (1 octet)
+                In case of an error, the error response will be returned.
 
-		This command is used to send the Config Model Subscription Del messages.
+        Opcode 0x25 - Config Model Network Key Get
 
-		In case of an error, the error response will be returned.
+                Controller Index:       <controller id>
+                Command parameters:     Network index (2 octets)
+                                        Node address (2 octets)
+                                        Network key index (2 octets)
+                Response parameters:    Model Netkey Status (1 octet)
 
-	Opcode 0x24 - Config Model Network Key Add
+                This command is used to send the Config Model Network Key Get messages.
 
-		Controller Index:       <controller id>
-		Command parameters:     Network index (2 octets)
-		                        Node address (2 octets)
-		                        Network key (16 octets)
-		                        Network key index (2 octets)
-		Response parameters: 	Model Netkey Status (1 octet)
+                In case of an error, the error response will be returned.
 
-		This command is used to send the Config Model Network Key Add messages.
+        Opcode 0x26 - Config Model Network Key Del
 
-		In case of an error, the error response will be returned.
+                Controller Index:       <controller id>
+                Command parameters:     Network index (2 octets)
+                                        Node address (2 octets)
+                                        Network key index (2 octets)
+                Response parameters:    Model Netkey Status (1 octet)
 
-	Opcode 0x25 - Config Model Network Key Get
+                This command is used to send the Config Model Network Key Del messages.
 
-		Controller Index:       <controller id>
-		Command parameters:     Network index (2 octets)
-		                        Node address (2 octets)
-		                        Network key index (2 octets)
-		Response parameters: 	Model Netkey Status (1 octet)
+                In case of an error, the error response will be returned.
 
-		This command is used to send the Config Model Network Key Get messages.
+        Opcode 0x27 - Config Model Application Key Add
 
-		In case of an error, the error response will be returned.
+                Controller Index:       <controller id>
+                Command parameters:     Network index (2 octets)
+                                        Node address (2 octets)
+                                        Network key index (2 octets)
+                                        Application key (16 octets)
+                                        Application key index (2 octets)
+                Response parameters:    Model Appkey Status (1 octet)
 
-	Opcode 0x26 - Config Model Network Key Del
+                This command is used to send the Config Model Application Key Add messages.
 
-		Controller Index:       <controller id>
-		Command parameters:     Network index (2 octets)
-		                        Node address (2 octets)
-		                        Network key index (2 octets)
-		Response parameters: 	Model Netkey Status (1 octet)
+                In case of an error, the error response will be returned.
 
-		This command is used to send the Config Model Network Key Del messages.
+        Opcode 0x28 - Config Model Application Key Delete
 
-		In case of an error, the error response will be returned.
+                Controller Index:       <controller id>
+                Command parameters:     Network index (2 octets)
+                                        Node address (2 octets)
+                                        Network key index (2 octets)
+                                        Application key index (2 octets)
+                Response parameters:    Model Appkey Status (1 octet)
 
-	Opcode 0x27 - Config Model Application Key Add
+                This command is used to send the Config Model Application Key Delete messages.
 
-		Controller Index:       <controller id>
-		Command parameters:     Network index (2 octets)
-		                        Node address (2 octets)
-		                        Network key index (2 octets)
-		                        Application key (16 octets)
-		                        Application key index (2 octets)
-		Response parameters: 	Model Appkey Status (1 octet)
+                In case of an error, the error response will be returned.
 
-		This command is used to send the Config Model Application Key Add messages.
+        Opcode 0x29 - Config Model Application Key Get
 
-		In case of an error, the error response will be returned.
+                Controller Index:       <controller id>
+                Command parameters:     Network index (2 octets)
+                                        Node address (2 octets)
+                                        Application key index (2 octets)
+                Response parameters:    Model Appkey Status (1 octet)
 
-	Opcode 0x28 - Config Model Application Key Delete
+                This command is used to send the Config Model Application Key Get messages.
 
-		Controller Index:       <controller id>
-		Command parameters:     Network index (2 octets)
-		                        Node address (2 octets)
-		                        Network key index (2 octets)
-		                        Application key index (2 octets)
-		Response parameters: 	Model Appkey Status (1 octet)
-
-		This command is used to send the Config Model Application Key Delete messages.
-
-		In case of an error, the error response will be returned.
-
-	Opcode 0x29 - Config Model Application Key Get
-
-		Controller Index:       <controller id>
-		Command parameters:     Network index (2 octets)
-		                        Node address (2 octets)
-		                        Application key index (2 octets)
-		Response parameters: 	Model Appkey Status (1 octet)
-
-		This command is used to send the Config Model Application Key Get messages.
-
-		In case of an error, the error response will be returned.
+                In case of an error, the error response will be returned.
 
     Opcode 0x2A - Config Model Application Bind
 
-		Controller Index:       <controller id>
-		Command parameters:     Network index (2 octets)
-		                        Node address (2 octets)
-		                        Element address (2 octets)
-		                        Application key index (2 octets)
-		                        Model ID (2 octets)
-		Response parameters: 	Model Application Bind Status (1 octet)
+                Controller Index:       <controller id>
+                Command parameters:     Network index (2 octets)
+                                        Node address (2 octets)
+                                        Element address (2 octets)
+                                        Application key index (2 octets)
+                                        Model ID (2 octets)
+                Response parameters:    Model Application Bind Status (1 octet)
 
-		This command is used to send the Config Model Application Bind messages.
+                This command is used to send the Config Model Application Bind messages.
 
-		In case of an error, the error response will be returned.
+                In case of an error, the error response will be returned.
 
     Opcode 0x2B - Config Model Application Unbind
 
-		Controller Index:       <controller id>
-		Command parameters:     Network index (2 octets)
-		                        Node address (2 octets)
-		                        Element address (2 octets)
-		                        Application key index (2 octets)
-		                        Model ID (2 octets)
-		Response parameters: 	Model Application Unbind Status (1 octet)
+                Controller Index:       <controller id>
+                Command parameters:     Network index (2 octets)
+                                        Node address (2 octets)
+                                        Element address (2 octets)
+                                        Application key index (2 octets)
+                                        Model ID (2 octets)
+                Response parameters:    Model Application Unbind Status (1 octet)
 
-		This command is used to send the Config Model Application Unbind messages.
+                This command is used to send the Config Model Application Unbind messages.
 
-		In case of an error, the error response will be returned.
+                In case of an error, the error response will be returned.
 
     Opcode 0x2C - Config Model Application Get
 
-		Controller Index:       <controller id>
-		Command parameters:     Network index (2 octets)
-		                        Node address (2 octets)
-		                        Element address (2 octets)
-		                        Application key index (2 octets)
-		                        Model ID (2 octets)
-		Response parameters: 	Model Application Status (1 octet)
+                Controller Index:       <controller id>
+                Command parameters:     Network index (2 octets)
+                                        Node address (2 octets)
+                                        Element address (2 octets)
+                                        Application key index (2 octets)
+                                        Model ID (2 octets)
+                Response parameters:    Model Application Status (1 octet)
 
-		This command is used to send the Config Model Application Get messages.
+                This command is used to send the Config Model Application Get messages.
 
-		In case of an error, the error response will be returned.
+                In case of an error, the error response will be returned.
 
     Opcode 0x2D - Config Model Application Vendor Get
 
-		Controller Index:       <controller id>
-		Command parameters:     Network index (2 octets)
-		                        Node address (2 octets)
-		                        Element address (2 octets)
-		                        Application key index (2 octets)
-		                        Model ID (2 octets)
-		                        CID (2 octets)
-		Response parameters: 	Model Application Status (1 octet)
+                Controller Index:       <controller id>
+                Command parameters:     Network index (2 octets)
+                                        Node address (2 octets)
+                                        Element address (2 octets)
+                                        Application key index (2 octets)
+                                        Model ID (2 octets)
+                                        CID (2 octets)
+                Response parameters:    Model Application Status (1 octet)
 
-		This command is used to send the Config Model Application Vendor Get messages.
+                This command is used to send the Config Model Application Vendor Get messages.
 
-		In case of an error, the error response will be returned.
+                In case of an error, the error response will be returned.
 
     Opcode 0x2E - Config Model Heartbeat Publication Set
 
-		Controller Index:       <controller id>
-		Command parameters:     Network index (2 octets)
-		                        Node address (2 octets)
-		                        Network key index (2 octets)
-		                        Destination address (2 octets)
-		                        Count (1 octet)
-		                        Period (1 octet)
-		                        TTL (1 octet)
-		                        Features (2 octets)
-		Response parameters: 	Model Heartbeat Publication Status (1 octet)
+                Controller Index:       <controller id>
+                Command parameters:     Network index (2 octets)
+                                        Node address (2 octets)
+                                        Network key index (2 octets)
+                                        Destination address (2 octets)
+                                        Count (1 octet)
+                                        Period (1 octet)
+                                        TTL (1 octet)
+                                        Features (2 octets)
+                Response parameters:    Model Heartbeat Publication Status (1 octet)
 
-		This command is used to send the Config Model Heartbeat Publication Set messages.
+                This command is used to send the Config Model Heartbeat Publication Set messages.
 
-		In case of an error, the error response will be returned.
+                In case of an error, the error response will be returned.
 
     Opcode 0x2F - Config Model Heartbeat Publication Get
 
-		Controller Index:       <controller id>
-		Command parameters:     Network index (2 octets)
-		                        Node address (2 octets)
-		Response parameters: 	Model Heartbeat Publication Status (1 octet)
+                Controller Index:       <controller id>
+                Command parameters:     Network index (2 octets)
+                                        Node address (2 octets)
+                Response parameters:    Model Heartbeat Publication Status (1 octet)
 
-		This command is used to send the Config Model Heartbeat Publication Get messages.
+                This command is used to send the Config Model Heartbeat Publication Get messages.
 
-		In case of an error, the error response will be returned.
+                In case of an error, the error response will be returned.
 
     Opcode 0x30 - Config Model Heartbeat Subscription Set
 
-		Controller Index:       <controller id>
-		Command parameters:     Network index (2 octets)
-		                        Node address (2 octets)
-		                        Source (2 octets)
-		                        Destination address (2 octets)
-		                        Period (1 octet)
-		Response parameters: 	Model Heartbeat Subscription Status (1 octet)
+                Controller Index:       <controller id>
+                Command parameters:     Network index (2 octets)
+                                        Node address (2 octets)
+                                        Source (2 octets)
+                                        Destination address (2 octets)
+                                        Period (1 octet)
+                Response parameters:    Model Heartbeat Subscription Status (1 octet)
 
-		This command is used to send the Config Model Heartbeat Subscription Set messages.
+                This command is used to send the Config Model Heartbeat Subscription Set messages.
 
-		In case of an error, the error response will be returned.
+                In case of an error, the error response will be returned.
 
     Opcode 0x31 - Config Model Heartbeat Subscription Get
 
-		Controller Index:       <controller id>
-		Command parameters:     Network index (2 octets)
-		                        Node address (2 octets)
-		Response parameters: 	Model Heartbeat Subscription Status (1 octet)
+                Controller Index:       <controller id>
+                Command parameters:     Network index (2 octets)
+                                        Node address (2 octets)
+                Response parameters:    Model Heartbeat Subscription Status (1 octet)
 
-		This command is used to send the Config Model Heartbeat Subscription Get messages.
+                This command is used to send the Config Model Heartbeat Subscription Get messages.
 
-		In case of an error, the error response will be returned.
+                In case of an error, the error response will be returned.
 
     Opcode 0x32 - Config Model Network Transmit Get
 
-		Controller Index:       <controller id>
-		Command parameters:     Network index (2 octets)
-		                        Node address (2 octets)
-		Response parameters: 	Model Network Transmit Status (1 octet)
+                Controller Index:       <controller id>
+                Command parameters:     Network index (2 octets)
+                                        Node address (2 octets)
+                Response parameters:    Model Network Transmit Status (1 octet)
 
-		This command is used to send the Config Model Network Transmit Get messages.
+                This command is used to send the Config Model Network Transmit Get messages.
 
-		In case of an error, the error response will be returned.
+                In case of an error, the error response will be returned.
 
     Opcode 0x33 - Config Model Network Transmit Set
 
-		Controller Index:       <controller id>
-		Command parameters:     Network index (2 octets)
-		                        Node address (2 octets)
-		                        Transmit (1 octet)
-		Response parameters: 	ModelNetwork Transmit Status (1 octet)
+                Controller Index:       <controller id>
+                Command parameters:     Network index (2 octets)
+                                        Node address (2 octets)
+                                        Transmit (1 octet)
+                Response parameters:    ModelNetwork Transmit Status (1 octet)
 
-		This command is used to send the Config Model Network Transmit Set messages.
+                This command is used to send the Config Model Network Transmit Set messages.
 
-		In case of an error, the error response will be returned.
+                In case of an error, the error response will be returned.
 
     Opcode 0x34 - Config Model Subscription Overwrite
 
-		Controller Index:       <controller id>
-		Command parameters:     Network index (2 octets)
-		                        Node address (2 octets)
-		                        Element address (2 octets)
-		                        Subscription address (2 octets)
-		                        Model ID (2 octets)
-		Response parameters: 	Model Subscription Status (1 octet)
+                Controller Index:       <controller id>
+                Command parameters:     Network index (2 octets)
+                                        Node address (2 octets)
+                                        Element address (2 octets)
+                                        Subscription address (2 octets)
+                                        Model ID (2 octets)
+                Response parameters:    Model Subscription Status (1 octet)
 
-		This command is used to send the Config Model Subscription Overwrite messages.
+                This command is used to send the Config Model Subscription Overwrite messages.
 
-		In case of an error, the error response will be returned.
+                In case of an error, the error response will be returned.
 
-	Opcode 0x35 - Config Model Subscription Delete All
+        Opcode 0x35 - Config Model Subscription Delete All
 
-		Controller Index:       <controller id>
-		Command parameters:     Network index (2 octets)
-		                        Node address (2 octets)
-		                        Element address (2 octets)
-		                        Model ID (2 octets)
-		Response parameters: 	Model Subscription Status (1 octet)
+                Controller Index:       <controller id>
+                Command parameters:     Network index (2 octets)
+                                        Node address (2 octets)
+                                        Element address (2 octets)
+                                        Model ID (2 octets)
+                Response parameters:    Model Subscription Status (1 octet)
 
-		This command is used to send th Config Model Subscription Delete All messages.
+                This command is used to send th Config Model Subscription Delete All messages.
 
-		In case of an error, the error response will be returned.
+                In case of an error, the error response will be returned.
 
-	Opcode 0x36 - Config Model Subscription Get
+        Opcode 0x36 - Config Model Subscription Get
 
-		Controller Index:       <controller id>
-		Command parameters:     Network index (2 octets)
-		                        Node address (2 octets)
-		                        Element address (2 octets)
-		                        Model ID (2 octets)
-		Response parameters: 	Model Subscription Status (1 octet)
+                Controller Index:       <controller id>
+                Command parameters:     Network index (2 octets)
+                                        Node address (2 octets)
+                                        Element address (2 octets)
+                                        Model ID (2 octets)
+                Response parameters:    Model Subscription Status (1 octet)
 
-		This command is used to send the Config Model Subscription Get messages.
+                This command is used to send the Config Model Subscription Get messages.
 
-		In case of an error, the error response will be returned.
+                In case of an error, the error response will be returned.
 
-	Opcode 0x37 - Config Model Subscription Vendor Get
+        Opcode 0x37 - Config Model Subscription Vendor Get
 
-		Controller Index:       <controller id>
-		Command parameters:     Network index (2 octets)
-		                        Node address (2 octets)
-		                        Element address (2 octets)
-		                        Model ID (2 octets)
-		                        CID (2 octets)
-		Response parameters: 	Model Subscription Status (1 octet)
+                Controller Index:       <controller id>
+                Command parameters:     Network index (2 octets)
+                                        Node address (2 octets)
+                                        Element address (2 octets)
+                                        Model ID (2 octets)
+                                        CID (2 octets)
+                Response parameters:    Model Subscription Status (1 octet)
 
-		This command is used to send the Config Model Subscription Vendor Get messages.
+                This command is used to send the Config Model Subscription Vendor Get messages.
 
-		In case of an error, the error response will be returned.
+                In case of an error, the error response will be returned.
 
-	Opcode 0x38 - Config Model Subscription Virtual Address Add
+        Opcode 0x38 - Config Model Subscription Virtual Address Add
 
-		Controller Index:       <controller id>
-		Command parameters:     Network index (2 octets)
-		                        Node address (2 octets)
-		                        Element address (2 octets)
-		                        Model ID (2 octets)
-		                        Virtual address (16 octets)
-		Response parameters: 	Model Subscription Status (1 octet)
+                Controller Index:       <controller id>
+                Command parameters:     Network index (2 octets)
+                                        Node address (2 octets)
+                                        Element address (2 octets)
+                                        Model ID (2 octets)
+                                        Virtual address (16 octets)
+                Response parameters:    Model Subscription Status (1 octet)
 
-		This command is used to send the Config Model Subscription Virtual Address Add messages.
+                This command is used to send the Config Model Subscription Virtual Address Add messages.
 
-		In case of an error, the error response will be returned.
+                In case of an error, the error response will be returned.
 
-	Opcode 0x39 - Config Model Subscription Virtual Address Delete
+        Opcode 0x39 - Config Model Subscription Virtual Address Delete
 
-		Controller Index:       <controller id>
-		Command parameters:     Network index (2 octets)
-		                        Node address (2 octets)
-		                        Element address (2 octets)
-		                        Model ID (2 octets)
-		                        Virtual address (16 octets)
-		Response parameters: 	Model Subscription Status (1 octet)
+                Controller Index:       <controller id>
+                Command parameters:     Network index (2 octets)
+                                        Node address (2 octets)
+                                        Element address (2 octets)
+                                        Model ID (2 octets)
+                                        Virtual address (16 octets)
+                Response parameters:    Model Subscription Status (1 octet)
 
-		This command is used to send the Config Model Subscription Virtual Address Delete messages.
+                This command is used to send the Config Model Subscription Virtual Address Delete messages.
 
-		In case of an error, the error response will be returned.
+                In case of an error, the error response will be returned.
 
-	Opcode 0x3A - Config Model Subscription Virtual Address Overwrite
+        Opcode 0x3A - Config Model Subscription Virtual Address Overwrite
 
-		Controller Index:       <controller id>
-		Command parameters:     Network index (2 octets)
-		                        Node address (2 octets)
-		                        Element address (2 octets)
-		                        Model ID (2 octets)
-		                        Virtual address (16 octets)
-		Response parameters: 	Model Subscription Status (1 octet)
+                Controller Index:       <controller id>
+                Command parameters:     Network index (2 octets)
+                                        Node address (2 octets)
+                                        Element address (2 octets)
+                                        Model ID (2 octets)
+                                        Virtual address (16 octets)
+                Response parameters:    Model Subscription Status (1 octet)
 
-		This command is used to send the Config Model Subscription Virtual Address Overwrite messages.
+                This command is used to send the Config Model Subscription Virtual Address Overwrite messages.
 
-		In case of an error, the error response will be returned.
+                In case of an error, the error response will be returned.
 
-	Opcode 0x3B - Config Model Network Key Update
+        Opcode 0x3B - Config Model Network Key Update
 
-		Controller Index:       <controller id>
-		Command parameters:     Network index (2 octets)
-		                        Node address (2 octets)
-		                        Network key (16 octets)
-		                        Network key index (2 octets)
-		Response parameters: 	Model Netkey Status (1 octet)
+                Controller Index:       <controller id>
+                Command parameters:     Network index (2 octets)
+                                        Node address (2 octets)
+                                        Network key (16 octets)
+                                        Network key index (2 octets)
+                Response parameters:    Model Netkey Status (1 octet)
 
-		This command is used to send the Config Model Network Key Update messages.
+                This command is used to send the Config Model Network Key Update messages.
 
-		In case of an error, the error response will be returned.
+                In case of an error, the error response will be returned.
 
-	Opcode 0x3C - Config Model Application Key Update
+        Opcode 0x3C - Config Model Application Key Update
 
-		Controller Index:       <controller id>
-		Command parameters:     Network index (2 octets)
-		                        Node address (2 octets)
-		                        Network key index (2 octets)
-		                        Appkey key (16 octets)
-		                        Application key index (2 octets)
-		Response parameters: 	Model Appkey Status (1 octet)
+                Controller Index:       <controller id>
+                Command parameters:     Network index (2 octets)
+                                        Node address (2 octets)
+                                        Network key index (2 octets)
+                                        Appkey key (16 octets)
+                                        Application key index (2 octets)
+                Response parameters:    Model Appkey Status (1 octet)
 
-		This command is used to send the Config Model Application Key Update messages.
+                This command is used to send the Config Model Application Key Update messages.
 
-		In case of an error, the error response will be returned.
+                In case of an error, the error response will be returned.
 
-	Opcode 0x3D - Config Model Node Identity Set
+        Opcode 0x3D - Config Model Node Identity Set
 
-		Controller Index:       <controller id>
-		Command parameters:     Network index (2 octets)
-		                        Node address (2 octets)
-		                        Network key index (2 octets)
-		                        Identity (1 octet)
-		Response parameters: 	Model Node Identity Status (1 octet)
+                Controller Index:       <controller id>
+                Command parameters:     Network index (2 octets)
+                                        Node address (2 octets)
+                                        Network key index (2 octets)
+                                        Identity (1 octet)
+                Response parameters:    Model Node Identity Status (1 octet)
 
-		This command is used to send the Config Model Node Identity Set messages.
+                This command is used to send the Config Model Node Identity Set messages.
 
-		In case of an error, the error response will be returned.
+                In case of an error, the error response will be returned.
 
-	Opcode 0x3E - Config Model Node Identity Get
+        Opcode 0x3E - Config Model Node Identity Get
 
-		Controller Index:       <controller id>
-		Command parameters:     Network index (2 octets)
-		                        Node address (2 octets)
-		                        Network key index (2 octets)
-		Response parameters: 	Model Node Identity Status (1 octet)
+                Controller Index:       <controller id>
+                Command parameters:     Network index (2 octets)
+                                        Node address (2 octets)
+                                        Network key index (2 octets)
+                Response parameters:    Model Node Identity Status (1 octet)
 
-		This command is used to send the Config Model Node Identity Get messages.
+                This command is used to send the Config Model Node Identity Get messages.
 
-		In case of an error, the error response will be returned.
+                In case of an error, the error response will be returned.
 
-	Opcode 0x3F - Config Model Node Identity Reset
+        Opcode 0x3F - Config Model Node Identity Reset
 
-		Controller Index:       <controller id>
-		Command parameters:     Network index (2 octets)
-		                        Node address (2 octets)
-		Response parameters: 	Model Node Identity Status (1 octet)
+                Controller Index:       <controller id>
+                Command parameters:     Network index (2 octets)
+                                        Node address (2 octets)
+                Response parameters:    Model Node Identity Status (1 octet)
 
-		This command is used to send the Config Model Node Identity Reset messages.
+                This command is used to send the Config Model Node Identity Reset messages.
 
-		In case of an error, the error response will be returned.
+                In case of an error, the error response will be returned.
 
-	Opcode 0x40 - Config Model LPN Polltimeout Get
+        Opcode 0x40 - Config Model LPN Polltimeout Get
 
-		Controller Index:       <controller id>
-		Command parameters:     Network index (2 octets)
-		                        Node address (2 octets)
-		                        Unicast Address (2 octets)
-		Response parameters: 	Model Node Identity Status (1 octet)
+                Controller Index:       <controller id>
+                Command parameters:     Network index (2 octets)
+                                        Node address (2 octets)
+                                        Unicast Address (2 octets)
+                Response parameters:    Model Node Identity Status (1 octet)
 
-		This command is used to send the Config Model LPN Polltimeout Get messages.
+                This command is used to send the Config Model LPN Polltimeout Get messages.
 
-		In case of an error, the error response will be returned.
+                In case of an error, the error response will be returned.
 
     Opcode 0x41 - Config Model Publication Virtual Address Set
 
-		Controller Index:       <controller id>
-		Command parameters:     Network index (2 octets)
-		                        Node address (2 octets)
-		                        Element address (2 octets)
-		                        Model ID (2 octets)
-		                        Virtual address (16 octets)
-		                        Application key index (2 octets)
-		                        Credential flag (1 octet)
-		                        TTL (1 octet)
-		                        Period (1 octet)
-		                        Transmit (1 octet)
-		Response parameters: 	Model Publication Status (1 octet)
+                Controller Index:       <controller id>
+                Command parameters:     Network index (2 octets)
+                                        Node address (2 octets)
+                                        Element address (2 octets)
+                                        Model ID (2 octets)
+                                        Virtual address (16 octets)
+                                        Application key index (2 octets)
+                                        Credential flag (1 octet)
+                                        TTL (1 octet)
+                                        Period (1 octet)
+                                        Transmit (1 octet)
+                Response parameters:    Model Publication Status (1 octet)
 
-		This command is used to send the Config Model Publication Virtual Address Set messages.
+                This command is used to send the Config Model Publication Virtual Address Set messages.
 
-		In case of an error, the error response will be returned.
+                In case of an error, the error response will be returned.
 
     Opcode 0x42 - Config Model Application Vendor Bind
 
-		Controller Index:       <controller id>
-		Command parameters:     Network index (2 octets)
-		                        Node address (2 octets)
-		                        Element address (2 octets)
-		                        Application key index (2 octets)
-		                        Model ID (2 octets)
-		                        CID (2 octets)
-		Response parameters: 	Model Application Bind Status (1 octet)
+                Controller Index:       <controller id>
+                Command parameters:     Network index (2 octets)
+                                        Node address (2 octets)
+                                        Element address (2 octets)
+                                        Application key index (2 octets)
+                                        Model ID (2 octets)
+                                        CID (2 octets)
+                Response parameters:    Model Application Bind Status (1 octet)
 
-		This command is used to send the Config Model Application Vendor Bind messages.
+                This command is used to send the Config Model Application Vendor Bind messages.
 
-		In case of an error, the error response will be returned.
+                In case of an error, the error response will be returned.
 
     Opcode 0x43 - Health Fault Get
 
-		Controller Index:       <controller id>
-		Command parameters:     Node address (2 octets)
-		                        Application index (2 octets)
-		                        CID (2 octets)
+                Controller Index:       <controller id>
+                Command parameters:     Node address (2 octets)
+                                        Application index (2 octets)
+                                        CID (2 octets)
+                Response parameters:    <none>
 
-		This command is used to send the Health Fault Get messages.
+                This command is used to send the Health Fault Get messages.
 
-		In case of an error, the error response will be returned.
+                In case of an error, the error response will be returned.
 
     Opcode 0x44 - Health Fault Clear
 
-		Controller Index:       <controller id>
-		Command parameters:     Node address (2 octets)
-		                        Application index (2 octets)
-		                        CID (2 octets)
-		                        Acknowledgement (1 octet)
-		Response parameters: 	Health Fault Clear Status (1 octet)
+                Controller Index:       <controller id>
+                Command parameters:     Node address (2 octets)
+                                        Application index (2 octets)
+                                        CID (2 octets)
+                                        Acknowledgement (1 octet)
+                Response parameters:    Health Fault Clear Status (1 octet)
 
-		This command is used to send the Health Fault Clear messages.
+                This command is used to send the Health Fault Clear messages.
 
-		In case of an error, the error response will be returned.
+                In case of an error, the error response will be returned.
 
     Opcode 0x45 - Health Fault Test
 
-		Controller Index:       <controller id>
-		Command parameters:     Node address (2 octets)
-		                        Application index (2 octets)
-		                        CID (2 octets)
-		                        Test ID (1 octet)
-		                        Acknowledgement (1 octet)
-		Response parameters: 	Health Fault Test Status (1 octet)
+                Controller Index:       <controller id>
+                Command parameters:     Node address (2 octets)
+                                        Application index (2 octets)
+                                        CID (2 octets)
+                                        Test ID (1 octet)
+                                        Acknowledgement (1 octet)
+                Response parameters:    Health Fault Test Status (1 octet)
 
-		This command is used to send the Health Fault Test messages.
+                This command is used to send the Health Fault Test messages.
 
-		In case of an error, the error response will be returned.
+                In case of an error, the error response will be returned.
 
     Opcode 0x46 - Health Period Get
 
-		Controller Index:       <controller id>
-		Command parameters:     Node address (2 octets)
-		                        Application index (2 octets)
-		Response parameters: 	Health Period Get Status (1 octet)
+                Controller Index:       <controller id>
+                Command parameters:     Node address (2 octets)
+                                        Application index (2 octets)
+                Response parameters:    Health Period Get Status (1 octet)
 
-		This command is used to send the Health Period Get messages.
+                This command is used to send the Health Period Get messages.
 
-		In case of an error, the error response will be returned.
+                In case of an error, the error response will be returned.
 
     Opcode 0x47 - Health Period Set
 
-		Controller Index:       <controller id>
-		Command parameters:     Node address (2 octets)
-		                        Application index (2 octets)
-		                        Divisor (1 octet)
-		                        Acknowledgement (1 octet)
-		Response parameters: 	Health Period Set Status (1 octet)
+                Controller Index:       <controller id>
+                Command parameters:     Node address (2 octets)
+                                        Application index (2 octets)
+                                        Divisor (1 octet)
+                                        Acknowledgement (1 octet)
+                Response parameters:    Health Period Set Status (1 octet)
 
-		This command is used to send the Health Period Set messages.
+                This command is used to send the Health Period Set messages.
 
-		In case of an error, the error response will be returned.
+                In case of an error, the error response will be returned.
 
     Opcode 0x48 - Health Attention Get
 
-		Controller Index:       <controller id>
-		Command parameters:     Node address (2 octets)
-		                        Application index (2 octets)
-		Response parameters: 	Health Attention Get Status (1 octet)
+                Controller Index:       <controller id>
+                Command parameters:     Node address (2 octets)
+                                        Application index (2 octets)
+                Response parameters:    Health Attention Get Status (1 octet)
 
-		This command is used to send the Health Attention Get messages.
+                This command is used to send the Health Attention Get messages.
 
-		In case of an error, the error response will be returned.
+                In case of an error, the error response will be returned.
 
     Opcode 0x49 - Health Attention Set
 
-		Controller Index:       <controller id>
-		Command parameters:     Node address (2 octets)
-		                        Application index (2 octets)
-		                        Attention (1 octet)
-		                        Acknowledgement (1 octet)
-		Response parameters: 	Health Attention Set Status (1 octet)
+                Controller Index:       <controller id>
+                Command parameters:     Node address (2 octets)
+                                        Application index (2 octets)
+                                        Attention (1 octet)
+                                        Acknowledgement (1 octet)
+                Response parameters:    Health Attention Set Status (1 octet)
 
-		This command is used to send the Health Attention Set messages.
+                This command is used to send the Health Attention Set messages.
 
-		In case of an error, the error response will be returned.
+                In case of an error, the error response will be returned.
 
     Opcode 0x4A - Provision Advertising
 
-		Controller Index:       <controller id>
-		Command parameters:     UUID (16 octets)
-		                        Network key index (2 octets)
-		                        Node address (2 octets)
-		                        Attention duration(1 octet)
-		                        Network key (16 octets)
+                Controller Index:       <controller id>
+                Command parameters:     UUID (16 octets)
+                                        Network key index (2 octets)
+                                        Node address (2 octets)
+                                        Attention duration(1 octet)
+                                        Network key (16 octets)
 
-		This command is used to start the provision advertising.
+                This command is used to start the provision advertising.
 
-		In case of an error, the error response will be returned.
+                In case of an error, the error response will be returned.
 
     Opcode 0x4B - Config Key Refesh Phase Get
 
-		Controller Index:       <controller id>
-		Command parameters:     Network index (2 octets)
-		                        Node address (2 octets)
-		                        Network key index (2 octets)
-		Response parameters: 	Key Refesh Get Status (1 octet)
-		                        Phase (1 octets)
+                Controller Index:       <controller id>
+                Command parameters:     Network index (2 octets)
+                                        Node address (2 octets)
+                                        Network key index (2 octets)
+                Response parameters:    Key Refesh Get Status (1 octet)
+                                        Phase (1 octets)
 
-		This command is used to send the Key Refesh Phase Get messages.
+                This command is used to send the Key Refesh Phase Get messages.
 
-		In case of an error, the error response will be returned.
+                In case of an error, the error response will be returned.
 
     Opcode 0x4C - Key Refesh Phase Set
 
-		Controller Index:       <controller id>
-		Command parameters:     Network index (2 octets)
-		                        Node address (2 octets)
-		                        Network key index (2 octets)
-		                        Phase (1 octet)
-		Response parameters: 	Key Refesh Phase Set Status (1 octet)
-		                        Phase (1 octets)
+                Controller Index:       <controller id>
+                Command parameters:     Network index (2 octets)
+                                        Node address (2 octets)
+                                        Network key index (2 octets)
+                                        Phase (1 octet)
+                Response parameters:    Key Refesh Phase Set Status (1 octet)
+                                        Phase (1 octets)
 
-		This command is used to send the Key Refesh Phase Set messages.
+                This command is used to send the Key Refesh Phase Set messages.
 
-		In case of an error, the error response will be returned.
+                In case of an error, the error response will be returned.
 
     Opcode 0x4D - Virtual Address Add
 
-		Controller Index:       <controller id>
-		Command parameters:     Label UUID (16 octets)
+                Controller Index:       <controller id>
+                Command parameters:     Label UUID (16 octets)
+                Response parameters:    <none>
 
-		This command is used to add a Label UUID to the stack. If
-		the Label UUID is already added, the reference will be
-		incremented.
+                This command is used to add a Label UUID to the stack. If
+                the Label UUID is already added, the reference will be
+                incremented.
 
-		In case of an error, the error response will be returned.
+                In case of an error, the error response will be returned.
 
     Opcode 0x4E - Virtual Address Delete
 
-		Controller Index:       <controller id>
-		Command parameters:     Label UUID (16 octets)
+                Controller Index:       <controller id>
+                Command parameters:     Label UUID (16 octets)
+                Response parameters:    <none>
 
-		This command is used to delete a Label UUID from the stack.
-		If the Label UUID was added before, the reference will be
-		decremented.
+                This command is used to delete a Label UUID from the stack.
+                If the Label UUID was added before, the reference will be
+                decremented.
 
-		In case of an error, the error response will be returned.
+                In case of an error, the error response will be returned.
 
-	Opcode 0x4F - SAR Transmitter Get
+        Opcode 0x4F - SAR Transmitter Get
 
-		Controller Index:		<controller id>
-		Command parameters:		Node address (2 octets)
+                Controller Index:       <controller id>
+                Command parameters:     Node address (2 octets)
+                Response parameters:    <none>
 
-		This command is used to get the current SAR Transmitter state of a node.
+                This command is used to get the current SAR Transmitter state of a node.
 
-	Opcode 0x50 - SAR Transmitter Set
+        Opcode 0x50 - SAR Transmitter Set
 
-		Controller Index:		<controller id>
-		Command parameters:		Node address (2 octets)
-								Segment interval step (1 octet)
-								Unicast re.trans. count (1 octet)
-								Unicast re.trans. count without progress count (1 octet)
-								Unicast re.trans. interval step (1 octet)
-								Unicast re.trans. interval increment (1 octet)
-								Multicast re.trans. count (1 octet)
-								Multicast re.trans. interval step (1 octet)
+                Controller Index:       <controller id>
+                Command parameters:     Node address (2 octets)
+                                        Segment interval step (1 octet)
+                                        Unicast re.trans. count (1 octet)
+                                        Unicast re.trans. count without progress count (1 octet)
+                                        Unicast re.trans. interval step (1 octet)
+                                        Unicast re.trans. interval increment (1 octet)
+                                        Multicast re.trans. count (1 octet)
+                                        Multicast re.trans. interval step (1 octet)
+                Response parameters:    <none>
 
-		This command is used to set SAR Transmitter state of a node.
+                This command is used to set SAR Transmitter state of a node.
 
-	Opcode 0x51 - SAR Receiver Get
+        Opcode 0x51 - SAR Receiver Get
 
-		Controller Index:		<controller id>
-		Command parameters:		Node address (2 octets)
+                Controller Index:       <controller id>
+                Command parameters:     Node address (2 octets)
+                Response parameters:    <none>
 
-		This command is used to get the current SAR Receiver state of a node.
+                This command is used to get the current SAR Receiver state of a node.
 
-	Opcode 0x52 - SAR Receiver Set
+        Opcode 0x52 - SAR Receiver Set
 
-		Controller Index:		<controller id>
-		Command parameters:		Node address (2 octets)
-								Segments threshold (1 octet)
-								Acked. delay increment (1 octet)
-								Acked re.trans. count (1 octet)
-								Discard timeout (1 octet)
-								Receiver segment interval step (1 octet)
+                Controller Index:       <controller id>
+                Command parameters:     Node address (2 octets)
+                                        Segments threshold (1 octet)
+                                        Acked. delay increment (1 octet)
+                                        Acked re.trans. count (1 octet)
+                                        Discard timeout (1 octet)
+                                        Receiver segment interval step (1 octet)
+                Response parameters:    <none>
 
-		This command is used to set the SAR Receiver state of a node.
+                This command is used to set the SAR Receiver state of a node.
 
-	Opcode 0x53 - Large Composition Data Get
+        Opcode 0x53 - Large Composition Data Get
 
-		Controller Index:		<controller id>
-		Command parameters:		Network index (2 octets)
-		                        Node address (2 octets)
-								Page (1 octet)
-								Offset (2 octet)
+                Controller Index:       <controller id>
+                Command parameters:     Network index (2 octets)
+                                        Node address (2 octets)
+                                        Page (1 octet)
+                                        Offset (2 octet)
+                Response parameters:    <none>
 
-		This command is used to read a portion of a page of the Composition Data.
+                This command is used to read a portion of a page of the Composition Data.
 
-	Opcode 0x54 - Models Metadata Get
+        Opcode 0x54 - Models Metadata Get
 
-		Controller Index:		<controller id>
-		Command parameters:		Network index (2 octets)
-		                        Node address (2 octets)
-								Page (1 octet)
-								Offset (2 octet)
+                Controller Index:       <controller id>
+                Command parameters:     Network index (2 octets)
+                                        Node address (2 octets)
+                                        Page (1 octet)
+                                        Offset (2 octet)
+                Response parameters:    <none>
 
-		This command is used to read a portion of a page of the Models Metadata state
+                This command is used to read a portion of a page of the Models Metadata state
 
-	Opcode 0x55 - Opcodes Aggregator Init
+        Opcode 0x55 - Opcodes Aggregator Init
 
-		Controller Index:		<controller id>
-		Command parameters:		Network index (2 octets)
-		                        App index (2 octets)
-								Node address (2 octet)
-								Element address (2 octet)
+                Controller Index:       <controller id>
+                Command parameters:     Network index (2 octets)
+                                        App index (2 octets)
+                                        Node address (2 octet)
+                                        Element address (2 octet)
+                Response parameters:    <none>
 
-		This command is used to initialise Opcodes aggregator client context.
+                This command is used to initialise Opcodes aggregator client context.
 
-	Opcode 0x56 - Opcodes Aggregator Send
+        Opcode 0x56 - Opcodes Aggregator Send
 
-		Controller Index:		<controller id>
+                Controller Index:       <controller id>
+                Command parameters:     <none>
+                Response parameters:    <none>
 
-		This command is used to send previously configured context and sends aggregated
-		message to target node.
+                This command is used to send previously configured context and sends aggregated
+                message to target node.
 
     Opcode 0x57 - Composition Change Prepare
 
-		Controller Index:       <controller id>
-		Command parameters:     <none>
+                Controller Index:       <controller id>
+                Command parameters:     <none>
+                Response parameters:    <none>
 
-		This command is used to prepare device for composition change. Success
-		means that device saved old composition data in persistant storage and
-		will swap it on next reboot.
+                This command is used to prepare device for composition change. Success
+                means that device saved old composition data in persistant storage and
+                will swap it on next reboot.
 
     Opcode 0x58 - Set Alternative Composition Data
 
-		Controller Index:       <controller id>
-		Command parameters:     <none>
+                Controller Index:       <controller id>
+                Command parameters:     <none>
+                Response parameters:    <none>
 
-		This command is used to tell the device which composition data to set
-		on Mesh init, if alternative exists. Calling this means we expect device
-		to have 1 alternative composition data, and this data must differ from
-		default one.
+                This command is used to tell the device which composition data to set
+                on Mesh init, if alternative exists. Calling this means we expect device
+                to have 1 alternative composition data, and this data must differ from
+                default one.
 
     Opcode 0x59 - Remote Provisioning Scan Start
 
-		Controller Index:       <controller id>
-		Command parameters:     Destination (2 octets)
-		                        Timeout (1 octets)
-		                        UUID (16 octets)
+                Controller Index:       <controller id>
+                Command parameters:     Destination (2 octets)
+                                        Timeout (1 octets)
+                                        UUID (16 octets)
+                Response parameters:    <none>
 
-		This command is used to tell device to tell the server to start scanning
-		for unprovisioned devices.
+                This command is used to tell device to tell the server to start scanning
+                for unprovisioned devices.
 
     Opcode 0x5a - Remote Provisioning Extended Scan Start
 
-		Controller Index:       <controller id>
-		Command parameters:     Destination (2 octets)
-		                        Timeout (1 octets)
-		                        UUID (16 octets)
-		                        Ad Type Count (1 octets)
-		                        Ad Types (variable)
+                Controller Index:       <controller id>
+                Command parameters:     Destination (2 octets)
+                                        Timeout (1 octets)
+                                        UUID (16 octets)
+                                        Ad Type Count (1 octets)
+                                        Ad Types (variable)
+                Response parameters:    <none>
 
-		This command is used to tell device to tell the server to start scanning
-		for unprovisioned devices and gather additional data of given Ad Types.
+                This command is used to tell device to tell the server to start scanning
+                for unprovisioned devices and gather additional data of given Ad Types.
 
     Opcode 0x5b - Remote Provisioning Scan Capabilities Get
 
-		Controller Index:       <controller id>
-		Command parameters:     Destination (2 octets)
+                Controller Index:       <controller id>
+                Command parameters:     Destination (2 octets)
+                Response parameters:    <none>
 
-		This command is used to get scanning capabilities of Remote Provisioning
-		Server, by Client.
+                This command is used to get scanning capabilities of Remote Provisioning
+                Server, by Client.
 
     Opcode 0x5c - Remote Provisioning Scan Get
 
-		Controller Index:       <controller id>
-		Command parameters:     Destination (2 octets)
+                Controller Index:       <controller id>
+                Command parameters:     Destination (2 octets)
+                Response parameters:    <none>
 
-		This command is used to get current scanning state of Remote
-		Provisioning Server, by Client.
+                This command is used to get current scanning state of Remote
+                Provisioning Server, by Client.
 
     Opcode 0x5d - Remote Provisioning Scan Stop
 
-		Controller Index:       <controller id>
-		Command parameters:     Destination (2 octets)
+                Controller Index:       <controller id>
+                Command parameters:     Destination (2 octets)
+                Response parameters:    <none>
 
-
-		This command is used to stop any ongoing scanning on Remote Provisioning
-		Server, by Client.
+                This command is used to stop any ongoing scanning on Remote Provisioning
+                Server, by Client.
 
     Opcode 0x5e - Remote Provisioning Link Get
 
-		Controller Index:       <controller id>
-		Command parameters:     Destination (2 octets)
+                Controller Index:       <controller id>
+                Command parameters:     Destination (2 octets)
+                Response parameters:    <none>
 
-		This command is used to get current link status of Remote Provisioning
-		Server, by Client.
+                This command is used to get current link status of Remote Provisioning
+                Server, by Client.
 
     Opcode 0x5f - Remote Provisioning Link Close
 
-		Controller Index:       <controller id>
-		Command parameters:     Destination (2 octets)
+                Controller Index:       <controller id>
+                Command parameters:     Destination (2 octets)
+                Response parameters:    <none>
 
-		This command is used to close any opened link of Remote Provisioning
-		Server, by Client.
+                This command is used to close any opened link of Remote Provisioning
+                Server, by Client.
 
     Opcode 0x60 - Remote Provisioning Provision Remote
 
-		Controller Index:       <controller id>
-		Command parameters:     Destination (2 octets)
-		                        UUID (16 octets)
-		                        Network Index (2 octets)
-		                        Address (2 octets)
+                Controller Index:       <controller id>
+                Command parameters:     Destination (2 octets)
+                                        UUID (16 octets)
+                                        Network Index (2 octets)
+                                        Address (2 octets)
+                Response parameters:    <none>
 
-		This command is used to provision a Mesh Node using a PB-Remote
+                This command is used to provision a Mesh Node using a PB-Remote
 
     Opcode 0x61 - Remote Provisioning Reprovision Remote
 
-		Controller Index:       <controller id>
-		Command parameters:     Destination (2 octets)
-		                        Address (2 octets)
+                Controller Index:       <controller id>
+                Command parameters:     Destination (2 octets)
+                                        Address (2 octets)
+                Response parameters:    <none>
 
-		This command can be used to change the device key,
-		unicast address and composition data of another device.
+                This command can be used to change the device key,
+                unicast address and composition data of another device.
 
-	Opcode 0x62 - Subnet Bridge Get
+        Opcode 0x62 - Subnet Bridge Get
 
-		Controller Index:       <controller id>
-		Command parameters:     Destination (2 octet)
+                Controller Index:       <controller id>
+                Command parameters:     Destination (2 octet)
+                Response parameters:    <none>
 
-		This command is used to get the current Subnet Bridge state of a node.
+                This command is used to get the current Subnet Bridge state of a node.
 
-	Opcode 0x63 - Subnet Bridge Set
+        Opcode 0x63 - Subnet Bridge Set
 
-		Controller Index:       <controller id>
-		Command parameters:     Destination (2 octet)
-					State (1 octet)
+                Controller Index:       <controller id>
+                Command parameters:     Destination (2 octet)
+                                        State (1 octet)
+                Response parameters:    <none>
 
-		This command is used  to set the Subnet Bridge state of a node.
+                This command is used  to set the Subnet Bridge state of a node.
 
-	Opcode 0x64 - Bridging Table Add
+        Opcode 0x64 - Bridging Table Add
 
-		Controller Index:       <controller id>
-		Command parameters:     Destination (2 octet)
-					Direction (1 octet)
-					Network Index 1 (2 octet)
-					Network Index 2 (2 octet)
-					Address 1 (2 octet)
-					Address 2 (2 octet)
+                Controller Index:       <controller id>
+                Command parameters:     Destination (2 octet)
+                                        Direction (1 octet)
+                                        Network Index 1 (2 octet)
+                                        Network Index 2 (2 octet)
+                                        Address 1 (2 octet)
+                                        Address 2 (2 octet)
+                Response parameters:    <none>
 
-		This command is used to add an entry in the Bridging table of a node.
+                This command is used to add an entry in the Bridging table of a node.
 
-	Opcode 0x65 - Bridging Table Remove
+        Opcode 0x65 - Bridging Table Remove
 
-		Controller Index:       <controller id>
-		Command parameters:     Destination (2 octet)
-					Network Index 1 (2 octet)
-					Network Index 2 (2 octet)
-					Address 1 (2 octet)
-					Address 2 (2 octet)
+                Controller Index:       <controller id>
+                Command parameters:     Destination (2 octet)
+                                        Network Index 1 (2 octet)
+                                        Network Index 2 (2 octet)
+                                        Address 1 (2 octet)
+                                        Address 2 (2 octet)
+                Response parameters:    <none>
 
-		This command is used remove an entry in the Bridging table of a node.
+                This command is used remove an entry in the Bridging table of a node.
 
-	Opcode 0x66 - Bridged Subnets Get
+        Opcode 0x66 - Bridged Subnets Get
 
-		Controller Index:       <controller id>
-		Command parameters:     Destination (2 octet)
-					Filter (1 octet)
-					Network Index (2 octet)
-					Start Index (1 octet)
+                Controller Index:       <controller id>
+                Command parameters:     Destination (2 octet)
+                                        Filter (1 octet)
+                                        Network Index (2 octet)
+                                        Start Index (1 octet)
+                Response parameters:    <none>
 
-		This command is used to get the current Bridged subnets list of a node.
+                This command is used to get the current Bridged subnets list of a node.
 
-	Opcode 0x67 - Bridging Table Get
+        Opcode 0x67 - Bridging Table Get
 
-		Controller Index:       <controller id>
-		Command parameters:     Destination (2 octet)
-					Network Index 1 (2 octet)
-					Network Index 2 (2 octet)
-					Start Index (2 octet)
+                Controller Index:       <controller id>
+                Command parameters:     Destination (2 octet)
+                                        Network Index 1 (2 octet)
+                                        Network Index 2 (2 octet)
+                                        Start Index (2 octet)
+                Response parameters:    <none>
 
-		This command is used to get the current Bridging table list of a node.
+                This command is used to get the current Bridging table list of a node.
 
-	Opcode 0x68 - Bridge Capability Get
+        Opcode 0x68 - Bridge Capability Get
 
-		Controller Index:       <controller id>
-		Command parameters:     Destination (2 octet)
+                Controller Index:       <controller id>
+                Command parameters:     Destination (2 octet)
+                Response parameters:    <none>
 
-		This command is used to get the current Bridge table size of a node.
+                This command is used to get the current Bridge table size of a node.
 
-	Opcode 0x6C - Private Beacon Get
+        Opcode 0x6C - Private Beacon Get
 
-		Controller Index:       <controller id>
-		Command parameters:     Destination (2 octet)
+                Controller Index:       <controller id>
+                Command parameters:     Destination (2 octet)
+                Response parameters:    <none>
 
-		This command is used to get the current Private Beacon state and
-		Random Update Interval Steps state of a node.
+                This command is used to get the current Private Beacon state and
+                Random Update Interval Steps state of a node.
 
-	Opcode 0x6D - Private Beacon Set
+        Opcode 0x6D - Private Beacon Set
 
-		Controller Index:       <controller id>
-		Command parameters:     Destination (2 octet)
-								Enabled (1 octet)
-								Random interval (1 octet)
+                Controller Index:       <controller id>
+                Command parameters:     Destination (2 octet)
+                                        Enabled (1 octet)
+                                        Random interval (1 octet)
+                Response parameters:    <none>
 
-		This command is used  to set the Private Beacon state and the Random
-		Update Interval Steps state of a node.
+                This command is used  to set the Private Beacon state and the Random
+                Update Interval Steps state of a node.
 
-	Opcode 0x6E - Private GATT Proxy Get
+        Opcode 0x6E - Private GATT Proxy Get
 
-		Controller Index:       <controller id>
-		Command parameters:     Destination (2 octet)
+                Controller Index:       <controller id>
+                Command parameters:     Destination (2 octet)
 
-		This command is used to get the current Private GATT Proxy state of a node.
+                This command is used to get the current Private GATT Proxy state of a node.
 
-	Opcode 0x6F - Private GATT Proxy Set
+        Opcode 0x6F - Private GATT Proxy Set
 
-		Controller Index:       <controller id>
-		Command parameters:     Destination (2 octet)
-								State (1 octet)
+                Controller Index:       <controller id>
+                Command parameters:     Destination (2 octet)
+                                        State (1 octet)
+                Response parameters:    <none>
 
-		This command is used to set the Private GATT Proxy state of a node.
+                This command is used to set the Private GATT Proxy state of a node.
 
-	Opcode 0x70 - Private Node Identity Get
+        Opcode 0x70 - Private Node Identity Get
 
-		Controller Index:       <controller id>
-		Command parameters:     Destination (2 octet)
-								NetKey idx (2 octet)
+                Controller Index:       <controller id>
+                Command parameters:     Destination (2 octet)
+                                        NetKey idx (2 octet)
+                Response parameters:    <none>
 
-		This command is used to get the current Private Node Identity state for a subnet.
+                This command is used to get the current Private Node Identity state for a subnet.
 
-	Opcode 0x71 - Private Node Identity Set
+        Opcode 0x71 - Private Node Identity Set
 
-		Controller Index:       <controller id>
-		Command parameters:     Destination (2 octet)
-								NetKey idx (2 octet)
-								State (1 octet)
+                Controller Index:       <controller id>
+                Command parameters:     Destination (2 octet)
+                                        NetKey idx (2 octet)
+                                        State (1 octet)
+                Response parameters:    <none>
 
-		This command is used to set the current Private Node Identity state for a subnet.
+                This command is used to set the current Private Node Identity state for a subnet.
 
-	Opcode 0x72 - IUT Proxy Private Identity Enable
+        Opcode 0x72 - IUT Proxy Private Identity Enable
 
-		Controller Index:       <controller id>
+                Controller Index:       <controller id>
+                Command parameters:    <none>
+                Response parameters:    <none>
 
-		This command is used to enable Proxy Private Identity of the IUT
+                This command is used to enable Proxy Private Identity of the IUT
 
-	Opcode 0x73 - On-Demand Private Proxy Get
+        Opcode 0x73 - On-Demand Private Proxy Get
 
-		Controller Index:       <controller id>
-		Command parameters:     Destination (2 octet)
+                Controller Index:       <controller id>
+                Command parameters:     Destination (2 octet)
+                Response parameters:    <none>
 
-		This command is used to get the current On-Demand Private GATT Proxy state of a node.
+                This command is used to get the current On-Demand Private GATT Proxy state of a node.
 
-	Opcode 0x74 - On-Demand Private Proxy Set
+        Opcode 0x74 - On-Demand Private Proxy Set
 
-		Controller Index:       <controller id>
-		Command parameters:     Destination (2 octet)
-								Val (1 octet)
+                Controller Index:       <controller id>
+                Command parameters:     Destination (2 octet)
+                                        Val (1 octet)
+                Response parameters:    <none>
 
-		This command is  used to set the On-Demand Private GATT Proxy state of a node.
+                This command is  used to set the On-Demand Private GATT Proxy state of a node.
 
-	Opcode 0x75 - Mesh SRPL Clear
+        Opcode 0x75 - Mesh SRPL Clear
 
-		Controller Index:       <controller id>
-		Command parameters:     Destination (2 octet)
-								Rnage start (2 octet)
-								Range length (1 octet)
-								Acknowledged (1 octet)
+                Controller Index:       <controller id>
+                Command parameters:     Destination (2 octet)
+                                        Rnage start (2 octet)
+                                        Range length (1 octet)
+                                        Acknowledged (1 octet)
+                Response parameters:    <none>
 
-		This command is used send SOLICITATION_PDU_RPL_ITEMS_CLEAR or SOLICITATION_PDU_RPL_ITEMS_
-		CLEAR_UNACKNOWLEDGED message to remove one or more items from the solicitation replay
-		protection list of a node.
+                This command is used send SOLICITATION_PDU_RPL_ITEMS_CLEAR or SOLICITATION_PDU_RPL_ITEMS_
+                CLEAR_UNACKNOWLEDGED message to remove one or more items from the solicitation replay
+                protection list of a node.
 
-	Opcode 0x76 - Proxy Solicit
+        Opcode 0x76 - Proxy Solicit
 
-		Controller Index:       <controller id>
+                Controller Index:       <controller id>
+                Command parameters:    <none>
+                Response parameters:    <none>
 
-		This command is used to schedule advertising of Solicitation PDUs on Proxy Client (IUT).
+                This command is used to schedule advertising of Solicitation PDUs on Proxy Client (IUT).
 
-	Opcode 0x77 - Proxy Client Connect
+        Opcode 0x77 - Proxy Client Connect
 
-		Controller Index:       <controller id>
-		Command parameters:     Network index (2 octets)
-		Response parameters: 	Proxy Client Connect Status (1 octet)
+                Controller Index:       <controller id>
+                Command parameters:     Network index (2 octets)
+                Response parameters:    Proxy Client Connect Status (1 octet)
 
-		This command is used to allow Proxy Client on IUT to auto connect
-		to a network of given index.
+                This command is used to allow Proxy Client on IUT to auto connect
+                to a network of given index.
 
-		In case of an error, the error response will be returned.
+                In case of an error, the error response will be returned.
 
-	Opcode 0x78 - Start command/response
-		Controller Index:	<controller id>
-		Command parameters:	<none>
+        Opcode 0x78 - Start command/response
+                Controller Index:       <controller id>
+                Command parameters:     <none>
+                Response parameters:    <none>
 
-		This command is used to start advertising either as
-		unprovisioned beacon or network node. Action depends on
-		previous configuration.
+                This command is used to start advertising either as
+                unprovisioned beacon or network node. Action depends on
+                previous configuration.
 
-		In case of an error, the error response will be returned.
+                In case of an error, the error response will be returned.
 
 Events:
-	Opcode 0x80 - Output number action Event
+        Opcode 0x80 - Output number action Event
 
-		Controller Index:	<controller id>
-		Event parameters:	Action (2 octets)
-					Number (4 octets)
+                Controller Index:       <controller id>
+                Event parameters:       Action (2 octets)
+                                        Number (4 octets)
 
-	Opcode 0x81 - Output string action Event
+        Opcode 0x81 - Output string action Event
 
-		Controller Index:	<controller id>
-		Event parameters:	String Length (1 octet)
-					String (variable)
+                Controller Index:       <controller id>
+                Event parameters:       String Length (1 octet)
+                                        String (variable)
 
-	Opcode 0x82 - Input action Event
+        Opcode 0x82 - Input action Event
 
-		Controller Index:	<controller id>
-		Event parameters:	Action (2 octets)
-					Size (1 octet)
+                Controller Index:       <controller id>
+                Event parameters:       Action (2 octets)
+                                        Size (1 octet)
 
-		This event indicates that input action is required. Depending
-		on action it may require reply with 'Input number' or
-		'Input string' commands.
+                This event indicates that input action is required. Depending
+                on action it may require reply with 'Input number' or
+                'Input string' commands.
 
-		Depending on action either number or string fields are valid.
+                Depending on action either number or string fields are valid.
 
-	Opcode 0x83 - Provisioned Event
+        Opcode 0x83 - Provisioned Event
 
-		Controller Index:	<controller id>
-		Event parameters:	<none>
+                Controller Index:       <controller id>
+                Event parameters:       <none>
 
-		This event indicate that node was provisioned.
+                This event indicate that node was provisioned.
 
-	Opcode 0x84 - Link open Event
+        Opcode 0x84 - Link open Event
 
-		Controller Index:	<controller id>
-		Event parameters:	Bearer (1 octet)
+                Controller Index:       <controller id>
+                Event parameters:       Bearer (1 octet)
 
-		Valid Bearer parameter values:
+                Valid Bearer parameter values:
+                        0x00 = PB-ADV
+                        0x01 = PB-GATT
 
-					0x00 = PB-ADV
-					0x01 = PB-GATT
+                This event indicates that provisioning link has been opened on
+                given bearer.
 
-		This event indicates that provisioning link has been opened on
-		given bearer.
+        Opcode 0x85 - Link closed Event
 
-	Opcode 0x85 - Link closed Event
+                Controller Index:       <controller id>
+                Event parameters:       Bearer (1 octet)
 
-		Controller Index:	<controller id>
-		Event parameters:	Bearer (1 octet)
+                Valid Bearer parameter values:
+                        0x00 = PB-ADV
+                        0x01 = PB-GATT
 
-		Valid Bearer parameter values:
+                This event indicates that provisioning link has been closed on
+                given bearer.
 
-					0x00 = PB-ADV
-					0x01 = PB-GATT
+        Opcode 0x86 - Network receive Event
 
-		This event indicates that provisioning link has been closed on
-		given bearer.
+                Controller Index:       <controller id>
+                Event parameters:       TTL (1 octet)
+                                        CTL (1 octet)
+                                        SRC (2 octets)
+                                        DST (2 octets)
+                                        Payload_Len (1 octet)
+                                        Payload (variable)
 
-	Opcode 0x86 - Network receive Event
+                This event indicates reception of network packet.
 
-		Controller Index:	<controller id>
-		Event parameters:	TTL (1 octet)
-					CTL (1 octet)
-					SRC (2 octets)
-					DST (2 octets)
-					Payload_Len (1 octet)
-					Payload (variable)
+        Opcode 0x87 - Invalid BearerOpcode Event
 
-		This event indicates reception of network packet.
+                Controller Index:       <controller id>
+                Event parameters:       Opcode (1 octet)
 
-	Opcode 0x87 - Invalid BearerOpcode Event
+                This event indicates reception of provisioning message with
+                invalid RFU BearerOpcode.
 
-		Controller Index:	<controller id>
-		Event parameters:	Opcode (1 octet)
+        Opcode 0x88 - Transport Incomplete Timer Expired Event
 
-		This event indicates reception of provisioning message with
-		invalid RFU BearerOpcode.
+                Controller Index:       <controller id>
+                Event parameters:       <none>
 
-	Opcode 0x88 - Transport Incomplete Timer Expired Event
+                This event indicates that segmented message incomplete timer
+                expired.
 
-		Controller Index:	<controller id>
-		Event parameters:	<none>
+        Opcode 0x89 - Friendship Established Event
 
-		This event indicates that segmented message incomplete timer
-		expired.
+                Controller Index:       <controller id>
+                Event parameters:       Network Key Index (2 octet)
+                                        LPN address (2 octet)
+                                        Receive delay (1 octets)
+                                        Poll timeout (4 octets)
 
-	Opcode 0x89 - Friendship Established Event
+                This event indicates that a Friendship has been established
+                (as a Friend).
 
-		Controller Index:	<controller id>
-		Event parameters:	Network Key Index (2 octet)
-					LPN address (2 octet)
-					Receive delay (1 octets)
-					Poll timeout (4 octets)
+        Opcode 0x8a - Friendship Terminated Event
 
-		This event indicates that a Friendship has been established
-		(as a Friend).
+                Controller Index:       <controller id>
+                Event parameters:       Network Key Index (2 octet)
+                                        LPN address (2 octet)
 
-	Opcode 0x8a - Friendship Terminated Event
+                This event indicates that a Friendship has been terminated
+                (as a Friend).
 
-		Controller Index:	<controller id>
-		Event parameters:	Network Key Index (2 octet)
-					LPN address (2 octet)
+        Opcode 0x8b - LPN Established Event
 
-		This event indicates that a Friendship has been terminated
-		(as a Friend).
+                Controller Index:       <controller id>
+                Event parameters:       Network Key Index (2 octet)
+                                        Friend address (2 octet)
+                                        Queue size (1 octets)
+                                        Receive window (1 octets)
 
-	Opcode 0x8b - LPN Established Event
+                This event indicates that a Friendship has been established
+                (as a LPN).
 
-		Controller Index:	<controller id>
-		Event parameters:	Network Key Index (2 octet)
-					Friend address (2 octet)
-					Queue size (1 octets)
-					Receive window (1 octets)
+        Opcode 0x8c - LPN Terminated Event
 
-		This event indicates that a Friendship has been established
-		(as a LPN).
+                Controller Index:       <controller id>
+                Event parameters:       Network Key Index (2 octet)
+                                        Friend address (2 octet)
 
-	Opcode 0x8c - LPN Terminated Event
+                This event indicates that a Friendship has been terminated
+                (as a LPN).
 
-		Controller Index:	<controller id>
-		Event parameters:	Network Key Index (2 octet)
-					Friend address (2 octet)
+        Opcode 0x8d - LPN Polled Event
 
-		This event indicates that a Friendship has been terminated
-		(as a LPN).
+                Controller Index:       <controller id>
+                Event parameters:       Network Key Index (2 octet)
+                                        Friend address (2 octet)
+                                        Retry (1 octet)
 
-	Opcode 0x8d - LPN Polled Event
+                Retry parameter is a binary value indicaing that a poll was a retry.
 
-		Controller Index:	<controller id>
-		Event parameters:	Network Key Index (2 octet)
-					Friend address (2 octet)
-					Retry (1 octet)
+                This event indicates that the IUT as an LPN has polled a Friend.
 
-		Retry parameter is a binary value indicaing that a poll was a retry.
+        Opcode 0x8e - Provisioned Node Added
 
-		This event indicates that the IUT as an LPN has polled a Friend.
+                Controller Index:       <controller id>
+                Event parameters:       Network Key Index (2 octets)
+                                        Address (2 octets)
+                                        UUID (16 octets)
+                                        Number of elements (1 octet)
 
-	Opcode 0x8e - Provisioned Node Added
+                This event indicates that the IUT has provisioned a new node.
 
-		Controller Index:	<controller id>
-		Event parameters:	Network Key Index (2 octets)
-					Address (2 octets)
-					UUID (16 octets)
-					Number of elements (1 octet)
+        Opcode 0x8f - Access Layer Message Received
 
-		This event indicates that the IUT has provisioned a new node.
+                Controller Index:       <controller id>
+                Event parameters:       SRC (2 octets)
+                                        DST (2 octets)
+                                        Payload_Len (1 octet)
+                                        Payload (variable)
 
-	Opcode 0x8f - Access Layer Message Received
+                This event indicates that the IUT has received an Access layer message.
 
-		Controller Index:	<controller id>
-		Event parameters:	SRC (2 octets)
-					DST (2 octets)
-					Payload_Len (1 octet)
-					Payload (variable)
+        Opcode 0x90 - Target node has been lost due to some error in the transfer.
 
-		This event indicates that the IUT has received an Access layer message.
+                Controller Index:       <controller id>
+                Event parameters:       <none>
 
-	Opcode 0x90 - Target node has been lost due to some error in the transfer.
-
-		Controller Index:	<controller id>
-
-		This event indicates that blob client lost the target due to some error during
-		transfer.
+                This event indicates that blob client lost the target due to some error during
+                transfer.

--- a/doc/btp_micp.txt
+++ b/doc/btp_micp.txt
@@ -3,90 +3,90 @@ Microphone Control Profile(ID 16)
 
 Commands and responses:
 
-	Opcode 0x00 - Error response
+        Opcode 0x00 - Error response
 
-	Opcode 0x01 - Read supported commands
+        Opcode 0x01 - Read supported commands
 
-		Controller Index:	<controller id>
-		Command parameters:     <none>
-		Response parameters:    <supported commands> (variable)
+                Controller Index:       <controller id>
+                Command parameters:     <none>
+                Response parameters:    <supported commands> (variable)
 
-		Each bit in response is a flag indicating if command with
-		opcode matching bit number is supported. Bit set to 1 means
-		that command is supported. Bit 0 is reserved and shall always
-		be set to 0. If specific bit is not present in response (less
-		than required bytes received) it shall be assumed that command
-		is not supported.
+                Each bit in response is a flag indicating if command with
+                opcode matching bit number is supported. Bit set to 1 means
+                that command is supported. Bit 0 is reserved and shall always
+                be set to 0. If specific bit is not present in response (less
+                than required bytes received) it shall be assumed that command
+                is not supported.
 
-		In case of an error, the error response will be returned.
+                In case of an error, the error response will be returned.
 
-	Opcode 0x02 - Discovery
+        Opcode 0x02 - Discovery
 
-		Controller Index:	<controller id>
-		Command parameters:     Address_Type (1 octet)
-					Address (6 octets)
-		Response parameters: <none>
+                Controller Index:       <controller id>
+                Command parameters:     Address_Type (1 octet)
+                                        Address (6 octets)
+                Response parameters: <none>
 
-		This command is used to discover primary service, AICS included
-		service(s) and all characteristics related to them. During discovery,
-		the IUT may send events:
-				Discovered Event
+                This command is used to discover primary service, AICS included
+                service(s) and all characteristics related to them. During discovery,
+                the IUT may send events:
+                                Discovered Event
 
-		In case of an error, the error response will be returned.
+                In case of an error, the error response will be returned.
 
-	Opcode 0x03 - Mute read
+        Opcode 0x03 - Mute read
 
-		Controller Index:	<controller id>
-		Command parameters:     Address_Type (1 octet)
-					Address (6 octets)
-		Response parameters:	<none>
+                Controller Index:       <controller id>
+                Command parameters:     Address_Type (1 octet)
+                                        Address (6 octets)
+                Response parameters:    <none>
 
-		This command is used to read Mute characteristic. During read
-		operation, the IUT may send event:
-				Mute State event
+                This command is used to read Mute characteristic. During read
+                operation, the IUT may send event:
+                                Mute State event
 
-		In case of an error, the error reponse will be returned.
+                In case of an error, the error reponse will be returned.
 
-	Opcode 0x04 - Mute
+        Opcode 0x04 - Mute
 
-		Controller Index:	<controller id>
-		Command parameters:     Address_Type (1 octet)
-					Address (6 octets)
-		Response parameters:	<none>
+                Controller Index:       <controller id>
+                Command parameters:     Address_Type (1 octet)
+                                        Address (6 octets)
+                Response parameters:    <none>
 
-		This command is used to request Mute operation. During write operation,
-		the IUT may send event:
-				Mute State event
+                This command is used to request Mute operation. During write operation,
+                the IUT may send event:
+                                Mute State event
 
-		In case of an error, the error reponse will be returned.
+                In case of an error, the error reponse will be returned.
 
 
 Events:
-	Opcode 0x80 - Discovered Event
+        Opcode 0x80 - Discovered Event
 
-		Controller Index:	<controller id>
-		Event parameters:	Address_Type (1 octet)
-					Address (6 octets)
-					ATT status (1 octet)
-					MICP Mute handle (2 octets)
-					AICS State handle (2 octets)
-					AICS Gain handle (2 octets)
-					AICS Type handle (2 octets)
-					AICS Status handle (2 octets)
-					AICS Control Point handle (2 octets)
-					AICS Description handle (2 octets)
+                Controller Index:       <controller id>
+                Event parameters:       Address_Type (1 octet)
+                                        Address (6 octets)
+                                        ATT status (1 octet)
+                                        MICP Mute handle (2 octets)
+                                        AICS State handle (2 octets)
+                                        AICS Gain handle (2 octets)
+                                        AICS Type handle (2 octets)
+                                        AICS Status handle (2 octets)
+                                        AICS Control Point handle (2 octets)
+                                        AICS Description handle (2 octets)
 
-		This event returns handles of MICP characteristic and AICS included
-		service characteristics.
+                This event returns handles of MICP characteristic and AICS included
+                service characteristics.
 
-	Opcode 0x81 - Mute State event
+        Opcode 0x81 - Mute State event
 
-		Controller Index:	<controller id>
-		Event parameters:	Address_Type (1 octet)
-					Address (6 octets)
-					ATT status (1 octet)
-					Mute state (1 octet)
+                Controller Index:       <controller id>
+                Event parameters:       Address_Type (1 octet)
+                                        Address (6 octets)
+                                        ATT status (1 octet)
+                                        Mute state (1 octet)
 
-		This event returns Mute state (from primary service).
+                This event returns Mute state (from primary service).
 
 

--- a/doc/btp_mics.txt
+++ b/doc/btp_mics.txt
@@ -3,75 +3,80 @@ Microphone Control Service(ID 18)
 
 Commands and responses:
 
-	Opcode 0x00 - Error response
+        Opcode 0x00 - Error response
 
-	Opcode 0x01 - Read supported commands
-		Controller Index:       <controller id>
-		Command parameters:     <none>
-		Response parameters:    <supported commands> (variable)
+        Opcode 0x01 - Read supported commands
 
-		Each bit in response is a flag indicating if command with
-		opcode matching bit number is supported. Bit set to 1 means
-		that command is supported. Bit 0 is reserved and shall always
-		be set to 0. If specific bit is not present in response (less
-		than required bytes received) it shall be assumed that command
-		is not supported.
+                Controller Index:       <controller id>
+                Command parameters:     <none>
+                Response parameters:    <supported commands> (variable)
 
-		In case of an error, the error response will be returned.
+                Each bit in response is a flag indicating if command with
+                opcode matching bit number is supported. Bit set to 1 means
+                that command is supported. Bit 0 is reserved and shall always
+                be set to 0. If specific bit is not present in response (less
+                than required bytes received) it shall be assumed that command
+                is not supported.
 
-	Opcode 0x02 - Mute disable
-		Controller Index:	<controller id>
-		Command parameters:     <none>
-		Response parameters:	<none>
+                In case of an error, the error response will be returned.
 
-		This command is used to disable Mute functionality. During
-		operation, the IUT may send event:
-				Mute State event
+        Opcode 0x02 - Mute disable
 
-		In case of an error, the error reponse will be returned.
+                Controller Index:       <controller id>
+                Command parameters:     <none>
+                Response parameters:    <none>
 
-	Opcode 0x03 - Mute read
-		Controller Index:	<controller id>
-		Command parameters:     <none>
-		Response parameters:	<none>
+                This command is used to disable Mute functionality. During
+                operation, the IUT may send event:
+                        Mute State event
 
-		This command is used to read Mute state. During operation,
-		the IUT may send event:
-				Mute State event
+                In case of an error, the error reponse will be returned.
 
-		In case of an error, the error reponse will be returned.
+        Opcode 0x03 - Mute read
 
-	Opcode 0x04 - Mute
-		Controller Index:	<controller id>
-		Command parameters:     <none>
-		Response parameters:	<none>
+                Controller Index:       <controller id>
+                Command parameters:     <none>
+                Response parameters:    <none>
 
-		This command is used to request Mute operation. During
-		operation, the IUT may send event:
-				Mute State event
+                This command is used to read Mute state. During operation,
+                the IUT may send event:
+                        Mute State event
 
-		In case of an error, the error reponse will be returned.
+                In case of an error, the error reponse will be returned.
 
-	Opcode 0x05 - Unmute
-		Controller Index:	<controller id>
-		Command parameters:     <none>
-		Response parameters:	<none>
+        Opcode 0x04 - Mute
 
-		This command is used to request Unmute operation. During
-		operation, the IUT may send event:
-				Mute State event
+                Controller Index:       <controller id>
+                Command parameters:     <none>
+                Response parameters:    <none>
 
-		In case of an error, the error reponse will be returned.
+                This command is used to request Mute operation. During
+                operation, the IUT may send event:
+                        Mute State event
+
+                In case of an error, the error reponse will be returned.
+
+        Opcode 0x05 - Unmute
+
+                Controller Index:       <controller id>
+                Command parameters:     <none>
+                Response parameters:    <none>
+
+                This command is used to request Unmute operation. During
+                operation, the IUT may send event:
+                        Mute State event
+
+                In case of an error, the error reponse will be returned.
 
 
 Events:
-	Opcode 0x80 - Mute State event
+        Opcode 0x80 - Mute State event
 
-		Controller Index:	<controller id>
-		Event parameters:	Address_Type (1 octet)
-					Address (6 octets)
-					Mute state (1 octet)
+                Controller Index:       <controller id>
+                Event parameters:       Address_Type (1 octet)
+                                        Address (6 octets)
+                                        Mute state (1 octet)
 
-		This event returns Mute state (from primary service).
+                This event returns Mute state (from primary service).
 
 

--- a/doc/btp_ots.txt
+++ b/doc/btp_ots.txt
@@ -3,41 +3,41 @@ OTS Service (ID 29)
 
 Commands and responses:
 
-	Opcode 0x00 - Error response
+        Opcode 0x00 - Error response
 
-	Opcode 0x01 - Read Supported Commands command/response
+        Opcode 0x01 - Read Supported Commands command/response
 
-		Controller Index:	<controller id>
-		Command parameters:	<none>
-		Response parameters:	<supported commands> (variable)
+                Controller Index:       <controller id>
+                Command parameters:     <none>
+                Response parameters:    <supported commands> (variable)
 
-		Each bit in response is a flag indicating if command with
-		opcode matching bit number is supported. Bit set to 1 means
-		that command is supported. Bit 0 is reserved and shall always
-		be set to 0. If specific bit is not present in response (less
-		than required bytes received) it shall be assumed that command
-		is not supported.
+                Each bit in response is a flag indicating if command with
+                opcode matching bit number is supported. Bit set to 1 means
+                that command is supported. Bit 0 is reserved and shall always
+                be set to 0. If specific bit is not present in response (less
+                than required bytes received) it shall be assumed that command
+                is not supported.
 
-		In case of an error, the error response will be returned.
+                In case of an error, the error response will be returned.
 
-	Opcode 0x02 - Register Object command/response
+        Opcode 0x02 - Register Object command/response
 
-		Controller Index:	<controller id>
-		Command parameters:	Flags (1 octet)
-					Properties (4 octets)
-					Allocation_Size 4 octets)
-					Current_Size (4 octets)
-					Name_Length (1 octet)
-					Name (variable)
-		Response parameters:	Object_ID (4 octets)
+                Controller Index:       <controller id>
+                Command parameters:     Flags (1 octet)
+                                        Properties (4 octets)
+                                        Allocation_Size 4 octets)
+                                        Current_Size (4 octets)
+                                        Name_Length (1 octet)
+                                        Name (variable)
+                Response parameters:    Object_ID (4 octets)
 
-	This command is used to register new Object in OTS server with
-	specified parameters. Properties are OTS Object properties as per
-	specification. Allocation and current sizes defines Object sizes
-	as per specification.
+                This command is used to register new Object in OTS server with
+                specified parameters. Properties are OTS Object properties as per
+                specification. Allocation and current sizes defines Object sizes
+                as per specification.
 
-	Possible values for the Flags parameter are a bit-wise or of
-	the following bits:
-		0 = Skip Unsupported Properties
+                Possible values for the Flags parameter are a bit-wise or of
+                the following bits:
+                        0 = Skip Unsupported Properties
 
-	In case of an error, the error response will be returned.
+                In case of an error, the error response will be returned.

--- a/doc/btp_pacs.txt
+++ b/doc/btp_pacs.txt
@@ -3,146 +3,147 @@ Published Audio Capabilities Service (ID 12)
 
 Commands and responses:
 
-	Opcode 0x00 - Error response
+        Opcode 0x00 - Error response
 
-	Opcode 0x01 - Read supported commands
-		Controller Index:    <controller id>
-		Command parameters:  <none>
-		Response parameters: <supported commands> (variable)
+        Opcode 0x01 - Read supported commands
 
-		Each bit in response is a flag indicating if command with
-		opcode matching bit number is supported. Bit set to 1 means
-		that command is supported. Bit 0 is reserved and shall always
-		be set to 0. If specific bit is not present in response (less
-		than required bytes received) it shall be assumed that command
-		is not supported.
+                Controller Index:    <controller id>
+                Command parameters:  <none>
+                Response parameters: <supported commands> (variable)
 
-		In case of an error, the error response will be returned.
+                Each bit in response is a flag indicating if command with
+                opcode matching bit number is supported. Bit set to 1 means
+                that command is supported. Bit 0 is reserved and shall always
+                be set to 0. If specific bit is not present in response (less
+                than required bytes received) it shall be assumed that command
+                is not supported.
 
-	Opcode 0x02 - Update characteristic
-		Controller Index:    <controller id>
-		Command parameters:  ID of the characteristic (1 octet)
-		Response parameters: <none>
+                In case of an error, the error response will be returned.
 
-        Possible values for the ID of the characteristic:
+        Opcode 0x02 - Update characteristic
 
-            0x01 Sink PAC Characteristic
-            0x02 Source PAC Characteristic
-            0x03 Sink Audio Location Characteristic
-            0x04 Source Audio Location Characteristic
-            0x05 Available Audio Contexts Characteristic
-            0x06 Supported Audio Contexts Characteristic
+                Controller Index:    <controller id>
+                Command parameters:  ID of the characteristic (1 octet)
+                Response parameters: <none>
 
-		This command is used to trigger the IUT to update the selected
-		PACS characteristics.
+                Possible values for the ID of the characteristic:
+                        0x01 Sink PAC Characteristic
+                        0x02 Source PAC Characteristic
+                        0x03 Sink Audio Location Characteristic
+                        0x04 Source Audio Location Characteristic
+                        0x05 Available Audio Contexts Characteristic
+                        0x06 Supported Audio Contexts Characteristic
 
-		In case of an error, the error response will be returned.
+                This command is used to trigger the IUT to update the selected
+                PACS characteristics.
 
-	Opcode 0x03: Set Audio Locations
+                In case of an error, the error response will be returned.
 
-		Controller Index:	<controller id>
-		Command parameters:	Direction (1 octet)
-					Locations (4 octets)
-		Response parameters:	<None>
+        Opcode 0x03: Set Audio Locations
 
-		Direction is a byte; Audio Sink or Source.
-		Locations is a 4 byte bit-field; Locations supported.
+                Controller Index:       <controller id>
+                Command parameters:     Direction (1 octet)
+                                        Locations (4 octets)
+                Response parameters:    <None>
 
-		Possible values for Direction is:
-		1 = Audio Sink
-		2 = Audio Source
+                Direction is a byte; Audio Sink or Source.
+                Locations is a 4 byte bit-field; Locations supported.
 
-		Possible values for Locations are a combination of the
-		following bit definitions:
+                Possible values for Direction is:
+                1 = Audio Sink
+                2 = Audio Source
 
-		Bit:	Definition:
-		 0	Front Left
-		 1	Front Right
-		 2	Front Center
-		 3	LF Effects 1
-		 4	Back Left
-		 5	Back Right
-		 6	Front Left Of Center
-		 7	Front Right Of Center
-		 8	Back Center
-		 9	LF Effects 2
-		10	Side Left
-		11	Side Right
-		12	Top Front Left
-		13	Top Front Right
-		14	Top Front Center
-		15	Top Center
-		16	Top Back Left
-		17	Top Back Right
-		18	Top Side Left
-		19	Top Side Right
-		20	Top Back Center
-		21	Bottom Front Center
-		22	Bottom Front Left
-		23	Bottom Front Right
-		24	Front Left Wide
-		25	Front Right Wide
-		26	Left Surround
-		27	Right Surround
-		
-		This command is used to set supported Audio Locations. 
-		
-		In case of an error, the error response will be returned.
+                Possible values for Locations are a combination of the
+                following bit definitions:
 
-	Opcode 0x04: Set Available Audio Contexts
+                Bit:    Definition:
+                 0      Front Left
+                 1      Front Right
+                 2      Front Center
+                 3      LF Effects 1
+                 4      Back Left
+                 5      Back Right
+                 6      Front Left Of Center
+                 7      Front Right Of Center
+                 8      Back Center
+                 9      LF Effects 2
+                10      Side Left
+                11      Side Right
+                12      Top Front Left
+                13      Top Front Right
+                14      Top Front Center
+                15      Top Center
+                16      Top Back Left
+                17      Top Back Right
+                18      Top Side Left
+                19      Top Side Right
+                20      Top Back Center
+                21      Bottom Front Center
+                22      Bottom Front Left
+                23      Bottom Front Right
+                24      Front Left Wide
+                25      Front Right Wide
+                26      Left Surround
+                27      Right Surround
+                
+                This command is used to set supported Audio Locations. 
+                
+                In case of an error, the error response will be returned.
 
-		Controller Index:	<controller id>
-		Command parameters:	Sink Contexts (2 octet)
-					Source Contexts (2 octets)
-		Response parameters:	<None>
+        Opcode 0x04: Set Available Audio Contexts
 
-		Sink Contexts is a two octet bit-field; Available Audio Sink Contexts.
-		Source Contexts is a two octet bit-field; Available Audio Source Contexts.
+                Controller Index:       <controller id>
+                Command parameters:     Sink Contexts (2 octet)
+                                        Source Contexts (2 octets)
+                Response parameters:    <None>
 
-		Possible values for Contexts are a combination of the
-		following bit definitions:
+                Sink Contexts is a two octet bit-field; Available Audio Sink Contexts.
+                Source Contexts is a two octet bit-field; Available Audio Source Contexts.
 
-		Bit:	Definition:
-		 0	Unspecified
-		 1	Conversational
-		 2	Media
-		 3	Game
-		 4	Instructional
-		 5	Voice Assistants
-		 6	Live
-		 7	Sound Effects
-		 8	Notifications
-		 9	Ringtone
-		10	Alerts
-		11	Emergency Alarm
+                Possible values for Contexts are a combination of the
+                following bit definitions:
 
-		This command is used to set the available audio Contexts. 
-		
-		In case of an error, the error response will be returned.
+                Bit:    Definition:
+                 0      Unspecified
+                 1      Conversational
+                 2      Media
+                 3      Game
+                 4      Instructional
+                 5      Voice Assistants
+                 6      Live
+                 7      Sound Effects
+                 8      Notifications
+                 9      Ringtone
+                10      Alerts
+                11      Emergency Alarm
 
-	Opcode 0x05: Set Supported Audio Contexts
+                This command is used to set the available audio Contexts. 
+                
+                In case of an error, the error response will be returned.
 
-		Controller Index:	<controller id>
-		Command parameters:	Sink Contexts (2 octet)
-					Source Contexts (2 octets)
-		Response parameters:	<None>
+        Opcode 0x05: Set Supported Audio Contexts
 
-		Sink Contexts is a two octet bit-field; Supported Audio Sink Contexts.
-		Source Contexts is a two octet bit-field; Supported Audio Source Contexts.
+                Controller Index:       <controller id>
+                Command parameters:     Sink Contexts (2 octet)
+                                        Source Contexts (2 octets)
+                Response parameters:    <None>
 
-		For a definition of the bit-field Contexts - please see above.
+                Sink Contexts is a two octet bit-field; Supported Audio Sink Contexts.
+                Source Contexts is a two octet bit-field; Supported Audio Source Contexts.
 
-		This command is used to set the supported audio Contexts. 
-		
-		In case of an error, the error response will be returned.
+                For a definition of the bit-field Contexts - please see above.
+
+                This command is used to set the supported audio Contexts. 
+                
+                In case of an error, the error response will be returned.
 
 Events:
-	Opcode 0x80 - Characteristic Subscribed
+        Opcode 0x80 - Characteristic Subscribed
 
-		Controller Index:	<controller id>
-		Event parameters:	Address_Type (1 octet)
-					Address (6 octets)
-					Handle (2 octets)
+                Controller Index:       <controller id>
+                Event parameters:       Address_Type (1 octet)
+                                        Address (6 octets)
+                                        Handle (2 octets)
 
-		This event indicates that a lower tester has subscribed to
-		a PACS characteristic with a given handle.
+                This event indicates that a lower tester has subscribed to
+                a PACS characteristic with a given handle.

--- a/doc/btp_pbp.txt
+++ b/doc/btp_pbp.txt
@@ -3,75 +3,77 @@ PBP Service (ID 30)
 
 Commands and responses:
 
-	Opcode 0x00 - Error response
+        Opcode 0x00 - Error response
 
-	Opcode 0x01 - Read Supported Commands command/response
+        Opcode 0x01 - Read Supported Commands command/response
 
-		Controller Index:	<controller id>
-		Command parameters:	<none>
-		Response parameters:	<supported commands> (variable)
+                Controller Index:       <controller id>
+                Command parameters:     <none>
+                Response parameters:    <supported commands> (variable)
 
-		Each bit in response is a flag indicating if command with
-		opcode matching bit number is supported. Bit set to 1 means
-		that command is supported. Bit 0 is reserved and shall always
-		be set to 0. If specific bit is not present in response (less
-		than required bytes received) it shall be assumed that command
-		is not supported.
+                Each bit in response is a flag indicating if command with
+                opcode matching bit number is supported. Bit set to 1 means
+                that command is supported. Bit 0 is reserved and shall always
+                be set to 0. If specific bit is not present in response (less
+                than required bytes received) it shall be assumed that command
+                is not supported.
 
-		In case of an error, the error response will be returned.
+                In case of an error, the error response will be returned.
 
-	Opcode 0x02: Set Public Broadcast Announcement
+        Opcode 0x02: Set Public Broadcast Announcement
 
-		Controller Index:	<controller id>
-		Command parameters:	Features (1 octet)
-							Metadata LTVs len (1 octet)
-							LTVs (varies)
+                Controller Index:       <controller id>
+                Command parameters:     Features (1 octet)
+                                                        Metadata LTVs len (1 octet)
+                                                        LTVs (varies)
 
-		This command is used to set the Public Broadcast Announcement in broadcast advertisements
+                This command is used to set the Public Broadcast Announcement in
+                broadcast advertisements
 
-		In case of an error, the error response will be returned.
+                In case of an error, the error response will be returned.
 
-	Opcode 0x03: Set Broadcast Name
+        Opcode 0x03: Set Broadcast Name
 
-		Controller Index:	<controller id>
-		Command parameters:	Name Length (1 octet)
-							Name (<Name Length> octets)
+                Controller Index:       <controller id>
+                Command parameters:     Name Length (1 octet)
+                                                        Name (<Name Length> octets)
 
-		This command is used to set the Public Broadcast Announcement in broadcast advertisements
+                This command is used to set the Public Broadcast Announcement in
+                broadcast advertisements
 
-		In case of an error, the error response will be returned.
+                In case of an error, the error response will be returned.
 
-	Opcode 0x04 - Broadcast Scan Start
-		Controller Index:	<controller id>
-		Command parameters:	<none>
-		Response parameters:	<none>
+        Opcode 0x04 - Broadcast Scan Start
+                Controller Index:       <controller id>
+                Command parameters:     <none>
+                Response parameters:    <none>
 
-        This command is used to start scanning for Public Broadcast Announcements.
-        In case of an error, the error status response will be returned.
-        In case of a success, the IUT continues processing the command
-        asynchronously.
+                This command is used to start scanning for Public Broadcast Announcements.
+                In case of an error, the error status response will be returned.
+                In case of a success, the IUT continues processing the command
+                asynchronously.
 
-	Opcode 0x05 - Broadcast Scan Stop
-		Controller Index:	<controller id>
-		Command parameters:	<none>
-		Response parameters:	<none>
+        Opcode 0x05 - Broadcast Scan Stop
+                Controller Index:       <controller id>
+                Command parameters:     <none>
+                Response parameters:    <none>
 
-        This command is used to stop scanning for Public Broadcast Announcements.
-        In case of an error, the error status response will be returned.
-        In case of a success, the IUT continues processing the command
-        asynchronously.
+                This command is used to stop scanning for Public Broadcast Announcements.
+                In case of an error, the error status response will be returned.
+                In case of a success, the IUT continues processing the command
+                asynchronously.
 
 Events:
-	Opcode 0x80 - Public Broadcast Announcement Found event
+        Opcode 0x80 - Public Broadcast Announcement Found event
 
-		Controller Index:	<controller id>
-		Event parameters:	Address_Type (1 octet)
-					Address (6 octets)
-					Broadcast_ID (3 octets)
-					Advertiser_SID (1 octet)
-					PA_Interval (2 octets)
-					PBA_Features (1 octet)
-					Broadcast_Name_Len (1 octet)
-					Broadcast_Name (<Broadcast_Name_Len> octets)
+                Controller Index:       <controller id>
+                Event parameters:       Address_Type (1 octet)
+                                        Address (6 octets)
+                                        Broadcast_ID (3 octets)
+                                        Advertiser_SID (1 octet)
+                                        PA_Interval (2 octets)
+                                        PBA_Features (1 octet)
+                                        Broadcast_Name_Len (1 octet)
+                                        Broadcast_Name (<Broadcast_Name_Len> octets)
 
-        This event returns info from scanned Public Broadcast Announcement.
+                This event returns info from scanned Public Broadcast Announcement.

--- a/doc/btp_tbs.txt
+++ b/doc/btp_tbs.txt
@@ -3,138 +3,138 @@ Telephone Bearer Service(ID 27)
 
 Commands and responses:
 
-	Opcode 0x00 - Error response
+        Opcode 0x00 - Error response
 
-	Opcode 0x01 - Read supported commands
+        Opcode 0x01 - Read supported commands
 
-		Controller Index:       <controller id>
-		Command parameters:     <none>
-		Response parameters:    <supported commands> (variable)
+                Controller Index:       <controller id>
+                Command parameters:     <none>
+                Response parameters:    <supported commands> (variable)
 
-		Each bit in response is a flag indicating if command with
-		opcode matching bit number is supported. Bit set to 1 means
-		that command is supported. Bit 0 is reserved and shall always
-		be set to 0. If specific bit is not present in response (less
-		than required bytes received) it shall be assumed that command
-		is not supported.
+                Each bit in response is a flag indicating if command with
+                opcode matching bit number is supported. Bit set to 1 means
+                that command is supported. Bit 0 is reserved and shall always
+                be set to 0. If specific bit is not present in response (less
+                than required bytes received) it shall be assumed that command
+                is not supported.
 
-		In case of an error, the error response will be returned.
+                In case of an error, the error response will be returned.
 
-	Opcode 0x02 - Remote Incoming
+        Opcode 0x02 - Remote Incoming
 
-		Controller Index:	<controller id>
-		Command parameters:     Index (1 octet)
-					Receiver URI len (1 octet)
-					Caller URI len (1 octet)
-					Friendly Name len (1 octet)
-					URI String (Varies)
-		Response parameters:	<none>
+                Controller Index:       <controller id>
+                Command parameters:     Index (1 octet)
+                                        Receiver URI len (1 octet)
+                                        Caller URI len (1 octet)
+                                        Friendly Name len (1 octet)
+                                        URI String (Varies)
+                Response parameters:    <none>
 
-		This command is used to generate incoming call from the server.
-		URI String variable is Receiver URI, Caller URI Friendly Name
-		concatenated.
+                This command is used to generate incoming call from the server.
+                URI String variable is Receiver URI, Caller URI Friendly Name
+                concatenated.
 
-		In case of an error, the error response will be returned.
+                In case of an error, the error response will be returned.
 
-	Opcode 0x03 - Hold Call
+        Opcode 0x03 - Hold Call
 
-		Controller Index:	<controller id>
-		Command parameters:     Index (1 octet)
-		Response parameters:	<none>
+                Controller Index:       <controller id>
+                Command parameters:     Index (1 octet)
+                Response parameters:    <none>
 
-		This command is used to hold a call.
+                This command is used to hold a call.
 
-		In case of an error, the error response will be returned.
+                In case of an error, the error response will be returned.
 
-	Opcode 0x04 - Set Bearer Name
+        Opcode 0x04 - Set Bearer Name
 
-		Controller Index:	<controller id>
-		Command parameters:     Index (1 octet)
-					Name len (1 octet)
-					Name (varies)
-		Response parameters:	<none>
+                Controller Index:       <controller id>
+                Command parameters:     Index (1 octet)
+                                        Name len (1 octet)
+                                        Name (varies)
+                Response parameters:    <none>
 
-		This command is used to set bearer provider name.
+                This command is used to set bearer provider name.
 
-		In case of an error, the error response will be returned.
+                In case of an error, the error response will be returned.
 
-	Opcode 0x05 - Set Technology
+        Opcode 0x05 - Set Technology
 
-		Controller Index:	<controller id>
-		Command parameters:     Index (1 octet)
-					Technology (1 octet)
-		Response parameters:	<none>
+                Controller Index:       <controller id>
+                Command parameters:     Index (1 octet)
+                                        Technology (1 octet)
+                Response parameters:    <none>
 
-		This command is used to set a new bearer technology.
+                This command is used to set a new bearer technology.
 
-		In case of an error, the error response will be returned.
+                In case of an error, the error response will be returned.
 
-	Opcode 0x06 - Set URI Schemes List
+        Opcode 0x06 - Set URI Schemes List
 
-		Controller Index:	<controller id>
-		Command parameters:     Index (1 octet)
-					URI len (1 octet)
-					URI count (1 octet)
-					URI (Varies)
-		Response parameters:	<none>
+                Controller Index:       <controller id>
+                Command parameters:     Index (1 octet)
+                                        URI len (1 octet)
+                                        URI count (1 octet)
+                                        URI (Varies)
+                Response parameters:    <none>
 
-		This command is used to set a new URI scheme list of a bearer.
-		For now, URI list with one element is supported.
+                This command is used to set a new URI scheme list of a bearer.
+                For now, URI list with one element is supported.
 
-		In case of an error, the error response will be returned.
+                In case of an error, the error response will be returned.
 
-	Opcode 0x07 - Set Status Flags
+        Opcode 0x07 - Set Status Flags
 
-		Controller Index:	<controller id>
-		Command parameters:     Index (1 octet)
-					Status Flags (2 octets)
-		Response parameters:	<none>
+                Controller Index:       <controller id>
+                Command parameters:     Index (1 octet)
+                                        Status Flags (2 octets)
+                Response parameters:    <none>
 
-		This command is used to set the feature and status value.
+                This command is used to set the feature and status value.
 
-		In case of an error, the error response will be returned.
+                In case of an error, the error response will be returned.
 
-	Opcode 0x08 - Remote Hold
+        Opcode 0x08 - Remote Hold
 
-		Controller Index:	<controller id>
-		Command parameters:     Index (1 octet)
-		Response parameters:	<none>
+                Controller Index:       <controller id>
+                Command parameters:     Index (1 octet)
+                Response parameters:    <none>
 
-		This command is used to notify the server that the remote
-		party held the call.
+                This command is used to notify the server that the remote
+                party held the call.
 
-		In case of an error, the error response will be returned.
+                In case of an error, the error response will be returned.
 
-	Opcode 0x09 - Originate Call
+        Opcode 0x09 - Originate Call
 
-		Controller Index:	<controller id>
-		Command parameters:     Index (1 octet)
-					URI len (1 octet)
-					URI (varies)
-		Response parameters:	<none>
+                Controller Index:       <controller id>
+                Command parameters:     Index (1 octet)
+                                        URI len (1 octet)
+                                        URI (varies)
+                Response parameters:    <none>
 
-		This command is used to originate call.
+                This command is used to originate call.
 
-		In case of an error, the error response will be returned.
+                In case of an error, the error response will be returned.
 
-	Opcode 0x0a - Set Signal Strength
+        Opcode 0x0a - Set Signal Strength
 
-		Controller Index:	<controller id>
-		Command parameters:     Index (1 octet)
-					Strength (1 octet)
-		Response parameters:	<none>
+                Controller Index:       <controller id>
+                Command parameters:     Index (1 octet)
+                                        Strength (1 octet)
+                Response parameters:    <none>
 
-		This command is used to update signal strength reported by the
-		server.
+                This command is used to update signal strength reported by the
+                server.
 
-		In case of an error, the error response will be returned.
+                In case of an error, the error response will be returned.
 
-	Opcode 0x0b - Terminate Call
+        Opcode 0x0b - Terminate Call
 
-		Controller Index:	<controller id>
-		Command parameters:     Index (1 octet)
-		Response parameters:	<none>
+                Controller Index:       <controller id>
+                Command parameters:     Index (1 octet)
+                Response parameters:    <none>
 
-		This command is used to terminate a call
+                This command is used to terminate a call
 
-		In case of an error, the error response will be returned.
+                In case of an error, the error response will be returned.

--- a/doc/btp_tmap.txt
+++ b/doc/btp_tmap.txt
@@ -3,44 +3,44 @@ TMAP Service (ID 28)
 
 Commands and responses:
 
-	Opcode 0x00 - Error response
+        Opcode 0x00 - Error response
 
-	Opcode 0x01 - Read Supported Commands command/response
+        Opcode 0x01 - Read Supported Commands command/response
 
-		Controller Index:	<controller id>
-		Command parameters:	<none>
-		Response parameters:	<supported commands> (variable)
+                Controller Index:       <controller id>
+                Command parameters:     <none>
+                Response parameters:    <supported commands> (variable)
 
-		Each bit in response is a flag indicating if command with
-		opcode matching bit number is supported. Bit set to 1 means
-		that command is supported. Bit 0 is reserved and shall always
-		be set to 0. If specific bit is not present in response (less
-		than required bytes received) it shall be assumed that command
-		is not supported.
+                Each bit in response is a flag indicating if command with
+                opcode matching bit number is supported. Bit set to 1 means
+                that command is supported. Bit 0 is reserved and shall always
+                be set to 0. If specific bit is not present in response (less
+                than required bytes received) it shall be assumed that command
+                is not supported.
 
-		In case of an error, the error response will be returned.
+                In case of an error, the error response will be returned.
 
 
-	Opcode 0x02 - Discover and Subscribe
+        Opcode 0x02 - Discover and Subscribe
 
-		Controller Index:	<controller id>
-		Command parameters:	Address_Type (1 octet)
-					Address (6 octets)
-		Response parameters:	<none>
+                Controller Index:       <controller id>
+                Command parameters:     Address_Type (1 octet)
+                                        Address (6 octets)
+                Response parameters:    <none>
 
-		This command is used to discover all remote TMAP characteristics.
-		In case of an error, the error status response will be returned.
-		In case of a success, the IUT continues processing the command
-		asynchronously.
+                This command is used to discover all remote TMAP characteristics.
+                In case of an error, the error status response will be returned.
+                In case of a success, the IUT continues processing the command
+                asynchronously.
 
 Events:
-	Opcode 0x80 - Discover and Subscribe Completed event
+        Opcode 0x80 - Discover and Subscribe Completed event
 
-		Controller Index:	<controller id>
-		Event parameters:	Address_Type (1 octet)
-					Address (6 octets)
-					Status  (1 octet)
-					Role    (2 octet)
+                Controller Index:       <controller id>
+                Event parameters:       Address_Type (1 octet)
+                                        Address (6 octets)
+                                        Status  (1 octet)
+                                        Role    (2 octet)
 
-        This event indicates that the IUT finished discovery TMAP
-        characteristics.
+                This event indicates that the IUT finished discovery TMAP
+                characteristics.

--- a/doc/btp_vcp.txt
+++ b/doc/btp_vcp.txt
@@ -3,205 +3,203 @@ Volume Control Profile(ID 19)
 
 Commands and responses:
 
-	Opcode 0x00 - Error response
+        Opcode 0x00 - Error response
 
-	Opcode 0x01 - Read supported commands
+        Opcode 0x01 - Read supported commands
 
-		Controller Index:       <controller id>
-		Command parameters:     <none>
-		Response parameters:    <supported commands> (variable)
+                Controller Index:       <controller id>
+                Command parameters:     <none>
+                Response parameters:    <supported commands> (variable)
 
-		Each bit in response is a flag indicating if command with
-		opcode matching bit number is supported. Bit set to 1 means
-		that command is supported. Bit 0 is reserved and shall always
-		be set to 0. If specific bit is not present in response (less
-		than required bytes received) it shall be assumed that command
-		is not supported.
+                Each bit in response is a flag indicating if command with
+                opcode matching bit number is supported. Bit set to 1 means
+                that command is supported. Bit 0 is reserved and shall always
+                be set to 0. If specific bit is not present in response (less
+                than required bytes received) it shall be assumed that command
+                is not supported.
 
-		In case of an error, the error response will be returned.
+                In case of an error, the error response will be returned.
 
-	Opcode 0x02 - Discovery
+        Opcode 0x02 - Discovery
 
-		Controller Index:       <controller id>
-		Command parameters:     Address_Type (1 octet)
-	                                Address (6 octets)
-		Response parameters:    <none>
+                Controller Index:       <controller id>
+                Command parameters:     Address_Type (1 octet)
+                                        Address (6 octets)
+                Response parameters:    <none>
 
-		This command is used to discover primary service, AICS included
-		service(s), VOCS included service(s) and all characteristics
-		related to them. During discovery, the IUT may send events:
-		                Discovery Completed event
+                This command is used to discover primary service, AICS included
+                service(s), VOCS included service(s) and all characteristics
+                related to them. During discovery, the IUT may send events:
+                                Discovery Completed event
 
-		In case of an error, the error response will be returned.
+                In case of an error, the error response will be returned.
 
-	Opcode 0x03 - State Read
+        Opcode 0x03 - State Read
 
-		Controller Index:       <controller id>
-		Command parameters:     Address_Type (1 octet)
-	                                Address (6 octets)
-		Response parameters:    <none>
+                Controller Index:       <controller id>
+                Command parameters:     Address_Type (1 octet)
+                                        Address (6 octets)
+                Response parameters:    <none>
 
-		This command is used to read Volume State characteristic. During
-		operation, the IUT may send event:
-				VCP State Event
+                This command is used to read Volume State characteristic. During
+                operation, the IUT may send event:
+                                VCP State Event
 
-	Opcode 0x04 - Flags Read
+        Opcode 0x04 - Flags Read
 
-		Controller Index:       <controller id>
-		Command parameters:     Address_Type (1 octet)
-	                                Address (6 octets)
-		Response parameters:    <none>
+                Controller Index:       <controller id>
+                Command parameters:     Address_Type (1 octet)
+                                        Address (6 octets)
+                Response parameters:    <none>
 
-		This command is used to read Volume Flags characteristic. During
-		operation, the IUT may send event:
-				VCP Flags Event
+                This command is used to read Volume Flags characteristic. During
+                operation, the IUT may send event:
+                                VCP Flags Event
 
-	Opcode 0x05 - Volume Down
+        Opcode 0x05 - Volume Down
 
-		Controller Index:       <controller id>
-		Command parameters:     Address_Type (1 octet)
-	                                Address (6 octets)
-		Response parameters:    <none>
+                Controller Index:       <controller id>
+                Command parameters:     Address_Type (1 octet)
+                                        Address (6 octets)
+                Response parameters:    <none>
 
-		This command is used to turn the volume down one step on a remote
-		Volume Renderer. During operation, the IUT may send event:
-				VCP State Event
-				VCP Flags Event
-				VCP Procedure Event
+                This command is used to turn the volume down one step on a remote
+                Volume Renderer. During operation, the IUT may send event:
+                                VCP State Event
+                                VCP Flags Event
+                                VCP Procedure Event
 
-	Opcode 0x06 - Volume Up
+        Opcode 0x06 - Volume Up
 
-		Controller Index:       <controller id>
-		Command parameters:     Address_Type (1 octet)
-	                                Address (6 octets)
-		Response parameters:    <none>
+                Controller Index:       <controller id>
+                Command parameters:     Address_Type (1 octet)
+                                        Address (6 octets)
+                Response parameters:    <none>
 
-		This command is used to turn the volume up one step on a remote
-		Volume Renderer. During operation, the IUT may send event:
-				VCP State Event
-				VCP Flags Event
-				VCP Procedure Event
+                This command is used to turn the volume up one step on a remote
+                Volume Renderer. During operation, the IUT may send event:
+                                VCP State Event
+                                VCP Flags Event
+                                VCP Procedure Event
 
-	Opcode 0x07 - Unmute volume down
+        Opcode 0x07 - Unmute volume down
 
-		Controller Index:       <controller id>
-		Command parameters:     Address_Type (1 octet)
-	                                Address (6 octets)
-		Response parameters:    <none>
+                Controller Index:       <controller id>
+                Command parameters:     Address_Type (1 octet)
+                                        Address (6 octets)
+                Response parameters:    <none>
 
-		This command is used to turn the volume down one step and unmute
-		a remote Volume Renderer. During operation, the IUT may send
-		event:
-				VCP State Event
-				VCP Flags Event
-				VCP Procedure Event
+                This command is used to turn the volume down one step and unmute
+                a remote Volume Renderer. During operation, the IUT may send
+                event:
+                                VCP State Event
+                                VCP Flags Event
+                                VCP Procedure Event
 
-	Opcode 0x08 - Unmute volume up
+        Opcode 0x08 - Unmute volume up
 
-		Controller Index:       <controller id>
-		Command parameters:     Address_Type (1 octet)
-	                                Address (6 octets)
-		Response parameters:    <none>
+                Controller Index:       <controller id>
+                Command parameters:     Address_Type (1 octet)
+                                        Address (6 octets)
+                Response parameters:    <none>
 
-		This command is used to turn the volume up one step and unmute
-		a remote Volume Renderer. During operation, the IUT may send
-		event:
-				VCP State Event
-				VCP Flags Event
+                This command is used to turn the volume up one step and unmute
+                a remote Volume Renderer. During operation, the IUT may send
+                event:
+                                VCP State Event
+                                VCP Flags Event
 
-	Opcode 0x09 - Set volume
+        Opcode 0x09 - Set volume
 
-		Controller Index:       <controller id>
-		Command parameters:     Address_Type (1 octet)
-					Address (6 octets)
-	                                Volume (1 octet)
-		Response parameters:    <none>
+                Controller Index:       <controller id>
+                Command parameters:     Address_Type (1 octet)
+                                        Address (6 octets)
+                                        Volume (1 octet)
+                Response parameters:    <none>
 
-		This command is used to set absolute volume on a remote Volume
-		Renderer. During operation, the IUT may send event:
-				VCP State Event
-				VCP Flags Event
-				VCP Procedure Event
+                This command is used to set absolute volume on a remote Volume
+                Renderer. During operation, the IUT may send event:
+                                VCP State Event
+                                VCP Flags Event
+                                VCP Procedure Event
 
-	Opcode 0x0a - Unmute
+        Opcode 0x0a - Unmute
 
-		Controller Index:       <controller id>
-		Command parameters:     Address_Type (1 octet)
-	                                Address (6 octets)
-		Response parameters:    <none>
+                Controller Index:       <controller id>
+                Command parameters:     Address_Type (1 octet)
+                                        Address (6 octets)
+                Response parameters:    <none>
 
-		This command is used to unmute a remote Volume Renderer. During
-		operation, the IUT may send event:
-				VCP State Event
-				VCP Procedure Event
+                This command is used to unmute a remote Volume Renderer. During
+                operation, the IUT may send event:
+                                VCP State Event
+                                VCP Procedure Event
 
-	Opcode 0x0b - Mute
+        Opcode 0x0b - Mute
 
-		Controller Index:       <controller id>
-		Command parameters:     Address_Type (1 octet)
-	                                Address (6 octets)
-		Response parameters:    <none>
+                Controller Index:       <controller id>
+                Command parameters:     Address_Type (1 octet)
+                                        Address (6 octets)
+                Response parameters:    <none>
 
-		This command is used to mute a remote Volume Renderer. During
-		operation, the IUT may send event:
-				VCP State Event
-				VCP Procedure Event
-
-
+                This command is used to mute a remote Volume Renderer. During
+                operation, the IUT may send event:
+                                VCP State Event
+                                VCP Procedure Event
 
 Events:
-	Opcode 0x80 - Discovered Event
+        Opcode 0x80 - Discovered Event
 
-		Controller Index:	<controller id>
-		Event parameters:	Address_Type (1 octet)
-					Address (6 octets)
-					ATT status (1 octet)
-					Volume Control Point handle (2 octets)
-					Volume Flags handle (2 octets)
-					Volume State handle (2 octets)
-					VOCS State handle (2 octets)
-					VOCS Location handle (2 octets)
-					VOCS Control handle (2 octets)
-					VOCS Description handle (2 octets)
-					AICS State handle (2 octets)
-					AICS Gain handle (2 octets)
-					AICS Type handle (2 octets)
-					AICS Status handle (2 octets)
-					AICS Control Point (2 octets)
-					AICS Description (2 octets)
+                Controller Index:       <controller id>
+                Event parameters:       Address_Type (1 octet)
+                                        Address (6 octets)
+                                        ATT status (1 octet)
+                                        Volume Control Point handle (2 octets)
+                                        Volume Flags handle (2 octets)
+                                        Volume State handle (2 octets)
+                                        VOCS State handle (2 octets)
+                                        VOCS Location handle (2 octets)
+                                        VOCS Control handle (2 octets)
+                                        VOCS Description handle (2 octets)
+                                        AICS State handle (2 octets)
+                                        AICS Gain handle (2 octets)
+                                        AICS Type handle (2 octets)
+                                        AICS Status handle (2 octets)
+                                        AICS Control Point (2 octets)
+                                        AICS Description (2 octets)
 
                 This event returns handles of VCP, VOCS and AICS characteristics.
 
         Opcode 0x81 - VCP State Event
 
-                Controller Index:	<controller id>
-		Event parameters:	Address_Type (1 octet)
-					Address (6 octets)
-					ATT status (1 octet)
-					Volume (1 octet)
-					Mute (1 octet)
+                Controller Index:       <controller id>
+                Event parameters:       Address_Type (1 octet)
+                                        Address (6 octets)
+                                        ATT status (1 octet)
+                                        Volume (1 octet)
+                                        Mute (1 octet)
 
-		This event returns Volume State information.
+                This event returns Volume State information.
 
-	Opcode 0x82 - VCP Flags Event
+        Opcode 0x82 - VCP Flags Event
 
-		Controller Index:	<controller id>
-		Event parameters:	Address_Type (1 octet)
-					Address (6 octets)
-					ATT status (1 octet)
-					Flags (1 octet)
+                Controller Index:       <controller id>
+                Event parameters:       Address_Type (1 octet)
+                                        Address (6 octets)
+                                        ATT status (1 octet)
+                                        Flags (1 octet)
 
-		This event returns Volume Flags information.
+                This event returns Volume Flags information.
 
-	Opcode 0x83 - VCP Procedure Event
+        Opcode 0x83 - VCP Procedure Event
 
-		Controller Index:	<controller id>
-		Event parameters:	Address_Type (1 octet)
-					Address (6 octets)
-					ATT status (1 octet)
-					Opcode (1 octet)
+                Controller Index:       <controller id>
+                Event parameters:       Address_Type (1 octet)
+                                        Address (6 octets)
+                                        ATT status (1 octet)
+                                        Opcode (1 octet)
 
-		This event returns VCP operation opcode information.
+                This event returns VCP operation opcode information.
 
 
 

--- a/doc/btp_vcs.txt
+++ b/doc/btp_vcs.txt
@@ -3,63 +3,63 @@ Volume Control Service (ID 8)
 
 Commands and responses:
 
-	Opcode 0x00 - Error response
+        Opcode 0x00 - Error response
 
-	Opcode 0x01 - Read supported commands
-		Controller Index:	<controller id>
-		Command parameters:	<none>
-		Response parameters:	<supported commands> (variable)
+        Opcode 0x01 - Read supported commands
+                Controller Index:       <controller id>
+                Command parameters:     <none>
+                Response parameters:    <supported commands> (variable)
 
-		Each bit in response is a flag indicating if command with
-		opcode matching bit number is supported. Bit set to 1 means
-		that command is supported. Bit 0 is reserved and shall always
-		be set to 0. If specific bit is not present in response (less
-		than required bytes received) it shall be assumed that command
-		is not supported.
+                Each bit in response is a flag indicating if command with
+                opcode matching bit number is supported. Bit set to 1 means
+                that command is supported. Bit 0 is reserved and shall always
+                be set to 0. If specific bit is not present in response (less
+                than required bytes received) it shall be assumed that command
+                is not supported.
 
-		In case of an error, the error response will be returned.
+                In case of an error, the error response will be returned.
 
-	Opcode 0x02 - Set volume command
-		Controller Index:	<controller id>
-		Command parameters:	Volume (1 octet)
-		Response parameters:	<none>
-		
-		This command is used to set absolute volume.
+        Opcode 0x02 - Set volume command
+                Controller Index:       <controller id>
+                Command parameters:     Volume (1 octet)
+                Response parameters:    <none>
+                
+                This command is used to set absolute volume.
 
-		In case of an error, the error response will be returned.
+                In case of an error, the error response will be returned.
 
-	Opcode 0x03 - Volume up
-		Controller Index:	<controller id>
-		Command parameter:	<none>
-		Response parameters:	<none>
+        Opcode 0x03 - Volume up
+                Controller Index:       <controller id>
+                Command parameter:      <none>
+                Response parameters:    <none>
 
-		This command is used for increasing the volume setting in VCS.
+                This command is used for increasing the volume setting in VCS.
 
-		In case of an error, the error reponse will be returned.
+                In case of an error, the error reponse will be returned.
 
-	Opcode 0x04 - Volume down
-		Controller Index:	<controller id>
-		Command parameter:	<none>
-		Response parameters:	<none>
+        Opcode 0x04 - Volume down
+                Controller Index:       <controller id>
+                Command parameter:      <none>
+                Response parameters:    <none>
 
-		This command is used for decreasing the volume setting in VCS.
+                This command is used for decreasing the volume setting in VCS.
 
-		In case of an error, the error response will be returned.
+                In case of an error, the error response will be returned.
 
-	Opcode 0x05 - Mute
-		Controller Index:	<controller id>
-		Command parameter:	<none>
-		Response parameters:	<none>
+        Opcode 0x05 - Mute
+                Controller Index:       <controller id>
+                Command parameter:      <none>
+                Response parameters:    <none>
 
-		This command is used for setting mute value to "mute" in VCS.
+                This command is used for setting mute value to "mute" in VCS.
 
-		In case of an error, the error response will be returned.
+                In case of an error, the error response will be returned.
 
-	Opcode 0x06 - Unmute
-		Controller Index:	<controller id>
-		Command parameter:	<none>
-		Response parameters:	<none>
+        Opcode 0x06 - Unmute
+                Controller Index:       <controller id>
+                Command parameter:      <none>
+                Response parameters:    <none>
 
-		This command is used for setting mute value to "unmute" in VCS.
+                This command is used for setting mute value to "unmute" in VCS.
 
-		In case of an error, the error response will be returned.
+                In case of an error, the error response will be returned.

--- a/doc/btp_vocs.txt
+++ b/doc/btp_vocs.txt
@@ -3,111 +3,111 @@ Volume Offset Control Service (ID 11)
 
 Commands and responses:
 
-	Opcode 0x00 - Error response
+        Opcode 0x00 - Error response
 
-	Opcode 0x01 - Read supported commands
-		Controller Index:	<controller id>
-		Command parameters:	<none>
-		Response parameters:	<supported commands> (variable)
+        Opcode 0x01 - Read supported commands
+                Controller Index:       <controller id>
+                Command parameters:     <none>
+                Response parameters:    <supported commands> (variable)
 
-		Each bit in response is a flag indicating if command with
-		opcode matching bit number is supported. Bit set to 1 means
-		that command is supported. Bit 0 is reserved and shall always
-		be set to 0. If specific bit is not present in response (less
-		than required bytes received) it shall be assumed that command
-		is not supported.
+                Each bit in response is a flag indicating if command with
+                opcode matching bit number is supported. Bit set to 1 means
+                that command is supported. Bit 0 is reserved and shall always
+                be set to 0. If specific bit is not present in response (less
+                than required bytes received) it shall be assumed that command
+                is not supported.
 
-		In case of an error, the error response will be returned.
+                In case of an error, the error response will be returned.
 
-	Opcode 0x02 - Update audio location
+        Opcode 0x02 - Update audio location
 
-		Controller Index:	<controller id>
-		Command parameters:	Location (4 octets)
-		Response parameters:	<none>
+                Controller Index:       <controller id>
+                Command parameters:     Location (4 octets)
+                Response parameters:    <none>
 
-		This command is used to change audio location.
+                This command is used to change audio location.
 
-		In case of an error, the error response will be returned.
+                In case of an error, the error response will be returned.
 
-	Opcode 0x03 - Update audio description
+        Opcode 0x03 - Update audio description
 
-		Controller Index:	<controller id>
-		Command parameters:	Description (string)
-		Response parameters:	<none>
+                Controller Index:       <controller id>
+                Command parameters:     Description (string)
+                Response parameters:    <none>
 
-		This command is used to change audio description.
+                This command is used to change audio description.
 
-		In case of an error, the error response will be returned.
+                In case of an error, the error response will be returned.
 
-	Opcode 0x04 - Offset State Get
+        Opcode 0x04 - Offset State Get
 
-		Controller Index:	<controller id>
-		Command parameters:     Address_Type (1 octet)
-					Address (6 octets)
-		Response parameters:	<none>
+                Controller Index:       <controller id>
+                Command parameters:     Address_Type (1 octet)
+                                        Address (6 octets)
+                Response parameters:    <none>
 
-		This command is used for reading VOCS Offset State characteristic.
-		During operation, the IUT may send event:
-				VOCS Offset State Event
+                This command is used for reading VOCS Offset State characteristic.
+                During operation, the IUT may send event:
+                                VOCS Offset State Event
 
-		In case of an error, the error response will be returned.
+                In case of an error, the error response will be returned.
 
-	Opcode 0x05 - Location Get
+        Opcode 0x05 - Location Get
 
-		Controller Index:	<controller id>
-		Command parameters:     Address_Type (1 octet)
-					Address (6 octets)
-		Response parameters:	<none>
+                Controller Index:       <controller id>
+                Command parameters:     Address_Type (1 octet)
+                                        Address (6 octets)
+                Response parameters:    <none>
 
-		This command is used for reading VOCS Location characteristic.
-		During operation, the IUT may send event:
-				VOCS Audio Location Event
+                This command is used for reading VOCS Location characteristic.
+                During operation, the IUT may send event:
+                                VOCS Audio Location Event
 
-		In case of an error, the error response will be returned.
+                In case of an error, the error response will be returned.
 
-	Opcode 0x06 - Offset State Set
+        Opcode 0x06 - Offset State Set
 
-		Controller Index:	<controller id>
-		Command parameters:     Address_Type (1 octet)
-					Address (6 octets)
-					Offset (2 octets)
-		Response parameters:	<none>
+                Controller Index:       <controller id>
+                Command parameters:     Address_Type (1 octet)
+                                        Address (6 octets)
+                                        Offset (2 octets)
+                Response parameters:    <none>
 
-		This command is used for setting VOCS Offset state. During
-		operation, the IUT may send event:
-				VOCS Offset State Event
-				VOCS Procedure Event
+                This command is used for setting VOCS Offset state. During
+                operation, the IUT may send event:
+                                VOCS Offset State Event
+                                VOCS Procedure Event
 
 Events:
-	Opcode 0x80 - VOCS Offset State event
+        Opcode 0x80 - VOCS Offset State event
 
-		Controller Index:	<controller id>
-		Event parameters:	Address_Type (1 octet)
-					Address (6 octets)
-					ATT status (1 octet)
-					Offset (2 octets)
+                Controller Index:       <controller id>
+                Event parameters:       Address_Type (1 octet)
+                                        Address (6 octets)
+                                        ATT status (1 octet)
+                                        Offset (2 octets)
 
-		This event returns VOCS Offset State information.
+                This event returns VOCS Offset State information.
 
-	Opcode 0x81 - VOCS Audio Location event
+        Opcode 0x81 - VOCS Audio Location event
 
-		Controller Index:	<controller id>
-		Event parameters:	Address_Type (1 octet)
-					Address (6 octets)
-					ATT status (1 octet)
-					Location (4 octets)
+                Controller Index:       <controller id>
+                Event parameters:       Address_Type (1 octet)
+                                        Address (6 octets)
+                                        ATT status (1 octet)
+                                        Location (4 octets)
 
-		This event returns VOCS Audio Location information.
+                This event returns VOCS Audio Location information.
 
-	Opcode 0x82 - VOCS Procedure Event
+        Opcode 0x82 - VOCS Procedure Event
 
-		Controller Index:	<controller id>
-		Event parameters:	Address_Type (1 octet)
-					Address (6 octets)
-					ATT status (1 octet)
-					Opcode (1 octet)
+                Controller Index:       <controller id>
+                Event parameters:       Address_Type (1 octet)
+                                        Address (6 octets)
+                                        ATT status (1 octet)
+                                        Opcode (1 octet)
 
-		This event returns VOCS operation opcode information.
+                This event returns VOCS operation opcode information.
 
 
 

--- a/doc/overview.txt
+++ b/doc/overview.txt
@@ -20,18 +20,18 @@ to signal notifications.
 Commands and events use single socket. All services are multi-plexed over same
 socket.
 
-	.--  IUT  --.                             .--Tester--.
-	|           |                             |          |
-	|           |          Command            |          |
-	|           | <-------------------------- |          |
-	|           |                             |          |
-	|           |          Response           |          |
-	|           | --------------------------> |          |
-	|           |                             |          |
-	|           |           Event             |          |
-	|           | --------------------------> |          |
-	|           |                             |          |
-	'-----------'                             '----------'
+        .--  IUT  --.                             .--Tester--.
+        |           |                             |          |
+        |           |          Command            |          |
+        |           | <-------------------------- |          |
+        |           |                             |          |
+        |           |          Response           |          |
+        |           | --------------------------> |          |
+        |           |                             |          |
+        |           |           Event             |          |
+        |           | --------------------------> |          |
+        |           |                             |          |
+        '-----------'                             '----------'
 
 
 Packet Structures
@@ -42,11 +42,11 @@ over the same socket. It will also support a basic control channel with service
 id 0. Due to use of single socket for command/response and events it is
 possible that event(s) will be received before response to command.
 
-	0            8       16                  24            40
-	+------------+--------+------------------+-------------+
-	| Service ID | Opcode | Controller Index | Data Length |
-	+------------+--------+------------------+-------------+
-	|                                                      |
+        0            8       16                  24            40
+        +------------+--------+------------------+-------------+
+        | Service ID | Opcode | Controller Index | Data Length |
+        +------------+--------+------------------+-------------+
+        |                                                      |
 
 The unique service ID is assigned by this specification for each service
 supported by tester.
@@ -61,19 +61,19 @@ All fields are in little-endian byte order (least significant byte first).
 Controller Index can have a special value <non-controller> to indicate that
 command or event is not related to any controller. Possible values:
 
-	<controller id>		0x00 to 0xFE
-	<non-controller>	0xFF
+        <controller id>         0x00 to 0xFE
+        <non-controller>        0xFF
 
 Error response is common for all services and has fixed structure:
 
-	Opcode 0x00 - Error response
+        Opcode 0x00 - Error response
 
-		Response parameters: Status (1 octet)
+                Response parameters: Status (1 octet)
 
-		Valid status values:	0x01 = Fail
-					0x02 = Unknown Command
-					0x03 = Not ready
-					0x04 = Invalid Index
+                Valid status values:    0x01 = Fail
+                                        0x02 = Unknown Command
+                                        0x03 = Not ready
+                                        0x04 = Invalid Index
 
 
 BTP Services


### PR DESCRIPTION
This unify documentation format, initial idea was to use tabs (8 spaces wide) for indentation but this seems to be causing discrepancies in editors and with time it was not really coherent (various places asuming 4 spaces tabs, or indentation with spaces only).

Just unify this and use spaces for indentation (8 spaces for level).

This also fixes some convention discrepancies in BTP descriptions so it is easier to follow.