### PR TITLE
boards: mynewt: Fix setting JLINK_SN under Windows

### DIFF
--- a/autopts/ptsprojects/boards/nordic_pca10056.py
+++ b/autopts/ptsprojects/boards/nordic_pca10056.py
@@ -15,7 +15,7 @@
 #
 
 import logging
-from autopts.bot.common import check_call
+from autopts.bot.mynewt import check_call
 
 supported_projects = ['mynewt']
 board_type = 'nordic_pca10056'

--- a/autopts/ptsprojects/boards/nordic_pca10095.py
+++ b/autopts/ptsprojects/boards/nordic_pca10095.py
@@ -15,7 +15,7 @@
 #
 
 import logging
-from autopts.bot.common import check_call
+from autopts.bot.mynewt import check_call
 
 # Note: always specify tty or COM in 'tty_file' of app core in config.py.
 # Otherwise, net core could be selected and BTP timeouts will occur.


### PR DESCRIPTION
Usage of MSYS2_BASH_PATH variable in check_call ensures that the right bash from msys2 is being used.