### PR TITLE
errata: Remove CSIP errata and sleep

### DIFF
--- a/autopts/client.py
+++ b/autopts/client.py
@@ -1154,18 +1154,6 @@ def run_test_case(ptses, test_case_instances, test_case_name, stats,
     thread_list = []
 
     for thread_count, (test_case_lt, pts) in enumerate(zip(test_case_lts, ptses), 1):
-        if test_case_name.startswith("CSIP/CL/SP") and len(ptses) > 1:
-            # The following tests have shown issues with IRKs being duplicated in one or more lower testers:
-            # - CSIP/CL/SPE/BI-01-C
-            # - CSIP/CL/SP/BV-07-C
-            # - CSIP/CL/SP/BV-03-C
-            # - CSIP/CL/SP/BV-04-C
-            #
-            # Adding a sleep between each lower tester thread start seem to circumvent this issue
-            # but not solve it. Local testing has shown that at least 3 seconds of sleep is required.
-            # The sleep time has been set to 10 to add additional robustness.
-            # This is related to Request ID 147314
-            time.sleep(10)
         thread = LTThread(
             name=f'LT{thread_count}-thread',
             args=(pts, test_case_lt, exceptions, finish_count))

--- a/errata/common.yaml
+++ b/errata/common.yaml
@@ -4,9 +4,3 @@
 
 GAP/GAT/BV-16-C: ES-26322
 GAP/GAT/BV-17-C: ES-26322
-
-# This errata affect so many cases (any test, including non-CSIP) that uses multiple connected lower testers, but we only track it for CSIP where it's most common
-CSIP/CL/SP/BV-03-C: Request ID 147314
-CSIP/CL/SP/BV-04-C: Request ID 147314
-CSIP/CL/SP/BV-07-C: Request ID 147314
-CSIP/CL/SPE/BI-01-C: Request ID 147314


### PR DESCRIPTION
The fix has been incorperated in PTS and the errata list and the sleep workaround has been updated.