### PR TITLE
bot:mynewt:checkcall: Edit check_call include wsl and project path

### DIFF
--- a/autopts/bot/mynewt.py
+++ b/autopts/bot/mynewt.py
@@ -36,7 +36,11 @@ PROJECT_NAME = Path(__file__).stem
 def check_call(cmd, env=None, cwd=None, shell=True):
     if sys.platform == 'win32':
         cmd = subprocess.list2cmdline(cmd)
-        cmd = [os.path.expandvars('$MSYS2_BASH_PATH'), '-c', cmd]
+        if cwd.startswith('wsl:'):
+            cmd = ["wsl.exe", "--cd", cwd.removeprefix('wsl:'), "--", "/bin/bash", "-i", "-c", cmd]
+            cwd = None
+        else:
+            cmd = [os.path.expandvars('$MSYS2_BASH_PATH'), '-c', cmd]
     return bot.common.check_call(cmd, env, cwd, shell)
 
 


### PR DESCRIPTION
Introduces support for project paths running in the Windows Subsystem for Linux (WSL) environment in the check_call function. The change is to add a condition that checks whether the current working directory (cwd) begins with the 'wsl:' prefix. If so, the function modifies the command (cmd) to run it in a WSL environment with the appropriate path, removing the 'wsl:' prefix from cwd. This allows commands to be executed correctly both in the native Windows environment and in WSL, depending on the project path format.

For example, if the project is located in the /usr/local/dev/mynewt_workspace/my_project directory in WSL, the corresponding prefixed path would be:
`'project_path': r'wsl:/usr/local/dev/mynewt_workspace/my_project'`
