### PR TITLE
BAP: Remove straggling broadcast_id

### DIFF
--- a/autopts/wid/bap.py
+++ b/autopts/wid/bap.py
@@ -2038,7 +2038,7 @@ def hdl_wid_380(_: WIDParams):
     subgroups = 1
     broadcast_id = btp.bap_broadcast_source_setup(
         streams_per_subgroup, subgroups, coding_format, vid, cid,
-        codec_ltvs_bytes, *qos_config, presentation_delay, broadcast_id)
+        codec_ltvs_bytes, *qos_config, presentation_delay)
 
     stack.bap.broadcast_id = broadcast_id
 


### PR DESCRIPTION
- Due to refactoring of PR#1366, an extra argument got left behind