### PR TITLE
Only set broadcast_ID for SCC/BV-38-C

### DIFF
--- a/autopts/ptsprojects/zephyr/bap.py
+++ b/autopts/ptsprojects/zephyr/bap.py
@@ -55,8 +55,6 @@ def set_pixits(ptses):
     pts.set_pixit("BAP", "TSPX_VS_Codec_ID", "ffff")
     pts.set_pixit("BAP", "TSPX_VS_Company_ID", "ffff")
     pts.set_pixit("BAP", "TSPX_broadcast_code", BROADCAST_CODE)
-    pts.set_pixit("BAP", "TSPX_Broadcast_ID", BROADCAST_ID)
-    pts.set_pixit("BAP", "TSPX_Broadcast_ID_2", BROADCAST_ID_2)
 
     if len(ptses) < 2:
         return
@@ -131,8 +129,6 @@ def test_cases(ptses):
                       TestFunc(lambda: stack.bap.set_broadcast_code(BROADCAST_CODE)),
                       TestFunc(lambda: set_addr(
                           stack.gap.iut_addr_get_str())),
-                      TestFunc(lambda: stack.bap.set_broadcast_id(BROADCAST_ID)),
-                      TestFunc(lambda: stack.bap.set_broadcast_id_2(BROADCAST_ID_2)),
                       ]
 
     pre_conditions_server = pre_conditions + [
@@ -146,6 +142,18 @@ def test_cases(ptses):
     ]
 
     custom_test_cases = [
+        # If TSPX_Broadcast_ID is set, then PTS will use that for validation,
+        # and since BAP/BSRC/SCC/BV-38-C is the only test that uses the v2 command,
+        # then only this test can reliably set TSPX_Broadcast_ID (and TSPX_Broadcast_ID_2)
+        ZTestCase("BAP", "BAP/BSRC/SCC/BV-38-C",
+                  cmds=pre_conditions +
+                         [TestFunc(lambda: pts.update_pixit_param(
+                          "BAP", "TSPX_Broadcast_ID", BROADCAST_ID)),
+                         TestFunc(lambda: pts.update_pixit_param(
+                          "BAP", "TSPX_Broadcast_ID_2", BROADCAST_ID_2)),
+                         TestFunc(lambda: stack.bap.set_broadcast_id(BROADCAST_ID)),
+                         TestFunc(lambda: stack.bap.set_broadcast_id_2(BROADCAST_ID_2))],
+                  generic_wid_hdl=bap_wid_hdl),
         # Errata in progress since the PTS should use
         # TSPX_VS_Company_ID and TSPX_VS_Codec_ID instead.
         ZTestCase("BAP", "BAP/UCL/SCC/BV-033-C",

--- a/autopts/wid/bap.py
+++ b/autopts/wid/bap.py
@@ -21,8 +21,6 @@ from autopts.ptsprojects.stack import get_stack, WildCard
 from autopts.ptsprojects.testcase import MMI
 from autopts.pybtp import btp
 from autopts.pybtp.btp import pts_addr_get, pts_addr_type_get, ascs_add_ase_to_cis, lt2_addr_get, lt2_addr_type_get
-from autopts.pybtp.btp.btp import CONTROLLER_INDEX, btp_hdr_check, get_iut_method as get_iut, pts_addr_get, \
-    pts_addr_type_get
 from autopts.pybtp.types import *
 from autopts.wid import generic_wid_hdl
 
@@ -326,6 +324,7 @@ def hdl_wid_114(params: WIDParams):
         broadcast_id = btp.bap_broadcast_source_setup(streams_per_subgroup, subgroups,
                                                       coding_format, vid, cid, codec_ltvs_bytes,
                                                       *qos_config, presentation_delay)
+        stack.bap.set_broadcast_id(broadcast_id)
 
     btp.bap_broadcast_adv_start(broadcast_id)
 
@@ -2032,7 +2031,6 @@ def hdl_wid_380(_: WIDParams):
                                              audio_locations, octets_per_frame,
                                              frames_per_sdu)
 
-    broadcast_id = 0x123456
     presentation_delay = 40000
     streams_per_subgroup = 2
     subgroups = 1


### PR DESCRIPTION
- Add custom case for BAP/BSRC/SCC/BV-38-C to set broadcast_ID
- Fixes regression for BAP/BSRC
 - These get a random broadcast_ID, so the IXIT value should not be set