### PR TITLE
TMAP: Allow time for broadcast to stop

### DIFF
--- a/autopts/wid/tmap.py
+++ b/autopts/wid/tmap.py
@@ -16,6 +16,7 @@
 import logging
 
 import re
+import time
 from argparse import Namespace
 
 from autopts.ptsprojects.stack import get_stack
@@ -562,6 +563,7 @@ def hdl_wid_506(params: WIDParams):
     source_id = 0x00
     btp.cap_broadcast_adv_stop(source_id)
     btp.cap_broadcast_source_stop(source_id)
+    time.sleep(10) # Allow some time for the stack to stop the broadcast
     btp.cap_broadcast_source_release(source_id)
 
     # Get Audio Locations from description


### PR DESCRIPTION
- Add sleep to allow time between stop and release
- Fixes TMAP/BMS/ASC/BV-01-C