### PR TITLE
doc/btp_gap: add filter accept list flag to discovery

### DIFF
--- a/doc/btp_gap.txt
+++ b/doc/btp_gap.txt
@@ -202,6 +202,7 @@ Commands and responses:
                         3 = Use active scan type
                         4 = Use observation procedure
                         5 = Use own ID address
+                        6 = Use filter accept list
 
                 This command is used to start discovery.
 
@@ -211,6 +212,8 @@ Commands and responses:
                 discoverable). This procedure can use either passive or active
                 scan type. If "Use observation procedure" (bit 4) is set,
                 "Use limited discovery procedure" (bit 2) is excluded.
+                If "Use filter accept list" (bit 6) is set, then the filter
+                accept list will be used to filter discovered devices.
 
                 In case of an error, the error response will be returned.
 


### PR DESCRIPTION
Add "use filter accept list" flag to Start Discovery.

Previously the BTP specification did not really say whether or not the filter accept list should be used for scan results.

This caused some confusion at least on our end, as we expected the accept list to apply for scanning as well. Now the application can explicitly say whether it wants to use the filtering or not. Any existing implementations that don't parse this flag will continue to behave the same way they used to, so this shouldn't cause backwards compatibility problems.