### PR TITLE
bluez: Update current support

### DIFF
--- a/autopts/ptsprojects/bluez/btestcase.py
+++ b/autopts/ptsprojects/bluez/btestcase.py
@@ -2,6 +2,7 @@
 # auto-pts - The Bluetooth PTS Automation Framework
 #
 # Copyright (c) 2017, Intel Corporation.
+# Copyright 2025 NXP
 #
 # This program is free software; you can redistribute it and/or modify it
 # under the terms and conditions of the GNU General Public License,
@@ -33,7 +34,7 @@ class BTestCase(TestCaseLT1):
         self.bluezctrl = get_iut()
 
         # first command is to start bluez btpclient
-        self.cmds.insert(0, TestFunc(self.bluezctrl.start))
+        self.cmds.insert(0, TestFunc(self.bluezctrl.start, self))
         self.cmds.insert(1, TestFunc(self.bluezctrl.wait_iut_ready_event))
 
         self.cmds.append(TestFuncCleanUp(self.stack.cleanup))

--- a/autopts/ptsprojects/bluez/gap.py
+++ b/autopts/ptsprojects/bluez/gap.py
@@ -2,6 +2,7 @@
 # auto-pts - The Bluetooth PTS Automation Framework
 #
 # Copyright (c) 2017, Intel Corporation.
+# Copyright 2025 NXP
 #
 # This program is free software; you can redistribute it and/or modify it
 # under the terms and conditions of the GNU General Public License,
@@ -16,7 +17,7 @@
 """GAP test cases"""
 
 from autopts.pybtp import btp
-from autopts.pybtp.types import Addr, IOCap, UUID, Prop, Perm, AdType
+from autopts.pybtp.types import Addr, IOCap, UUID, Prop, Perm, AdType, AdFlags
 from autopts.client import get_unique_name
 from autopts.wid.gap import hdl_wid_161
 from autopts.ptsprojects.stack import get_stack
@@ -116,13 +117,12 @@ def set_pixits(ptses):
     pts.set_pixit("GAP", "TSPX_maximum_ce_length", "0000")
     pts.set_pixit("GAP", "TSPX_conn_update_int_min", "0032")
     pts.set_pixit("GAP", "TSPX_conn_update_int_max", "0046")
-    pts.set_pixit("GAP", "TSPX_conn_update_slave_latency", "0001")
+    pts.set_pixit("GAP", "TSPX_conn_update_peripheral_latency", "0001")
     pts.set_pixit("GAP", "TSPX_conn_update_supervision_timeout", "01F4")
     pts.set_pixit("GAP", "TSPX_pairing_before_service_request", "FALSE")
     pts.set_pixit("GAP", "TSPX_iut_mandates_mitm", "FALSE")
     pts.set_pixit("GAP", "TSPX_encryption_before_service_request", "FALSE")
     pts.set_pixit("GAP", "TSPX_tester_appearance", "0000")
-    pts.set_pixit("GAP", "TSPX_advertising_data", "")
     pts.set_pixit("GAP", "TSPX_iut_device_IRK_for_resolvable_privacy_address_generation_procedure",
                   "00000000000000000000000000000000")
     pts.set_pixit("GAP", "TSPX_tester_device_IRK_for_resolvable_privacy_address_generation_procedure",
@@ -139,11 +139,15 @@ def test_cases(ptses):
 
     pts = ptses[0]
 
+    ad_str_flags = str(AdType.flags).zfill(2) + \
+                   str(AdFlags.br_edr_not_supp).zfill(2)
+    ad_str_flags_len = str(len(ad_str_flags) // 2).zfill(2)
+
     ad_str_manufacturer_data = str(format(AdType.manufacturer_data, 'x')).zfill(2) + \
                                iut_manufacturer_data
-    ad_str_manufacturer_data_len = str(len(ad_str_manufacturer_data) / 2).zfill(2)
+    ad_str_manufacturer_data_len = str(len(ad_str_manufacturer_data) // 2).zfill(2)
 
-    ad_pixit = ad_str_manufacturer_data_len + ad_str_manufacturer_data
+    ad_pixit = ad_str_flags_len + ad_str_flags + ad_str_manufacturer_data_len + ad_str_manufacturer_data
 
     pts_bd_addr = pts.q_bd_addr
     iut_device_name = get_unique_name(pts)
@@ -167,7 +171,7 @@ def test_cases(ptses):
             "GAP", "TSPX_using_public_device_address",
             "FALSE" if stack.gap.iut_addr_is_random() else "TRUE")),
         TestFunc(lambda: pts.update_pixit_param(
-            "GAP", "TSPX_using_private_device_address",
+            "GAP", "TSPX_using_random_device_address",
             "TRUE" if stack.gap.iut_addr_is_random() else "FALSE")),
         TestFunc(lambda: pts.update_pixit_param(
             "GAP", "TSPX_iut_device_name_in_adv_packet_for_random_address", iut_device_name)),

--- a/autopts/ptsprojects/bluez/iutctl.py
+++ b/autopts/ptsprojects/bluez/iutctl.py
@@ -2,6 +2,7 @@
 # auto-pts - The Bluetooth PTS Automation Framework
 #
 # Copyright (c) 2017, Intel Corporation.
+# Copyright 2025 NXP
 #
 # This program is free software; you can redistribute it and/or modify it
 # under the terms and conditions of the GNU General Public License,
@@ -52,11 +53,11 @@ class IUTCtl:
         self.socket_srv = None
         self.iut_process = None
 
-    def start(self):
+    def start(self, test_case):
         """Starts the IUT"""
 
         log("%s.%s", self.__class__, self.start.__name__)
-        self.socket_srv = BTPSocketSrv()
+        self.socket_srv = BTPSocketSrv(test_case.log_dir)
         self.socket_srv.open(self.btp_address)
         self.btp_socket = BTPWorker(self.socket_srv)
 

--- a/autopts/ptsprojects/bluez/sm.py
+++ b/autopts/ptsprojects/bluez/sm.py
@@ -2,6 +2,7 @@
 # auto-pts - The Bluetooth PTS Automation Framework
 #
 # Copyright (c) 2017, Intel Corporation.
+# Copyright 2025 NXP
 #
 # This program is free software; you can redistribute it and/or modify it
 # under the terms and conditions of the GNU General Public License,
@@ -36,67 +37,14 @@ def set_pixits(ptses):
     pts = ptses[0]
 
     pts.set_pixit("SM", "TSPX_bd_addr_iut", "DEADBEEFDEAD")
-    pts.set_pixit("SM", "TSPX_SMP_pin_code", "111111")
     pts.set_pixit("SM", "TSPX_OOB_Data", "0000000000000000FE12036E5A889F4D")
-    pts.set_pixit("SM", "TSPX_peer_addr_type", "00")
-    pts.set_pixit("SM", "TSPX_own_addr_type", "00")
-    pts.set_pixit("SM", "TSPX_conn_interval_min", "0190")
-    pts.set_pixit("SM", "TSPX_conn_interval_max", "0190")
-    pts.set_pixit("SM", "TSPX_conn_latency", "0000")
-    pts.set_pixit("SM", "TSPX_client_class_of_device", "100104")
-    pts.set_pixit("SM", "TSPX_server_class_of_device", "100104")
-    pts.set_pixit("SM", "TSPX_security_enabled", "TRUE")
-    pts.set_pixit("SM", "TSPX_delete_link_key", "TRUE")
-    pts.set_pixit("SM", "TSPX_pin_code", "1234")
     pts.set_pixit("SM", "TSPX_ATTR_HANDLE", "0000")
     pts.set_pixit("SM", "TSPX_ATTR_VALUE", "0000000000000000")
-    pts.set_pixit("SM", "TSPX_delay_variation_in", "FFFFFFFF")
-    pts.set_pixit("SM", "TSPX_delay_variation_out", "FFFFFFFF")
-    pts.set_pixit("SM", "TSPX_flushto", "FFFF")
-    pts.set_pixit("SM", "TSPX_inmtu", "02A0")
-    pts.set_pixit("SM", "TSPX_inquiry_length", "17")
-    pts.set_pixit("SM", "TSPX_latency_in", "FFFFFFFF")
-    pts.set_pixit("SM", "TSPX_latency_out", "FFFFFFFF")
-    pts.set_pixit("SM", "TSPX_linkto", "3000")
-    pts.set_pixit("SM", "TSPX_max_nbr_retransmissions", "10")
-    pts.set_pixit("SM", "TSPX_no_fail_verdicts", "FALSE")
-    pts.set_pixit("SM", "TSPX_outmtu", "02A0")
     pts.set_pixit("SM", "TSPX_tester_role_optional", "L2CAP_ROLE_INITIATOR")
-    pts.set_pixit("SM", "TSPX_page_scan_mode", "00")
-    pts.set_pixit("SM", "TSPX_page_scan_repetition_mode", "00")
-    pts.set_pixit("SM", "TSPX_peak_bandwidth_in", "00000000")
-    pts.set_pixit("SM", "TSPX_peak_bandwidth_out", "00000000")
-    pts.set_pixit("SM", "TSPX_psm", "0011")
-    pts.set_pixit("SM", "TSPX_service_type_in", "01")
-    pts.set_pixit("SM", "TSPX_service_type_out", "01")
-    pts.set_pixit("SM", "TSPX_support_retransmissions", "TRUE")
     pts.set_pixit("SM", "TSPX_time_guard", "180000")
-    pts.set_pixit("SM", "TSPX_timer_ertx", "120000")
-    pts.set_pixit("SM", "TSPX_timer_ertx_max", "300000")
-    pts.set_pixit("SM", "TSPX_timer_ertx_min", "60000")
-    pts.set_pixit("SM", "TSPX_timer_rtx", "10000")
-    pts.set_pixit("SM", "TSPX_timer_rtx_max", "60000")
-    pts.set_pixit("SM", "TSPX_timer_rtx_min", "1000")
-    pts.set_pixit("SM", "TSPX_token_bucket_size_in", "00000000")
-    pts.set_pixit("SM", "TSPX_token_bucket_size_out", "00000000")
-    pts.set_pixit("SM", "TSPX_token_rate_in", "00000000")
-    pts.set_pixit("SM", "TSPX_token_rate_out", "00000000")
-    pts.set_pixit("SM", "TSPX_rfc_mode_mode", "03")
-    pts.set_pixit("SM", "TSPX_rfc_mode_tx_window_size", "08")
-    pts.set_pixit("SM", "TSPX_rfc_mode_max_transmit", "03")
-    pts.set_pixit("SM", "TSPX_rfc_mode_retransmission_timeout", "07D0")
-    pts.set_pixit("SM", "TSPX_rfc_mode_monitor_timeout", "2EE0")
-    pts.set_pixit("SM", "TSPX_rfc_mode_maximum_pdu_size", "02A0")
-    pts.set_pixit("SM", "TSPX_extended_window_size", "0012")
     pts.set_pixit("SM", "TSPX_use_implicit_send", "TRUE")
-    pts.set_pixit("SM", "TSPX_use_dynamic_pin", "FALSE")
-    pts.set_pixit("SM", "TSPX_iut_SDU_size_in_bytes", "144")
-    pts.set_pixit("SM", "TSPX_secure_simple_pairing_pass_key_confirmation",
-                  "FALSE")
     pts.set_pixit("SM", "TSPX_Min_Encryption_Key_Length", "07")
     pts.set_pixit("SM", "TSPX_Bonding_Flags", "00")
-    pts.set_pixit("SM", "TSPX_delete_ltk", "FALSE")
-    pts.set_pixit("SM", "TSPX_mtu_size", "23")
     pts.set_pixit("SM", "TSPX_new_key_failed_count", "0")
 
 
@@ -117,9 +65,6 @@ def test_cases(ptses):
                       TestFunc(lambda: pts.update_pixit_param(
                           "SM", "TSPX_bd_addr_iut",
                           stack.gap.iut_addr_get_str())),
-                      TestFunc(lambda: pts.update_pixit_param(
-                          "SM", "TSPX_peer_addr_type",
-                          "01" if stack.gap.iut_addr_is_random() else "00")),
                       # FIXME Find better place to store PTS bdaddr
                       TestFunc(btp.set_pts_addr, pts_bd_addr, Addr.le_public)]
 

--- a/autopts/workspaces/bluez/bluez.pqw6
+++ b/autopts/workspaces/bluez/bluez.pqw6
@@ -1824,8 +1824,8 @@
             <Value>0046</Value>
           </Row>
           <Row>
-            <Name>TSPX_conn_update_slave_latency</Name>
-            <Description>Connection Update Slave Latency to be used. (Default: 0001)</Description>
+            <Name>TSPX_conn_update_peripheral_latency</Name>
+            <Description>Connection Update Peripheral Latency to be used. (Default: 0001)</Description>
             <Type>OCTETSTRING</Type>
             <Value>0001</Value>
           </Row>


### PR DESCRIPTION
This updates the current BlueZ AutoPTS support:

- Remove/update invalid PIXITs
- Pass path to log file when starting the IUT, to avoid the error below:

2025-03-13 10:26:13,234 LT1-thread root ERROR client.py: 
expected str, bytes or os.PathLike object, not NoneType
Traceback (most recent call last):
  File "/home/iulia/auto-pts/autopts/client.py", line 967, in _run_test_case
    test_case.pre_run()
  File "/home/iulia/auto-pts/autopts/ptsprojects/testcase.py", line 745, in pre_run
    cmd.start()
  File "/home/iulia/auto-pts/autopts/ptsprojects/testcase.py", line 267, in start
    self.func(*args, **self.kwds)
  File "/home/iulia/auto-pts/autopts/ptsprojects/bluez/iutctl.py", line 59, in start
    self.socket_srv = BTPSocketSrv()
                      ^^^^^^^^^^^^^^
  File "/home/iulia/auto-pts/autopts/pybtp/iutctl_common.py", line 215, in __init__
    super().__init__(log_dir)
  File "/home/iulia/auto-pts/autopts/pybtp/iutctl_common.py", line 56, in __init__
    self.log_file = open(os.path.join(log_dir, "autopts-iutctl.log"), "a")

- Add "BR/EDR not supported" flag in TSPX_advertising_data, since this flag is always added in advertising data for controllers with LE support