### PR TITLE
Force pairing for CSIP tests

### DIFF
--- a/autopts/wid/csip.py
+++ b/autopts/wid/csip.py
@@ -177,7 +177,10 @@ def hdl_wid_20100(params: WIDParams):
 
     btp.gap_conn(addr, addr_type)
     stack.gap.wait_for_connection(timeout=10, addr=addr)
-    stack.gap.gap_wait_for_sec_lvl_change(level=2, timeout=30, addr=addr)
+    sec_lvl = stack.gap.gap_wait_for_sec_lvl_change(level=2, timeout=10, addr=addr)
+    if sec_lvl != 2:
+        btp.gap_pair(addr, addr_type)
+        stack.gap.gap_wait_for_sec_lvl_change(level=2, timeout=30, addr=addr)
 
     #CSIP/CL/SP/BV-07-C will receive the WID 20101. Hence, no need to perform discovery here.
 


### PR DESCRIPTION
PTS can be sloppy with requesting pairing from IUT for CSIP tests, being a particular problem in CSIP/CL/SP/BV-07-C. With unfortunate timing this can lead to the IUT never receiving a pairing-request from a lower tester, and with some controllers this happens consistently. This commit forces the IUT to initiate pairing, regardless of a request from the lower tester being received or not.