### PR TITLE
wid: Fix GATT/SR/GAI/BV-01-C and GATT/SR/GAN/BV-01-C

### DIFF
--- a/autopts/wid/gatt.py
+++ b/autopts/wid/gatt.py
@@ -1686,7 +1686,14 @@ def hdl_wid_122(_: WIDParams):
     return '0000'
 
 
-def hdl_wid_130(_: WIDParams):
+def hdl_wid_130(params: WIDParams):
+    # Please delete security key before connecting to PTS if IUT was bonded previously.
+    btp.gap_unpair()
+
+    # This is needed until ES-27410 is incorporated
+    if params.test_case_name in ['GATT/SR/GAI/BV-01-C', 'GATT/SR/GAN/BV-01-C']:
+       btp.gap_set_bondable_off();
+
     return True
 
 


### PR DESCRIPTION
Those tests require non-bonding pairing if EATT is in used. WID 130 is used to ensure that no previous bond is present on IUT. Use it to tune IUT to non-bondable mode until ES-27410 is incorporated.