### PR TITLE
autopts: bot: common_features: report.py

### DIFF
--- a/autopts/bot/common_features/report.py
+++ b/autopts/bot/common_features/report.py
@@ -432,7 +432,7 @@ def pull_server_logs(args, tmp_dir, xml_folder):
                 file_bin = _pts.copy_file(file_path)
 
                 if not any(file_path.endswith(ext) for ext in
-                           ['.pts', '.pqw6', '.xlsx', '.gitignore', '.bls', '.bqw']):
+                           ['.pts', '.pqw6', '.xlsx', '.gitignore', '.bls', '.bqw', '.btt']):
                     _pts.delete_file(file_path)
 
                 if file_bin is None:


### PR DESCRIPTION
This PR adds support for the .btt file extension in the _pull_logs function to prevent errors related to file access conflicts during report cleanup.

The error occurred because .btt files—generated by the Ellisys Bluetooth Analyzer in the background—were not excluded from deletion, causing permission issues when they were still in use by the analyzer.

Example of the error:
xmlrpc.client.Fault: <Fault 1: "<class 'PermissionError'>:[WinError 32] The process cannot access the file because it is being used by another process: '...GAP_BROB_BCST_BV_04_C_2025_03_24_14_23_13.btt'">
