### PR TITLE
boards: Use sysbuild for nrf53

### DIFF
--- a/autopts/ptsprojects/boards/nrf53.py
+++ b/autopts/ptsprojects/boards/nrf53.py
@@ -12,12 +12,14 @@
 # FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
 # more details.
 #
+import logging
+import os
 
 from .nrf5x import *
 from autopts.bot.common import check_call
+from subprocess import CalledProcessError
 
 board_type = 'nrf5340dk/nrf5340/cpuapp'
-
 
 def build_and_flash(zephyr_wd, board, debugger_snr, conf_file=None, *args):
     """Build and flash Zephyr binary
@@ -30,22 +32,17 @@ def build_and_flash(zephyr_wd, board, debugger_snr, conf_file=None, *args):
                   board, conf_file)
 
     tester_dir = os.path.join(zephyr_wd, 'tests', 'bluetooth', 'tester')
-    controller_dir = os.path.join(zephyr_wd, 'samples', 'bluetooth', 'hci_ipc')
 
     check_call('rm -rf build/'.split(), cwd=tester_dir)
-    check_call('rm -rf build/'.split(), cwd=controller_dir)
 
     bttester_overlay = 'hci_ipc.conf'
 
     if conf_file and conf_file != 'default' and conf_file != 'prj.conf':
         bttester_overlay += f';{conf_file}'
 
-    cmd = ['west', 'build', '--no-sysbuild', '-b', board, '--', f'-DEXTRA_CONF_FILE=\'{bttester_overlay}\'']
+    cmd = ['west', 'build', '--sysbuild', '-b', board, '--', f'-DEXTRA_CONF_FILE=\'{bttester_overlay}\'']
     check_call(cmd, cwd=tester_dir)
-    check_call(['west', 'flash', '--skip-rebuild', '--recover', '-i', debugger_snr], cwd=tester_dir)
-
-    cmd = ['west', 'build', '--no-sysbuild', '-b', 'nrf5340dk/nrf5340/cpunet', '--',
-           f'-DEXTRA_CONF_FILE=\'nrf5340_cpunet_iso-bt_ll_sw_split.conf;'
-           f'../../../tests/bluetooth/tester/hci_ipc_cpunet.conf\'']
-    check_call(cmd, cwd=controller_dir)
-    check_call(['west', 'flash', '--skip-rebuild', '-i', debugger_snr], cwd=controller_dir)
+    try:
+        check_call(['west', 'flash', '--skip-rebuild', '-i', debugger_snr], cwd=tester_dir)
+    except CalledProcessError:
+        check_call(['west', 'flash', '--skip-rebuild', '--recover', '-i', debugger_snr], cwd=tester_dir)


### PR DESCRIPTION
Update the nrf53.py file so that it uses sysbuild rather than explicitly building the network and application core separately.