### PR TITLE
boards: Remove uses of overlay-le-audio-ctlr

### DIFF
--- a/autopts/ptsprojects/boards/frdm_mcxw71.py
+++ b/autopts/ptsprojects/boards/frdm_mcxw71.py
@@ -45,9 +45,7 @@ def build_and_flash(zephyr_wd, board, debugger_snr, conf_file=None, *args):
     check_call('rm -rf build/'.split(), cwd=tester_dir)
 
     cmd = ['west', 'build', '-p', 'auto', '-b', board]
-    if conf_file and conf_file not in ['default', 'prj.conf']:
-        if 'audio' in conf_file:
-            conf_file += ';overlay-le-audio-ctlr.conf'
+    if conf_file and conf_file not in ["default", "prj.conf"]:
         cmd.extend(('--', f'-DOVERLAY_CONFIG=\'{conf_file}\''))
     logging.info(f'cmd:{cmd}, tester_dir:{tester_dir}')
     check_call(cmd, cwd=tester_dir)

--- a/autopts/ptsprojects/boards/nrf54h.py
+++ b/autopts/ptsprojects/boards/nrf54h.py
@@ -46,9 +46,7 @@ def build_and_flash(zephyr_wd, board, debugger_snr, conf_file=None, *args):
     check_call('rm -rf build/'.split(), cwd=tester_dir)
 
     cmd = ['west', 'build', '--sysbuild', '-p', 'auto', '-b', board]
-    if conf_file and conf_file not in ['default', 'prj.conf']:
-        if 'audio' in conf_file:
-            conf_file += ';overlay-le-audio-ctlr.conf'
+    if conf_file and conf_file not in ["default", "prj.conf"]:
         cmd.extend(('--', f'-DEXTRA_CONF_FILE=\'{conf_file}\''))
 
     check_call(cmd, cwd=tester_dir)

--- a/autopts/ptsprojects/boards/nrf5x.py
+++ b/autopts/ptsprojects/boards/nrf5x.py
@@ -45,9 +45,7 @@ def build_and_flash(zephyr_wd, board, debugger_snr, conf_file=None, *args):
     check_call('rm -rf build/'.split(), cwd=tester_dir)
 
     cmd = ['west', 'build', '-p', 'auto', '-b', board]
-    if conf_file and conf_file not in ['default', 'prj.conf']:
-        if 'audio' in conf_file:
-            conf_file += ';overlay-le-audio-ctlr.conf'
+    if conf_file and conf_file not in ["default", "prj.conf"]:
         cmd.extend(('--', f'-DEXTRA_CONF_FILE=\'{conf_file}\''))
 
     check_call(cmd, cwd=tester_dir)


### PR DESCRIPTION
The overlay doesn't exist in Zephyr. If any specific overlay file should be used, e.g. the overlay-le-audio.conf, then that should be supplied as the `conf_file` without this extra `audio` check.