### PR TITLE
Fix `hdl_wid_52` decode error

### DIFF
--- a/autopts/wid/gatt.py
+++ b/autopts/wid/gatt.py
@@ -704,15 +704,15 @@ def hdl_wid_52(params: WIDParams):
 
     if attr.uuid == UUID.CEP:
         (value_read,) = struct.unpack("<H", attr.value)
-        value_read = '{0:04x}'.format(value_read)
+        value_read_str = '{0:04x}'.format(value_read)
     else:
         value_read = hexlify(attr.value).upper()
+        value_read_str = value_read.decode('utf-8')
 
-    value_read = value_read.decode('utf-8')
     # PTS may select characteristic with value bigger than MTU but asks to
     # verify only MTU bytes of data
-    if value_read != value:
-        if not value_read.startswith(value):
+    if value_read_str != value:
+        if not value_read_str.startswith(value):
             return False
 
     return True


### PR DESCRIPTION
The `value_read` variable is converted to a string in the if branch but not in the else one where it's still `bytes`. The `decode` method later called on `value_read` is trying to convert it to a string. But in the case we were in the if branch, `value_read` is already a string. This lead to an `AttributeError` because the `decode` method doesn't exist for string.

Introduce `value_read_str` variable to fix the issue. That variable will be used to convert `value_read` in each branch to a string.