### PR TITLE
requirements: client: Add missing pyudev library

### DIFF
--- a/autoptsclient_requirements.txt
+++ b/autoptsclient_requirements.txt
@@ -12,3 +12,4 @@ openpyxl
 pyyaml
 yepkit-pykush
 hidapi
+pyudev


### PR DESCRIPTION
The utils file imports pyudev, however this library is not listen in the client requirement file.

Fixes Issue #1443 