### PR TITLE
autopts: zephyr - sanitize build.ninja to fix ninja lexing and rm(linux command) errors on Windows

### DIFF
--- a/autopts/ptsprojects/boards/nrf5x.py
+++ b/autopts/ptsprojects/boards/nrf5x.py
@@ -16,40 +16,122 @@
 #
 import logging
 import os
+import re
+import shutil
 
 from autopts.bot.common import check_call
 
-supported_projects = ['zephyr']
+supported_projects = ["zephyr"]
 
 
 def reset_cmd(iutctl):
     """Return reset command for nRF5x DUT
-
     Dependency: nRF5x command line tools
     """
 
-    return f'nrfjprog -r -s {iutctl.debugger_snr}'
+    return f"nrfjprog -r -s {iutctl.debugger_snr}"
+
+
+def _sanitize_ninja(path):
+    """
+    Sanitize a Ninja build file by stripping ANSI escape sequences and
+    merging split command lines without removing report targets.
+
+    This helper is especially needed when building Zephyr on Windows
+    to prevent lexing errors in build.ninja caused by leftover ANSI
+    color codes and broken continuation lines.
+
+    Reads the specified build.ninja file, removes all ANSI
+    escape codes (e.g., color sequences like "\\x1b[...m"), and merges
+    any broken continuation lines (such as fragmented COMMAND arguments
+    like "-d 99 ram"). It preserves the structure and content of
+    custom report blocks (e.g., ram_report and rom_report) intact,
+    aside from ANSI code removal.
+
+    :param path: Path to the build.ninja file to sanitize
+    :type path: str
+    """
+    with open(path, "r", encoding="utf-8", errors="ignore") as f:
+        text = f.read()
+    clean = re.sub(r"\x1b\[[0-9;]*[mK]", "", text)
+
+    lines = clean.splitlines(keepends=True)
+    out = []
+    for line in lines:
+        if out and re.match(r"^[ \t]+-\w+", line):
+            out[-1] = out[-1].rstrip("\r\n") + " " + line.strip() + "\n"
+        else:
+            out.append(line)
+
+    with open(path, "w", encoding="utf-8") as f:
+        f.writelines(out)
 
 
 def build_and_flash(zephyr_wd, board, debugger_snr, conf_file=None, *args):
-    """Build and flash Zephyr binary
-    :param zephyr_wd: Zephyr source path
-    :param board: IUT
-    :param debugger_snr serial number
-    :param conf_file: configuration file to be used
     """
-    logging.debug("%s: %s %s %s", build_and_flash.__name__, zephyr_wd,
-                  board, conf_file)
+    Build the Zephyr test application and flash the resulting binary to an nRF5x board.
+
+    Steps performed:
+      1. Remove any existing "build" directory under the tester path.
+      2. Run CMake configuration only via `west build --cmake-only`, applying an optional overlay.
+      3. Sanitize the generated build.ninja file (strip ANSI codes and merge broken lines).
+      4. Invoke Ninja to perform a full build, including report targets.
+      5. Flash the built firmware with `west flash`, skipping rebuild and using recovery mode.
+
+    :param zephyr_wd: Path to the root of the Zephyr project.
+    :type zephyr_wd: str
+    :param board: Board name for the build (e.g., 'nrf52840dk/nrf52840').
+    :type board: str
+    :param debugger_snr: Serial number of the nRF5x debugger to use for flashing.
+    :type debugger_snr: str
+    :param conf_file: Optional Kconfig overlay filename (e.g., 'overlay.conf').
+    :type conf_file: str or None
+    """
+    logging.debug(
+        "%s called with zephyr_wd=%s, board=%s, overlay=%s",
+        build_and_flash.__name__,
+        zephyr_wd,
+        board,
+        conf_file,
+    )
+
+    # Determine tester and build directories
     tester_dir = os.path.join(zephyr_wd, "tests", "bluetooth", "tester")
+    build_dir = os.path.join(tester_dir, "build")
 
-    check_call('rm -rf build/'.split(), cwd=tester_dir)
+    # 1. Remove existing build directory if present
+    if os.path.isdir(build_dir):
+        logging.debug("Removing existing build directory at %s", build_dir)
+        shutil.rmtree(build_dir)
 
-    cmd = ['west', 'build', '-p', 'auto', '-b', board]
-    if conf_file and conf_file not in ['default', 'prj.conf']:
-        if 'audio' in conf_file:
-            conf_file += ';overlay-le-audio-ctlr.conf'
-        cmd.extend(('--', f'-DEXTRA_CONF_FILE=\'{conf_file}\''))
+    # 2. Configure with CMake only, adding EXTRA_CONF_FILE if an overlay is provided
+    cmd_configure = [
+        "west",
+        "build",
+        "--cmake-only",
+        "-p",
+        "auto",
+        "-b",
+        board,
+    ]
+    if conf_file and conf_file not in ("default", "prj.conf"):
+        # For audio-related overlays, append the controller overlay as well
+        if "audio" in conf_file:
+            conf_file += ";overlay-le-audio-ctlr.conf"
+        cmd_configure.extend(["--", f"-DEXTRA_CONF_FILE={conf_file}"])
+    check_call(cmd_configure, cwd=tester_dir)
 
-    check_call(cmd, cwd=tester_dir)
-    check_call(['west', 'flash', '--skip-rebuild', '--recover',
-                '-i', debugger_snr], cwd=tester_dir)
+    # 3. Sanitize build.ninja (remove ANSI escape sequences and fix line breaks)
+    ninja_file = os.path.join(build_dir, "build.ninja")
+    if os.path.isfile(ninja_file):
+        logging.debug("Sanitizing Ninja build file at %s", ninja_file)
+        _sanitize_ninja(ninja_file)
+
+    # 4. Run full Ninja build (including report generation)
+    check_call(["ninja", "-C", build_dir], cwd=tester_dir)
+
+    # 5. Flash the firmware, skipping rebuild and enabling recovery
+    check_call(
+        ["west", "flash", "--skip-rebuild", "--recover", "-i", debugger_snr],
+        cwd=tester_dir,
+    )


### PR DESCRIPTION
This patch improves the `build_and_flash` function for Zephyr-based projects on Windows by:

1. Replacing the hardcoded Linux `rm -rf` with cross-platform `shutil.rmtree`.
2. Running `west build` in CMake-only mode before actual compilation.
3. Adding `_sanitize_ninja()` to clean up `build.ninja` files:
   - Strips ANSI escape sequences (e.g. color codes like `\x1b[0m`)
   - Fixes broken continuation lines caused by improperly escaped commands (e.g. `-d 99 ram`)

This resolves the `ninja: lexing error` encountered during builds on Windows caused by colored output in custom command blocks (`ram_report`, `rom_report`, etc).

Errors info:
**'rm' is not recognized as an internal or external command,
operable program or batch file.**
and
**ninja: error: build.ninja:9364: lexing error**


