### PR TITLE
common: Move error.txt creation to the end of bot cleanup

### DIFF
--- a/autopts/bot/common.py
+++ b/autopts/bot/common.py
@@ -170,6 +170,7 @@ class BotClient(Client):
                        'create': False,
                        'all_stats': None,
                        'tc_stats': None}
+        self.error_txt_content = ""
 
     def parse_or_find_tty(self, args):
         if args.tty_alias:
@@ -507,10 +508,11 @@ class BotClient(Client):
         try:
             stats = self.run_tests()
         except:
-            report.make_error_txt(traceback.format_exc(), self.file_paths['ERROR_TXT_FILE'])
+            self.error_txt_content += traceback.format_exc() + "\n"
             raise
         finally:
             release_device(self.args.tty_file)
+            report.make_error_txt(self.error_txt_content, self.file_paths['ERROR_TXT_FILE'])
 
         report_data = bot_state
         report_data['end_time'] = time.time()
@@ -573,6 +575,9 @@ class BotClient(Client):
             self.send_email(report_data)
 
         self.bot_post_cleanup()
+
+        if self.error_txt_content:
+            report.make_error_txt(self.error_txt_content, self.file_paths['ERROR_TXT_FILE'])
 
         print("Done")
 

--- a/autopts/bot/mynewt.py
+++ b/autopts/bot/mynewt.py
@@ -129,7 +129,7 @@ class MynewtBotClient(bot.common.BotClient):
                 build_and_flash(args.project_path, board_type, overlay, args.debugger_snr)
             except BaseException as e:
                 traceback.print_exception(e)
-                report.make_error_txt('Build and flash step failed', self.file_paths['ERROR_TXT_FILE'])
+                self.error_txt_content += "Build and flash step failed\n"
                 raise BuildAndFlashException from e
 
             time.sleep(10)

--- a/autopts/bot/mynewt.py
+++ b/autopts/bot/mynewt.py
@@ -23,7 +23,6 @@ from pathlib import Path
 
 from autopts import bot
 from autopts.bot.common import BuildAndFlashException
-from autopts.bot.common_features import report
 from autopts.client import Client
 from autopts.ptsprojects.boards import get_board_type, get_build_and_flash
 from autopts.ptsprojects.mynewt.iutctl import get_iut, log

--- a/autopts/bot/zephyr.py
+++ b/autopts/bot/zephyr.py
@@ -29,7 +29,6 @@ import serial
 from autopts import bot
 from autopts import client as autoptsclient
 from autopts.bot.common import BotClient, BotConfigArgs, BuildAndFlashException
-from autopts.bot.common_features import report
 from autopts.ptsprojects.boards import get_board_type, get_build_and_flash, tty_to_com
 from autopts.ptsprojects.zephyr import ZEPHYR_PROJECT_URL
 from autopts.ptsprojects.zephyr.iutctl import get_iut, log

--- a/autopts/bot/zephyr.py
+++ b/autopts/bot/zephyr.py
@@ -141,7 +141,7 @@ class ZephyrBotClient(BotClient):
                 flush_serial(args.tty_file)
             except BaseException as e:
                 traceback.print_exception(e)
-                report.make_error_txt('Build and flash step failed', self.file_paths['ERROR_TXT_FILE'])
+                self.error_txt_content += "Build and flash step failed\n"
                 raise BuildAndFlashException from e
 
             time.sleep(10)

--- a/autopts/utils.py
+++ b/autopts/utils.py
@@ -451,12 +451,16 @@ def active_hub_server_set_usb_power(config, on):
 
 
 def print_thread_stack_trace():
-    logging.debug("Printing stack trace for each thread:")
-    for thread_id, thread_obj in threading._active.items():
-        stack = sys._current_frames().get(thread_id)
-        if stack is not None:
-            logging.debug(f"Thread ID: {thread_id}, Thread Name: {thread_obj.name}")
-            logging.debug(traceback.extract_stack(stack))
+    try:
+        logging.debug("Printing stack trace for each thread:")
+        for thread_id, thread_obj in threading._active.items():
+            stack = sys._current_frames().get(thread_id)
+            if stack is not None:
+                logging.debug(f"Thread ID: {thread_id}, Thread Name: {thread_obj.name}")
+                logging.debug(traceback.extract_stack(stack))
+    except RuntimeError as e:
+        # threading._active dictionary can change size during iteration
+        logging.debug(e)
 
 
 def exit_if_admin():

--- a/tools/cron/remote_terminal.py
+++ b/tools/cron/remote_terminal.py
@@ -13,6 +13,7 @@
 # more details.
 #
 import argparse
+import logging
 import os
 import shlex
 import socket
@@ -27,6 +28,8 @@ AUTOPTS_REPO = dirname(dirname(dirname(abspath(__file__))))
 sys.path.insert(0, AUTOPTS_REPO)
 
 from autopts.utils import terminate_process as utils_terminate_process  # noqa: E402, I001 # the order of import is very important here
+
+log = logging.info
 
 
 class StartArgumentParser(argparse.ArgumentParser):
@@ -54,7 +57,7 @@ class StartArgumentParser(argparse.ArgumentParser):
 def run_command(command, cwd):
     """Run a command as a subprocess and return the output."""
     try:
-        print(f'Running command: {command}')
+        log(f'Running command: {command}')
         output = subprocess.check_output(command, shell=True,
                                          cwd=cwd, stderr=subprocess.STDOUT)
         return output.decode()
@@ -66,7 +69,7 @@ def run_command(command, cwd):
 def open_process(command, cwd):
     """Run a command as a subprocess and skip the output."""
     try:
-        print(f'Running command: {command}')
+        log(f'Running command: {command}')
         subprocess.Popen(shlex.split(command),
                          shell=True,
                          cwd=cwd)
@@ -101,7 +104,7 @@ def copy_file(file_path):
 def start_server():
     args = StartArgumentParser().parse_args()
 
-    print(f"Serving on port {args.port} ...")
+    log(f"Serving on port {args.port} ...")
     server = xmlrpc.server.SimpleXMLRPCServer((args.ip, args.port), allow_none=True)
     server.register_function(run_command, 'run_command')
     server.register_function(open_process, 'open_process')
@@ -142,7 +145,7 @@ class RemoteTerminalClientProxy(xmlrpc.client.ServerProxy):
                          use_datetime=False, use_builtin_types=False,
                          headers=(), context=None)
 
-        print(f"{self.__init__.__name__}, uri={self.uri}")
+        log(f"{self.__init__.__name__}, uri={self.uri}")
 
         self.client_address = client_address
         self.client_port = client_port


### PR DESCRIPTION
Originally, error.txt was used solely to pass error information from the bot to the cron job, which then posted a comment under the PR. However, since the presence of error.txt now also signals the cron to terminate the bot, even less critical issues like a build or flash failure trigger early termination. As a temporary workaround, let's move the report.make_error_txt call to the end of the bot cleanup phase. A more robust error.txt handling mechanism should be implemented in the future.