### PR TITLE
log: Add "|" symbol to identify header in raw data

### DIFF
--- a/autopts/pybtp/iutctl_common.py
+++ b/autopts/pybtp/iutctl_common.py
@@ -82,6 +82,8 @@ class BTPSocket:
         f = self.log_file
         indent = ' ' * 18
 
+        hex_data = hex_data[:14] + "|" + hex_data[14 + 1:]
+
         if len(hex_data) > 47:
             # This ensures clean text indentation for longer raw data, with 16 bytes per line
             hex_data = '\n' + indent + re.sub(r'(.{48})', r'\1\n' + indent, hex_data)


### PR DESCRIPTION
Add | symbol between packet header and data for
BTP command. This could prove useful, as user
can see command data without counting bytes.