### PR TITLE
doc: Fix Periodic Transfer Received event

### DIFF
--- a/doc/btp_gap.txt
+++ b/doc/btp_gap.txt
@@ -871,13 +871,12 @@ Events:
         Opcode 0x90 - Periodic Transfer Received event
 
                 Controller Index:       <controller id>
-                Event parameters:       Sync Handle (2 octet)
-                                        TX_Power (1 octet)
-                                        RSSI (1 octet)
-                                        CTE Type (1 octet)
-                                        Data Status (1 octet)
-                                        Data Length (1 octet)
-                                        Data (variable)
+                Event parameters:       Adveriser_Address_Type (1 octet)
+                                        Advertiser_Address (6 octets)
+                                        Sync Handle (2 octets)
+                                        Status (1 octet)
+                                        Peer Address_Type (1 octet)
+                                        Peer Address (6 octets)
 
                 This event can be sent after IUT received Periodic Advertising Sync
                 Transfer was received.


### PR DESCRIPTION
Current description is bogus (likely copy-paste error from Periodic Report event) and makes no sense for PAST received event. Since event content is not currently used by autoPTS we can fix this. Only upstream user (Mynewt) is not following current doc for this event anyway.

While there are couple other parameters that could be added to this event for now lets keep it in line with detail level of Periodic Sync Established event.