### PR TITLE
SM: Update wid 102

### DIFF
--- a/autopts/wid/sm.py
+++ b/autopts/wid/sm.py
@@ -46,10 +46,17 @@ def hdl_wid_101(_: WIDParams):
 
 
 SM_ACL_DISCONN_ROUND = 0
+SM_TEST_CASE_NAME = None
 
 
 def hdl_wid_102(params: WIDParams):
     global SM_ACL_DISCONN_ROUND
+    global SM_TEST_CASE_NAME
+
+    if SM_TEST_CASE_NAME != params.test_case_name:
+        SM_TEST_CASE_NAME = params.test_case_name
+        SM_ACL_DISCONN_ROUND = 0
+
     if params.test_case_name in ['SM/CEN/SCCT/BV-03-C', 'SM/CEN/SCCT/BV-05-C']:
         if SM_ACL_DISCONN_ROUND == 1:
             btp.gap_disconn()


### PR DESCRIPTION
The global variable `SM_ACL_DISCONN_ROUND` is used to save the current number times of ACL disconnection. The default value of the `SM_ACL_DISCONN_ROUND` should be 0 when the test case is starting.

But when testing more than one case, the initialization value of the variable SM_ACL_DISCONN_ROUND is not 0, because the previous status is not cleared.

Add a global variable `SM_TEST_CASE_NAME` to save the test case name corresponding to the variable `SM_ACL_DISCONN_ROUND`. When the test case name is not same as the current test case name, clear the variable `SM_ACL_DISCONN_ROUND` because it is a new test sequence of new test case.