### PR TITLE
wid: Implement GATT WID 154

### DIFF
--- a/autopts/ptsprojects/stack/layers/gatt.py
+++ b/autopts/ptsprojects/stack/layers/gatt.py
@@ -82,6 +82,7 @@ class Gatt:
         self.notification_events = []
         self.notification_ev_received = Event()
         self.signed_write_handle = 0
+        self.value_len = 0
 
     def attr_value_set(self, handle, value):
         attr = self.server_db.attr_lookup_handle(handle)

--- a/autopts/wid/gatt.py
+++ b/autopts/wid/gatt.py
@@ -1959,7 +1959,7 @@ def hdl_wid_151(_: WIDParams):
             stack.gatt.value_len = val_len
             return f'{handle:04x}'
 
-    return False
+    return 0
 
 
 def hdl_wid_152(_: WIDParams):
@@ -2000,7 +2000,7 @@ def hdl_wid_152(_: WIDParams):
             stack.gatt.value_len = val_len
             return f'{handle:04x}'
 
-    return False
+    return 0
 
 
 def hdl_wid_154(_: WIDParams):

--- a/autopts/wid/gatt.py
+++ b/autopts/wid/gatt.py
@@ -1919,6 +1919,8 @@ def hdl_wid_150(params: WIDParams):
 
 
 def hdl_wid_151(_: WIDParams):
+    stack = get_stack()
+
     chrcs = btp.gatts_get_attrs(type_uuid='2803')
     for chrc in chrcs:
         handle, perm, type_uuid = chrc
@@ -1954,12 +1956,15 @@ def hdl_wid_151(_: WIDParams):
 
         _, val_len, _ = chrc_value_data
         if val_len > 0:
+            stack.gatt.value_len = val_len
             return f'{handle:04x}'
 
     return False
 
 
 def hdl_wid_152(_: WIDParams):
+    stack = get_stack()
+
     chrcs = btp.gatts_get_attrs(type_uuid='2803')
     for chrc in chrcs:
         handle, perm, type_uuid = chrc
@@ -1992,9 +1997,18 @@ def hdl_wid_152(_: WIDParams):
 
         _, val_len, _ = chrc_value_data
         if val_len > 64:
+            stack.gatt.value_len = val_len
             return f'{handle:04x}'
 
     return False
+
+
+def hdl_wid_154(_: WIDParams):
+    # description: Enter size of handle value based on previous mmi requirement.
+
+    stack = get_stack()
+
+    return stack.gatt.value_len
 
 
 def hdl_wid_304(params: WIDParams):


### PR DESCRIPTION
This WID requires context from previous MMIs and is used to pass size of characteristic value to LT.

It is used in following tests:
GATT/SR/GAW/BI-32-C
GATT/SR/GAW/BI-33-C
GATT/SR/GAW/BI-39-C
GATT/SR/GAW/BI-40-C