### PR TITLE
wid: Add missing WID for GAP layer

### DIFF
--- a/autopts/wid/gap.py
+++ b/autopts/wid/gap.py
@@ -1339,6 +1339,76 @@ def hdl_wid_243(_: WIDParams):
     return True
 
 
+def hdl_wid_246(_: WIDParams):
+    attrs = btp.gatts_get_attrs(type_uuid='2803')
+    bd_addr = btp.pts_addr_get()
+    bd_addr_type = btp.pts_addr_type_get()
+
+    perm = Perm.write_authn
+
+    for attr in attrs:
+        if not attr:
+            continue
+
+        (handle, permission, type_uuid) = attr
+        data = btp.gatts_get_attr_val(bd_addr_type, bd_addr, handle)
+        if not data:
+            continue
+
+        (att_rsp, val_len, val) = data
+
+        hdr = '<BH'
+        hdr_len = struct.calcsize(hdr)
+        uuid_len = val_len - hdr_len
+
+        (props, handle, chrc_uuid) = struct.unpack(f"<BH{uuid_len}s", val)
+        chrc_value_attr = btp.gatts_get_attrs(start_handle=handle,
+                                              end_handle=handle)
+        if not chrc_value_attr:
+            continue
+
+        (handle, permission, type_uuid) = chrc_value_attr[0]
+        if permission & perm:
+            return format(handle, 'x').zfill(4)
+
+    return 0
+
+
+def hdl_wid_247(_: WIDParams):
+    attrs = btp.gatts_get_attrs(type_uuid='2803')
+    bd_addr = btp.pts_addr_get()
+    bd_addr_type = btp.pts_addr_type_get()
+
+    perm = Perm.write_authn
+
+    for attr in attrs:
+        if not attr:
+            continue
+
+        (handle, permission, type_uuid) = attr
+        data = btp.gatts_get_attr_val(bd_addr_type, bd_addr, handle)
+        if not data:
+            continue
+
+        (att_rsp, val_len, val) = data
+
+        hdr = '<BH'
+        hdr_len = struct.calcsize(hdr)
+        uuid_len = val_len - hdr_len
+
+        (props, handle, chrc_uuid) = struct.unpack(f"<BH{uuid_len}s", val)
+        chrc_value_attr = btp.gatts_get_attrs(start_handle=handle,
+                                              end_handle=handle)
+        if not chrc_value_attr:
+            continue
+
+        (handle, permission, type_uuid) = chrc_value_attr[0]
+        if permission & perm:
+            return format(handle, 'x').zfill(4)
+
+    return 0
+
+
 def hdl_wid_248(_: WIDParams):
     attrs = btp.gatts_get_attrs(type_uuid='2803')
     bd_addr = btp.pts_addr_get()


### PR DESCRIPTION
Added wid 246 and 247 to return handle of a characteristic with specified permissions which required by new MMIs.

They're used in following tests:
GAP/SEC/SEM/BV-40-C
GAP/SEC/SEM/BV-22-C