### PR TITLE
bot: zephyr: Add build_env_cmd option

### DIFF
--- a/autopts/bot/common.py
+++ b/autopts/bot/common.py
@@ -124,6 +124,7 @@ class BotConfigArgs(Namespace):
         self.use_backup = args.get('use_backup', False)
         self.no_build = args.get('no_build', False)
         self.dongle_init_retry = args.get('dongle_init_retry', 5)
+        self.build_env_cmd = args.get('build_env_cmd', None)
 
         if self.ykush or self.active_hub_server:
             self.usb_replug_available = True

--- a/autopts/bot/zephyr.py
+++ b/autopts/bot/zephyr.py
@@ -136,7 +136,7 @@ class ZephyrBotClient(BotClient):
 
             try:
                 build_and_flash(args.project_path, board_type, args.debugger_snr,
-                                overlays, args.project_repos)
+                                overlays, args.project_repos, args.build_env_cmd)
 
                 flush_serial(args.tty_file)
             except BaseException as e:

--- a/autopts/ptsprojects/boards/nrf53_appcore.py
+++ b/autopts/ptsprojects/boards/nrf53_appcore.py
@@ -23,15 +23,23 @@ supported_projects = ['zephyr']
 board_type = 'nrf5340dk/nrf5340/cpuapp'
 
 
-def build_and_flash(zephyr_wd, board, debugger_snr, conf_file=None, *args):
+def build_and_flash(zephyr_wd, board, debugger_snr, conf_file=None, project_repos=None,
+                    env_cmd=None, *args):
     """Build and flash Zephyr binary
     :param zephyr_wd: Zephyr source path
     :param board: IUT
     :param debugger_snr serial number
     :param conf_file: configuration file to be used
+    :param project_repos: a list of repo paths
+    :param env_cmd: a command to for environment activation, e.g. source /path/to/venv/activate
     """
     logging.debug("%s: %s %s %s", build_and_flash.__name__, zephyr_wd,
                   board, conf_file)
+
+    if env_cmd:
+        env_cmd = env_cmd.split() + ['&&']
+    else:
+        env_cmd = []
 
     tester_dir = os.path.join(zephyr_wd, 'tests', 'bluetooth', 'tester')
 
@@ -43,5 +51,5 @@ def build_and_flash(zephyr_wd, board, debugger_snr, conf_file=None, *args):
         bttester_overlay += f';{conf_file}'
 
     cmd = ['west', 'build', '--no-sysbuild', '-b', board, '--', f'-DEXTRA_CONF_FILE=\'{bttester_overlay}\'']
-    check_call(cmd, cwd=tester_dir)
-    check_call(['west', 'flash', '--skip-rebuild', '--recover', '-i', debugger_snr], cwd=tester_dir)
+    check_call(env_cmd + cmd, cwd=tester_dir)
+    check_call(env_cmd + ['west', 'flash', '--skip-rebuild', '--recover', '-i', debugger_snr], cwd=tester_dir)

--- a/autopts/ptsprojects/boards/nrf5x.py
+++ b/autopts/ptsprojects/boards/nrf5x.py
@@ -31,15 +31,24 @@ def reset_cmd(iutctl):
     return f'nrfjprog -r -s {iutctl.debugger_snr}'
 
 
-def build_and_flash(zephyr_wd, board, debugger_snr, conf_file=None, *args):
+def build_and_flash(zephyr_wd, board, debugger_snr, conf_file=None, project_repos=None,
+                    env_cmd=None, *args):
     """Build and flash Zephyr binary
     :param zephyr_wd: Zephyr source path
     :param board: IUT
     :param debugger_snr serial number
     :param conf_file: configuration file to be used
+    :param project_repos: a list of repo paths
+    :param env_cmd: a command to for environment activation, e.g. source /path/to/venv/activate
     """
     logging.debug("%s: %s %s %s", build_and_flash.__name__, zephyr_wd,
                   board, conf_file)
+
+    if env_cmd:
+        env_cmd = env_cmd.split() + ['&&']
+    else:
+        env_cmd = []
+
     tester_dir = os.path.join(zephyr_wd, "tests", "bluetooth", "tester")
 
     check_call('rm -rf build/'.split(), cwd=tester_dir)
@@ -50,6 +59,6 @@ def build_and_flash(zephyr_wd, board, debugger_snr, conf_file=None, *args):
             conf_file += ';overlay-le-audio-ctlr.conf'
         cmd.extend(('--', f'-DEXTRA_CONF_FILE=\'{conf_file}\''))
 
-    check_call(cmd, cwd=tester_dir)
-    check_call(['west', 'flash', '--skip-rebuild', '--recover',
-                '-i', debugger_snr], cwd=tester_dir)
+    check_call(env_cmd + cmd, cwd=tester_dir)
+    check_call(env_cmd + ['west', 'flash', '--skip-rebuild', '--recover',
+                          '-i', debugger_snr], cwd=tester_dir)


### PR DESCRIPTION
Add the `build_env_cmd` option to allow configuring a shell command that activates the environment before running `west build` or `west flash`.

This can be used, for example, to activate a Python virtual environment:
  source ~/zephyrproject/.venv/bin/activate