### PR TITLE
Fix: Add missing advertisement enablement for CAP/CL/ADV/BV-02-C

### DIFF
--- a/autopts/ptsprojects/zephyr/cap.py
+++ b/autopts/ptsprojects/zephyr/cap.py
@@ -159,6 +159,8 @@ def test_cases(ptses):
     custom_test_cases = [
         ZTestCase("CAP", "CAP/CL/ADV/BV-01-C", cmds=pre_conditions + general_conditions,
                   generic_wid_hdl=cap_wid_hdl),
+        ZTestCase("CAP", "CAP/CL/ADV/BV-02-C", cmds=pre_conditions + targeted_conditions,
+                  generic_wid_hdl=cap_wid_hdl),
         ZTestCase("CAP", "CAP/CL/ADV/BV-03-C", cmds=pre_conditions + targeted_conditions,
                   generic_wid_hdl=cap_wid_hdl),
         ZTestCase("CAP", "CAP/ACC/ERR/BI-01-C", cmds=pre_conditions + [


### PR DESCRIPTION
The test case was failing due to missing advertisement setup for the IUT in Non-Bondable mode. 
This commit adds the required advertisement enablement to support Targeted Announcements (0x01).