### PR TITLE
mynewt: Add direct connectable mode test cases to privacy overlay

### DIFF
--- a/autopts/bot/iut_config/mynewt.py
+++ b/autopts/bot/iut_config/mynewt.py
@@ -52,6 +52,8 @@ iut_config = {
             'GAP/CONN/ACEP/BV-04-C',
             'GAP/CONN/DCEP/BV-05-C',
             'GAP/CONN/DCEP/BV-06-C',
+            'GAP/CONN/DCON/BV-04-C',
+            'GAP/CONN/DCON/BV-05-C',
             'GAP/CONN/GCEP/BV-05-C',
             'GAP/CONN/GCEP/BV-06-C',
             'GAP/CONN/SCEP/BV-03-C',


### PR DESCRIPTION
GAP/CONN/DCON/BV-(04/05)-C require mynewt-nimble to enable privacy mode for bttester.
This way RPA is used by IUT and proper behaviour is enforced.