### PR TITLE
boards/nrf5x: Use proper overlay for LL configuration

### DIFF
--- a/autopts/ptsprojects/boards/nrf5x.py
+++ b/autopts/ptsprojects/boards/nrf5x.py
@@ -53,10 +53,11 @@ def build_and_flash(zephyr_wd, board, debugger_snr, conf_file=None, project_repo
 
     check_call('rm -rf build/'.split(), cwd=tester_dir)
 
-    cmd = ['west', 'build', '-p', 'auto', '-b', board]
-    if conf_file and conf_file not in ["default", "prj.conf"]:
-        cmd.extend(('--', f'-DEXTRA_CONF_FILE=\'{conf_file}\''))
+    bttester_overlay = 'overlay-bt_ll_sw_split.conf'
+    if conf_file and conf_file != 'default' and conf_file != 'prj.conf':
+        bttester_overlay += f';{conf_file}'
+
+    cmd = ['west', 'build', '-p', 'auto', '-b', board, '--', f'-DEXTRA_CONF_FILE=\'{bttester_overlay}\'']
 
     check_call(env_cmd + cmd, cwd=tester_dir)
-    check_call(env_cmd + ['west', 'flash', '--skip-rebuild', '--recover',
-                          '-i', debugger_snr], cwd=tester_dir)
+    check_call(env_cmd + ['west', 'flash', '--skip-rebuild', '--recover', '-i', debugger_snr], cwd=tester_dir)


### PR DESCRIPTION
LL configuration overlay needs to be explicitly selected. This fixes controller configuration for combined build boards (nRF52 and nRF54L15).