### PR TITLE
iut: read data from netcore/additional UART

### DIFF
--- a/autopts/bot/common.py
+++ b/autopts/bot/common.py
@@ -97,6 +97,7 @@ class BotConfigArgs(Namespace):
         self.local_addr = args.get('local_ip', ['127.0.0.1'] * len(self.cli_port))
         self.server_count = args.get('server_count', len(self.cli_port))
         self.tty_file = args.get('tty_file', None)
+        self.net_tty_file = args.get('net_tty_file', None)
         self.tty_alias = args.get('tty_alias', None)
         self.debugger_snr = args.get('debugger_snr', None)
         self.kernel_image = args.get('kernel_image', None)

--- a/cliparser.py
+++ b/cliparser.py
@@ -218,6 +218,12 @@ class CliParser(argparse.ArgumentParser):
             except ValueError:
                 return f'TTY mode: Port {args.tty_file} is not a valid COM port!\n'
 
+        if args.net_tty_file.startswith("COM"):
+            try:
+                args.net_tty_file = com_to_tty(args.net_tty_file)
+            except ValueError:
+                return f'TTY mode: Port {args.net_tty_file} is not a valid COM port!\n'
+
         return ''
 
     def check_args_qemu(self, args):


### PR DESCRIPTION
Add support for reading data transmitted over additional UART instance. nrf5340 emulates two/three virtual COM ports one of which outputs logs from network core.