### PR TITLE
IUT: log data from network core

### DIFF
--- a/autopts/bot/common.py
+++ b/autopts/bot/common.py
@@ -95,6 +95,7 @@ class BotConfigArgs(Namespace):
         self.server_count = args.get('server_count', len(self.cli_port))
         self.tty_file = args.get('tty_file', None)
         self.tty_alias = args.get('tty_alias', None)
+        self.net_tty_file = args.get('net_tty_file', None)
         self.debugger_snr = args.get('debugger_snr', None)
         self.kernel_image = args.get('kernel_image', None)
         self.database_file = args.get('database_file', DATABASE_FILE)

--- a/cliparser.py
+++ b/cliparser.py
@@ -140,6 +140,13 @@ class CliParser(argparse.ArgumentParser):
                                    "with OS running on hardware will be done over "
                                    "this TTY. Hence, QEMU will not be used.")
 
+            self.add_argument("--net-tty-file", dest='net_tty_file', type=str, default=None,
+                              help="This can be used to log output from network core of IUT "
+                                   "(if additional port is available). Value should match "
+                                   "the COM/tty file port that outputs log from the network core. "
+                                   "There's no indication which COM port maps to the network "
+                                   "core.")
+
             self.add_argument("-j", "--jlink", dest="debugger_snr", type=str, default=None,
                               help="Specify jlink serial number manually.")
 


### PR DESCRIPTION
Add support for reading data transmitted over additional UART instance. nrf5340 emulates two/three virtual COM ports one of which outputs logs from network core.
Fixes #1496

Example:
![image](https://github.com/user-attachments/assets/c3f36bf7-0b4b-4453-a917-3fae0f9df463)

