### PR TITLE
btp: gatt: fix eatt_conn btp command

### DIFF
--- a/autopts/pybtp/btp/gatt.py
+++ b/autopts/pybtp/btp/gatt.py
@@ -1788,3 +1788,5 @@ def eatt_conn(bd_addr, bd_addr_type, num=1):
     data_ba.extend(struct.pack('B', num))
 
     iutctl.btp_socket.send(*GATTC['eatt_connect'], data=data_ba)
+
+    gatt_command_rsp_succ()


### PR DESCRIPTION
Add gatt_command_rsp_succ() to eatt_conn BTP command - the command response handling was missing. When another command was being called after eatt_conn, BTP ERROR occured because response from the former command was still on rx queue and was interpreted as response to the latter BTP command