### PR TITLE
zephyr: Add timeout PIXIT in GAP layer

### DIFF
--- a/autopts/ptsprojects/zephyr/gap.py
+++ b/autopts/ptsprojects/zephyr/gap.py
@@ -123,6 +123,7 @@ def set_pixits(ptses):
     pts.set_pixit("GAP", "TSPX_iut_valid_connection_interval_max", "03C0")
     pts.set_pixit("GAP", "TSPX_iut_valid_connection_latency", "0006")
     pts.set_pixit("GAP", "TSPX_iut_valid_timeout_multiplier", "0962")
+    pts.set_pixit("GAP", "TSPX_Tgap_conn_param_timeout", "30000")
     pts.set_pixit("GAP", "TSPX_iut_invalid_connection_interval_min", "0008")
     pts.set_pixit("GAP", "TSPX_iut_invalid_connection_interval_max", "00AA")
     pts.set_pixit("GAP", "TSPX_iut_invalid_connection_latency", "0000")


### PR DESCRIPTION
This PIXIT was removed while upgrading to PTS 8.9.1. 
However, only PIXIT name was changed; the option is still there.