### PR TITLE
mynewt: Remove non-existent PIXIT functions

### DIFF
--- a/autopts/ptsprojects/mynewt/l2cap.py
+++ b/autopts/ptsprojects/mynewt/l2cap.py
@@ -95,20 +95,11 @@ def test_cases(ptses):
                   "L2CAP", "TSPX_bd_addr_iut",
                   stack.gap.iut_addr_get_str())),
               TestFunc(lambda: pts.update_pixit_param(
-                  "L2CAP", "TSPX_bd_addr_iut_le",
-                  stack.gap.iut_addr_get_str())),
-              TestFunc(lambda: pts.update_pixit_param(
                   "L2CAP", "TSPX_iut_supported_max_channels", "2")),
-              TestFunc(lambda: pts.update_pixit_param(
-                  "L2CAP", "TSPX_IUT_mps", format(le_mps, '04x'))),
               TestFunc(lambda: pts.update_pixit_param(
                   "L2CAP", "TSPX_spsm", format(le_psm, '04x'))),
               TestFunc(lambda: pts.update_pixit_param(
                   "L2CAP", "TSPX_psm_unsupported", format(psm_unsupported, '04x'))),
-              TestFunc(lambda: pts.update_pixit_param(
-                  "L2CAP", "TSPX_iut_address_type_random",
-                  "TRUE" if stack.gap.iut_addr_is_random()
-                  else "FALSE")),
               TestFunc(lambda: pts.update_pixit_param(
                   "L2CAP", "TSPX_l2ca_num_concurrent_credit_based_connections", "2")),
               TestFunc(btp.set_pts_addr, pts_bd_addr, Addr.le_public)]


### PR DESCRIPTION
For PTS 8.10 PIXIT fields were removed,
but functions using those fields were present.
Remove functions that apply missing PIXITs.