### PR TITLE
common: Fix LoggerWorker closing

### DIFF
--- a/autopts/ptsprojects/zephyr/iutctl.py
+++ b/autopts/ptsprojects/zephyr/iutctl.py
@@ -284,7 +284,7 @@ class ZephyrCtl:
             self.btp_socket.close()
             self.btp_socket = None
 
-        if self.net_tty_file:
+        if self.uart_logger:
             self.uart_logger.close()
 
         if self.native_process and self.native_process.poll() is None:

--- a/autopts/pybtp/iutctl_common.py
+++ b/autopts/pybtp/iutctl_common.py
@@ -429,7 +429,7 @@ class LoggerWorker:
             try:
                 data = self._ser.read(99999)
             except serial.SerialException:
-                pass
+                continue
             text = data.decode('utf-8', errors='replace')
             self._log_file.write(text)
 
@@ -449,4 +449,8 @@ class LoggerWorker:
                 log('Waiting for _rx_worker to finish ...')
                 self._rx_worker.join(timeout=1)
 
-        self._ser.close()
+        if self._ser:
+            self._ser.close()
+
+        if self._log_file:
+            self._log_file.close()

--- a/tools/merge_db.py
+++ b/tools/merge_db.py
@@ -86,8 +86,9 @@ class TestCaseTable:
                         )
                         self.conn_merge.commit()
 
-        source_cursor.close()
-        source_conn.close()
+            source_cursor.close()
+            source_conn.close()
+
         self._close()
 
 


### PR DESCRIPTION
Add missing log file closing.
Replace `pass` with `continue` in the catch clause serial.SerialException, because the variable `data` could be unassigned or contain old logs.