### PR TITLE
Zephyr: Make TSPX_TARGET_LATENCY consistent

### DIFF
--- a/autopts/ptsprojects/zephyr/hap.py
+++ b/autopts/ptsprojects/zephyr/hap.py
@@ -78,7 +78,7 @@ def set_pixits(ptses):
     pts.set_pixit("HAP", "TSPX_Extended_Adv_Interval_max", "1200")
     pts.set_pixit("HAP", "TSPX_Periodic_Adv_Interval_min", "600")
     pts.set_pixit("HAP", "TSPX_Periodic_Adv_Interval_max", "600")
-    pts.set_pixit("HAP", "TSPX_TARGET_LATENCY", "TARGET_LOWER_LATENCY")
+    pts.set_pixit("HAP", "TSPX_TARGET_LATENCY", "TARGET_BALANCED_LATENCY_RELIABILITY")
     pts.set_pixit("HAP", "TSPX_TARGET_PHY", "LE_2M_PHY")
     pts.set_pixit("HAP", "TSPX_largest_preset_index", str(max_index))
     pts.set_pixit("HAP", "TSPX_num_presets", str(num_presets))

--- a/autopts/ptsprojects/zephyr/tmap.py
+++ b/autopts/ptsprojects/zephyr/tmap.py
@@ -47,7 +47,7 @@ def set_pixits(ptses):
     pts.set_pixit("TMAP", "TSPX_Extended_Adv_Interval_max", "1200")
     pts.set_pixit("TMAP", "TSPX_Periodic_Adv_Interval_min", "600")
     pts.set_pixit("TMAP", "TSPX_Periodic_Adv_Interval_max", "600")
-    pts.set_pixit("TMAP", "TSPX_TARGET_LATENCY", "TARGET_LOWER_LATENCY")
+    pts.set_pixit("TMAP", "TSPX_TARGET_LATENCY", "TARGET_BALANCED_LATENCY_RELIABILITY")
     pts.set_pixit("TMAP", "TSPX_TARGET_PHY", "LE_2M_PHY")
 
 


### PR DESCRIPTION
Modify 2 occurences of TSPX_TARGET_LATENCY to be
TARGET_BALANCED_LATENCY_RELIABILITY which is the value that the Zephyr BAP Unicast client uses.