### PR TITLE
ptscontrol: open_workspace: Add a default value for the copy parameter

### DIFF
--- a/autopts/ptscontrol.py
+++ b/autopts/ptscontrol.py
@@ -673,7 +673,7 @@ class PyPTS:
             os.remove(self._temp_workspace_path)
 
     @pts_lock_wrapper(PTS_START_LOCK)
-    def open_workspace(self, workspace_path, copy):
+    def open_workspace(self, workspace_path, copy=False):
         """Opens existing workspace"""
 
         log(f"open_workspace {workspace_path}")


### PR DESCRIPTION
Recently, a new `copy` parameter was added to the open_workspace method, but not all usages were updated (tools). Add a default value to this parameter to fix the exception:
TypeError: PyPTS.open_workspace() missing 1 required positional argument: 'copy'