### PR TITLE
cliparser: zephyr: Allow skipping kernel_image when --nb is used

### DIFF
--- a/autopts/bot/zephyr.py
+++ b/autopts/bot/zephyr.py
@@ -158,11 +158,12 @@ class ZephyrBotClient(BotClient):
 
         if args.iut_mode != 'tty':
             iut = self.get_iut()
-            iut.kernel_image = os.path.join(args.project_path, "tests/bluetooth/tester/build/zephyr/zephyr")
-            if args.iut_mode == 'qemu':
-                iut.kernel_image += '.elf'
-            else:
-                iut.kernel_image += '.exe'
+            if not iut.kernel_image:
+                iut.kernel_image = os.path.join(args.project_path, "tests/bluetooth/tester/build/zephyr/zephyr")
+                if args.iut_mode == 'qemu':
+                    iut.kernel_image += '.elf'
+                else:
+                    iut.kernel_image += '.exe'
 
         if args.no_build:
             if args.setcap_cmd:

--- a/cliparser.py
+++ b/cliparser.py
@@ -339,10 +339,7 @@ class CliParser(argparse.ArgumentParser):
         if args.kernel_image:
             if not os.path.isfile(args.kernel_image):
                 return f'Native IUT mode: kernel_image {repr(args.kernel_image)} is not a file!\n'
-        elif args.project_path:
-            if args.no_build:
-                return 'Native IUT mode: Specify a kernel_image if the --nb option is used.\n'
-        else:
+        elif not args.project_path:
             return 'Native IUT mode: specify kernel_image or project_path to use this IUT mode\n'
 
         if args.tty_file or args.tty_alias or args.debugger_snr:


### PR DESCRIPTION
If project_path is provided, assume that zephyr.exe is normally located under tests/bluetooth/tester/build/zephyr/. The kernel_image option is still kept, as it can be used to point to a custom location.