### PR TITLE
iutctl: btattach: Add option btattach_at_every_test_case

### DIFF
--- a/autopts/bot/common.py
+++ b/autopts/bot/common.py
@@ -106,6 +106,7 @@ class BotConfigArgs(Namespace):
         self.qemu_bin = args.get('qemu_bin', None)
         self.qemu_options = args.get('qemu_options', '-cpu cortex-m3 -machine lm3s6965evb')
         self.btattach_bin = args.get('btattach_bin', None)
+        self.btattach_at_every_test_case = args.get('btattach_at_every_test_case', False)
         self.btproxy_bin = args.get('btproxy_bin', None)
         self.btmgmt_bin = args.get('btmgmt_bin', None)
         self.hid_vid = args.get('hid_vid', None)

--- a/autopts/client.py
+++ b/autopts/client.py
@@ -1613,6 +1613,7 @@ def run_recovery(args, ptses):
 
 
 def replug_usb(args):
+    log(f'{replug_usb.__name__}')
     if args.ykush:
         if sys.platform == 'win32':
             device_id = tty_to_com(args.tty_file)
@@ -1633,6 +1634,10 @@ def replug_usb(args):
             time.sleep(1)
 
         args.tty_file = os.path.realpath(args.tty_alias)
+        iut = autoprojects.iutctl.get_iut()
+        if iut:
+            iut.tty_file = args.tty_file
+        log(f'TTY {args.tty_alias} mounted as {args.tty_file}\n')
 
 
 def setup_project_name(project):

--- a/autopts/client.py
+++ b/autopts/client.py
@@ -1573,7 +1573,9 @@ def run_recovery(args, ptses):
     iut.stop()
 
     if args.usb_replug_available:
+        iut.btattach_stop()
         replug_usb(args)
+        iut.btattach_start()
 
     for pts in ptses:
         req_sent = False

--- a/autopts/ptsprojects/iutctl.py
+++ b/autopts/ptsprojects/iutctl.py
@@ -141,7 +141,7 @@ class IutCtl:
             self._start_mode = self._start_qemu_mode
             self._stop_mode = self._stop_qemu_mode
             self._btproxy = Btproxy() if self.btproxy_bin else None
-            self._btattach = Btattach() if self.btattach_bin else None
+            self._btattach = Btattach(self.btmgmt_bin) if self.btattach_bin else None
 
             if not self._btattach_at_every_test_case:
                 self.btattach_start()
@@ -151,7 +151,7 @@ class IutCtl:
             self._native = NativeIUT()
             self._start_mode = self._start_native_mode
             self._stop_mode = self._stop_native_mode
-            self._btattach = Btattach() if self.btattach_bin else None
+            self._btattach = Btattach(self.btmgmt_bin) if self.btattach_bin else None
 
             if not self._btattach_at_every_test_case:
                 self.btattach_start()

--- a/autopts/pybtp/iutctl_common.py
+++ b/autopts/pybtp/iutctl_common.py
@@ -248,9 +248,10 @@ class BTPSocketSrv(BTPSocket):
     def close(self):
         super().close()
         try:
-            self.conn.shutdown(socket.SHUT_RDWR)
-            self.conn.close()
-            self.sock.close()
+            if self.conn is not None:
+                self.conn.shutdown(socket.SHUT_RDWR)
+                self.conn.close()
+                self.sock.close()
         except BaseException as e:
             logging.exception(e)
         self.sock = None

--- a/cliparser.py
+++ b/cliparser.py
@@ -160,6 +160,9 @@ class CliParser(argparse.ArgumentParser):
 
         self.add_argument("--btattach-bin", "--btattach_bin", default=None,
                           help="The path to the btattach executable, e.g. /usr/bin/btattach")
+        self.add_argument("--btattach-at-every-test-case", "--btattach_at_every_test_case",
+                          action='store_true', default=False,
+                          help="The path to the btattach executable, e.g. /usr/bin/btattach")
         self.add_argument("--btproxy-bin", "--btproxy_bin", default=None,
                           help="The path to the btproxy executable, e.g. /usr/bin/btproxy")
         self.add_argument("--qemu-bin", "--qemu_bin", default=None,


### PR DESCRIPTION
There is no need to run btattach at every test case. By default, unless btattach_at_every_test_case is specified, btattach is run only once, during IUT initialization.