### PR TITLE
iutctl: zaphyr: native: Remove flash.bin after each test case

### DIFF
--- a/autopts/config.py
+++ b/autopts/config.py
@@ -56,7 +56,6 @@ def generate_file_paths(file_paths=None, autopts_root_dir=AUTOPTS_ROOT_DIR):
         'REPORT_TXT_FILE': os.path.join(autopts_root_dir, "report.txt"),
         'REPORT_DIFF_TXT_FILE': os.path.join(FILE_PATHS['TMP_DIR'], "report-diff.txt"),
         'ERROR_TXT_FILE': os.path.join(FILE_PATHS['TMP_DIR'], 'error.txt'),
-        'FLASH_BIN_DIR': os.path.join(FILE_PATHS['TMP_DIR'], 'flash_bins'),
         # 'BOT_LOG_FILE': os.path.join(autopts_root_dir, 'autoptsclient_bot.log'),
     })
 

--- a/autopts/ptsprojects/iutctl.py
+++ b/autopts/ptsprojects/iutctl.py
@@ -25,7 +25,6 @@ import time
 
 import serial
 
-from autopts.config import FILE_PATHS
 from autopts.ptsprojects.boards import Board, tty_to_com
 from autopts.ptsprojects.stack import get_stack
 from autopts.pybtp import btp, defs
@@ -54,16 +53,13 @@ def get_qemu_cmd(kernel_image, qemu_bin, btp_address=BTP_ADDRESS, qemu_options="
     return qemu_cmd
 
 
-def get_native_cmd(kernel_image, hci, tty_baudrate, btp_address, rtscts, log_dir, **kwargs):
+def get_native_cmd(kernel_image, hci, tty_baudrate, btp_address, rtscts, **kwargs):
     """Return native command"""
 
     flow_control = "crtscts" if rtscts else ""
 
-    flash_bin_dir = os.path.join(FILE_PATHS['FLASH_BIN_DIR'], os.path.basename(log_dir), 'flash.bin')
-    os.makedirs(os.path.dirname(flash_bin_dir), exist_ok=True)
-
     return (
-        f"{kernel_image} --bt-dev=hci{hci} --flash={flash_bin_dir} "
+        f"{kernel_image} --bt-dev=hci{hci} "
         f'--attach_uart_cmd="socat %s,rawer,b{tty_baudrate},{flow_control} UNIX-CONNECT:{btp_address} &"'
     )
 
@@ -286,8 +282,7 @@ class IutCtl:
                                          hci=self.hci,
                                          tty_baudrate=self.tty_baudrate,
                                          btp_address=self.btp_address,
-                                         rtscts=self.rtscts,
-                                         log_dir=test_case.log_dir)
+                                         rtscts=self.rtscts)
 
         log(f"Starting native process: {native_cmd}")
 

--- a/autopts/ptsprojects/zephyr/iutctl.py
+++ b/autopts/ptsprojects/zephyr/iutctl.py
@@ -15,7 +15,9 @@
 #
 
 import logging
+import os
 
+from autopts.config import AUTOPTS_ROOT_DIR
 from autopts.ptsprojects.iutctl import IutCtl
 
 log = logging.debug
@@ -31,6 +33,14 @@ class ZephyrCtl(IutCtl):
         super().__init__(args)
         self._rtt_logger_name = "Logger"
         self.boot_log = "Booting Zephyr OS build"
+
+    def stop(self):
+        super().stop()
+
+        if self.iut_mode == "native":
+            flash_bin = os.path.join(AUTOPTS_ROOT_DIR, 'flash.bin')
+            if os.path.exists(flash_bin):
+                os.remove(flash_bin)
 
 
 def get_iut():


### PR DESCRIPTION
The --flash option is optional and it does not exist in every build. By default, flash.bin is generated in the work directory. Let's remove it after each test case to avoid fails caused by changes in settings.