### PR TITLE
client: cliparser: Fix simple client logging

### DIFF
--- a/autopts/client.py
+++ b/autopts/client.py
@@ -506,7 +506,6 @@ def init_pts(args, ptses):
     thread_count = len(args.cli_port)
     finish_count = CounterWithFlag(init_count=0)
 
-    init_logging('_' + '_'.join(str(x) for x in args.cli_port))
     server_count = getattr(args, 'server_count', len(args.cli_port))
 
     # PtsServer.finish_count.clear()

--- a/cliparser.py
+++ b/cliparser.py
@@ -429,6 +429,9 @@ class CliParser(argparse.ArgumentParser):
         """
         args = self.parse_args(None, arg_ns)
 
+        from autopts.client import init_logging
+        init_logging('_' + '_'.join(str(x) for x in args.cli_port))
+
         if args.btproxy_bin and not is_executable(args.btproxy_bin):
             return args, f'The btproxy_bin={args.btproxy_bin} is not an executable file'
 


### PR DESCRIPTION
If logging started before autoptsclient_zephyr_65001.log was initialized, subsequent logs were missing. Initialize the log file as early as possible to avoid this.