### PR TITLE
Testcase BAP/UCL/STR/BV-568-C expects mono codec configuration

### DIFF
--- a/autopts/wid/bap.py
+++ b/autopts/wid/bap.py
@@ -1314,7 +1314,7 @@ ac_configs = {
     'BAP/UCL/STR/BV-567-C':     ([(1, 0)], 1, True),    # AC 1, Generic, QoS, Mono, Default Ch Count, No PACS
 
     # Channels and Locations in Enabled
-    'BAP/UCL/STR/BV-568-C': ([(0, 1)], 1),              # AC 2, Generic, Multi Channels
+    'BAP/UCL/STR/BV-568-C': ([(0, 1)], 1, True),        # AC 2, Generic, Multi Channels
     'BAP/UCL/STR/BV-569-C': ([(0, 1)], 1),              # AC 2, Generic, Multi Location
     'BAP/UCL/STR/BV-570-C': ([(0, 1)], 1),              # AC 2, Generic, Multi Channels and Location
     'BAP/UCL/STR/BV-571-C': ([(0, 1)], 1),              # AC 10, Generic, Multi Channels


### PR DESCRIPTION
Issue:
	Source Audio Locations characteristic was correctly set to 0b1 (Front Left).
	However, Source PAC record had Supported_Audio_Channel_Counts with bit 0 and 1 set (indicating support for 1 and 2 channels).
	During codec config, script used PAC record's channel count (2) instead of inferring mono from Audio Location, causing test failure.

Fix:
	Added explicit mono configuration for BV-568-C to override PAC record channel count.
	Ensures codec config aligns with Audio Location (1 bit set) and test expectations.