### PR TITLE
wid: Use larger sync timeout in GAP WID 301

### DIFF
--- a/autopts/wid/gap.py
+++ b/autopts/wid/gap.py
@@ -1708,7 +1708,7 @@ def hdl_wid_301(params: WIDParams):
 
     # GAP/PADV/PASE/BV-02-C starts PA Sync in WID 302 which comes first
     if params.test_case_name not in ['GAP/PADV/PASE/BV-02-C']:
-        btp.gap_padv_create_sync(0, 0, 10, 0)
+        btp.gap_padv_create_sync(0, 0, 500, 0)
 
     return stack.gap.wait_periodic_report(10)
 


### PR DESCRIPTION
PTS seems to be using quite large periodic advertising intervals in some tests. To improve reliability use larger sync timeout.

This fix GAP/BIS/BSE/BV-01-C.