### PR TITLE
gatt: handle read multiple variable responses in WID 147 and 148

### DIFF
--- a/autopts/wid/gatt.py
+++ b/autopts/wid/gatt.py
@@ -1839,6 +1839,9 @@ def hdl_wid_147(params: WIDParams):
     hdl2 = MMI.args[1]
     btp.gattc_read_multiple_var(btp.pts_addr_type_get(), btp.pts_addr_get(), hdl1, hdl2)
     btp.gattc_read_multiple_var(btp.pts_addr_type_get(), btp.pts_addr_get(), hdl1, hdl2)
+
+    btp.gattc_read_multiple_var_rsp(store_rsp=False, store_val=True)
+    btp.gattc_read_multiple_var_rsp(store_rsp=False, store_val=True)
     return True
 
 
@@ -1856,6 +1859,9 @@ def hdl_wid_148(params: WIDParams):
     hdl2 = MMI.args[1]
     btp.gattc_read_multiple_var(btp.pts_addr_type_get(), btp.pts_addr_get(), hdl1, hdl2)
     btp.gattc_read_multiple_var(btp.pts_addr_type_get(), btp.pts_addr_get(), hdl1, hdl2)
+
+    btp.gattc_read_multiple_var_rsp(store_rsp=False, store_val=True)
+    btp.gattc_read_multiple_var_rsp(store_rsp=False, store_val=True)
     return True
 
 


### PR DESCRIPTION
Add explicit response handling for Read Multiple Variable Length Characteristic Values commands in WID handlers 147 and 148.

After sending two `gattc_read_multiple_var` commands, the handlers now wait for and process both responses by calling `gattc_read_multiple_var_rsp` with store_val=True to capture the returned values while not storing the raw response.

This ensures proper synchronization and value storage for GATT client read multiple variable length operations.