### PR TITLE
wid: cap: Use non-default audio context in audio updating tests

### DIFF
--- a/autopts/wid/cap.py
+++ b/autopts/wid/cap.py
@@ -204,12 +204,12 @@ def hdl_wid_202(_: WIDParams):
 
 
 wid_310_settings = {
-    "CAP/INI/UST/BV-32-C": pack_metadata(stream_context=0x0200),
-    "CAP/INI/UST/BV-33-C": pack_metadata(stream_context=0x0200),
-    "CAP/INI/UST/BV-34-C": pack_metadata(stream_context=0x0200, ccid_list=[0x00]),
-    "CAP/INI/UST/BV-35-C": pack_metadata(stream_context=0x0200, ccid_list=[0x00]),
-    "CAP/INI/UST/BV-36-C": pack_metadata(stream_context=0x0200, ccid_list=[0x00, 0x01]),
-    "CAP/INI/UST/BV-37-C": pack_metadata(stream_context=0x0200, ccid_list=[0x00, 0x01]),
+    "CAP/INI/UST/BV-32-C": pack_metadata(stream_context=0x0100),
+    "CAP/INI/UST/BV-33-C": pack_metadata(stream_context=0x0100),
+    "CAP/INI/UST/BV-34-C": pack_metadata(stream_context=0x0100, ccid_list=[0x00]),
+    "CAP/INI/UST/BV-35-C": pack_metadata(stream_context=0x0100, ccid_list=[0x00]),
+    "CAP/INI/UST/BV-36-C": pack_metadata(stream_context=0x0100, ccid_list=[0x00, 0x01]),
+    "CAP/INI/UST/BV-37-C": pack_metadata(stream_context=0x0100, ccid_list=[0x00, 0x01]),
 }
 
 


### PR DESCRIPTION
PTS 8.14 default TSPX_Streaming_ASE Audio_Contexts is little endian 0002 (0x0200). Use non-default context type in audio update tests so that it is not rejected by IUT.