### PR TITLE
TMAP: fix TMAP multi-LT CG VRC sync and PIXIT setup

### DIFF
--- a/autopts/ptsprojects/zephyr/tmap.py
+++ b/autopts/ptsprojects/zephyr/tmap.py
@@ -38,31 +38,33 @@ from autopts.utils import ResultWithFlag
 
 
 def set_pixits(ptses):
-    pts = ptses[0]
+    def _set_tmap_pixits(pts):
+        pts.set_pixit("TMAP", "TSPX_bd_addr_iut", "DEADBEEFDEAD")
+        pts.set_pixit("TMAP", "TSPX_Public_bd_addr_LT2", "000000000000")
+        pts.set_pixit("TMAP", "TSPX_iut_device_name_in_adv_packet_for_random_address", "")
+        pts.set_pixit("TMAP", "TSPX_time_guard", "180000")
+        pts.set_pixit("TMAP", "TSPX_use_implicit_send", "TRUE")
+        pts.set_pixit("TMAP", "TSPX_tester_database_file",
+                      r"C:\Program Files (x86)\Bluetooth SIG\Bluetooth PTS\Data\SIGDatabase\PTS_TMAP_db.xml")
+        pts.set_pixit("TMAP", "TSPX_mtu_size", "64")
+        pts.set_pixit("TMAP", "TSPX_secure_simple_pairing_pass_key_confirmation", "FALSE")
+        pts.set_pixit("TMAP", "TSPX_delete_link_key", "FALSE")
+        pts.set_pixit("TMAP", "TSPX_pin_code", "0000")
+        pts.set_pixit("TMAP", "TSPX_use_dynamic_pin", "FALSE")
+        pts.set_pixit("TMAP", "TSPX_delete_ltk", "TRUE")
+        pts.set_pixit("TMAP", "TSPX_security_enabled", "TRUE")
+        pts.set_pixit("TMAP", "TSPX_iut_ATT_transport", "ATT Bearer on LE Transport")
+        pts.set_pixit("TMAP", "TSPX_sirk", "838E680553F1415AA265BBAFC6EA03B8")
+        pts.set_pixit("TMAP", "TSPX_Connection_Interval", "120")
+        pts.set_pixit("TMAP", "TSPX_Extended_Adv_Interval_min", "1200")
+        pts.set_pixit("TMAP", "TSPX_Extended_Adv_Interval_max", "1200")
+        pts.set_pixit("TMAP", "TSPX_Periodic_Adv_Interval_min", "600")
+        pts.set_pixit("TMAP", "TSPX_Periodic_Adv_Interval_max", "600")
+        pts.set_pixit("TMAP", "TSPX_TARGET_LATENCY", "TARGET_BALANCED_LATENCY_RELIABILITY")
+        pts.set_pixit("TMAP", "TSPX_TARGET_PHY", "LE_2M_PHY")
 
-    pts.set_pixit("TMAP", "TSPX_bd_addr_iut", "DEADBEEFDEAD")
-    pts.set_pixit("TMAP", "TSPX_Public_bd_addr_LT2", "000000000000")
-    pts.set_pixit("TMAP", "TSPX_iut_device_name_in_adv_packet_for_random_address", "")
-    pts.set_pixit("TMAP", "TSPX_time_guard", "180000")
-    pts.set_pixit("TMAP", "TSPX_use_implicit_send", "TRUE")
-    pts.set_pixit("TMAP", "TSPX_tester_database_file",
-                  r"C:\Program Files (x86)\Bluetooth SIG\Bluetooth PTS\Data\SIGDatabase\PTS_TMAP_db.xml")
-    pts.set_pixit("TMAP", "TSPX_mtu_size", "64")
-    pts.set_pixit("TMAP", "TSPX_secure_simple_pairing_pass_key_confirmation", "FALSE")
-    pts.set_pixit("TMAP", "TSPX_delete_link_key", "FALSE")
-    pts.set_pixit("TMAP", "TSPX_pin_code", "0000")
-    pts.set_pixit("TMAP", "TSPX_use_dynamic_pin", "FALSE")
-    pts.set_pixit("TMAP", "TSPX_delete_ltk", "TRUE")
-    pts.set_pixit("TMAP", "TSPX_security_enabled", "TRUE")
-    pts.set_pixit("TMAP", "TSPX_iut_ATT_transport", "ATT Bearer on LE Transport")
-    pts.set_pixit("TMAP", "TSPX_sirk", "838E680553F1415AA265BBAFC6EA03B8")
-    pts.set_pixit("TMAP", "TSPX_Connection_Interval", "120")
-    pts.set_pixit("TMAP", "TSPX_Extended_Adv_Interval_min", "1200")
-    pts.set_pixit("TMAP", "TSPX_Extended_Adv_Interval_max", "1200")
-    pts.set_pixit("TMAP", "TSPX_Periodic_Adv_Interval_min", "600")
-    pts.set_pixit("TMAP", "TSPX_Periodic_Adv_Interval_max", "600")
-    pts.set_pixit("TMAP", "TSPX_TARGET_LATENCY", "TARGET_BALANCED_LATENCY_RELIABILITY")
-    pts.set_pixit("TMAP", "TSPX_TARGET_PHY", "LE_2M_PHY")
+    for pts in ptses:
+        _set_tmap_pixits(pts)
 
 
 def adv_init(advData):
@@ -230,6 +232,10 @@ def test_cases(ptses):
                     [SynchPoint("TMAP/CG/VRC/BV-02-C", 514), SynchPoint("TMAP/CG/VRC/BV-02-C_LT2", 514)]),
                 TestFunc(get_stack().synch.add_synch_element,
                     [SynchPoint("TMAP/CG/VRC/BV-02-C", 504), SynchPoint("TMAP/CG/VRC/BV-02-C_LT2", 504)]),
+                TestFunc(get_stack().synch.add_synch_element,
+                    [SynchPoint("TMAP/CG/VRC/BV-02-C", 502), SynchPoint("TMAP/CG/VRC/BV-02-C_LT2", 502)]),
+                TestFunc(get_stack().synch.add_synch_element,
+                    [SynchPoint("TMAP/CG/VRC/BV-02-C", 503), SynchPoint("TMAP/CG/VRC/BV-02-C_LT2", 503)]),
             ],
             generic_wid_hdl=tmap_wid_hdl,
             lt2="TMAP/CG/VRC/BV-02-C_LT2",
@@ -244,6 +250,10 @@ def test_cases(ptses):
                     [SynchPoint("TMAP/CG/VRC/BV-03-C", 514), SynchPoint("TMAP/CG/VRC/BV-03-C_LT2", 514)]),
                 TestFunc(get_stack().synch.add_synch_element,
                     [SynchPoint("TMAP/CG/VRC/BV-03-C", 504), SynchPoint("TMAP/CG/VRC/BV-03-C_LT2", 504)]),
+                TestFunc(get_stack().synch.add_synch_element,
+                    [SynchPoint("TMAP/CG/VRC/BV-03-C", 502), SynchPoint("TMAP/CG/VRC/BV-03-C_LT2", 502)]),
+                TestFunc(get_stack().synch.add_synch_element,
+                    [SynchPoint("TMAP/CG/VRC/BV-03-C", 503), SynchPoint("TMAP/CG/VRC/BV-03-C_LT2", 503)]),
             ],
             generic_wid_hdl=tmap_wid_hdl,
             lt2="TMAP/CG/VRC/BV-03-C_LT2",
@@ -258,6 +268,8 @@ def test_cases(ptses):
                     [SynchPoint("TMAP/CG/VRC/BV-09-C", 514), SynchPoint("TMAP/CG/VRC/BV-09-C_LT2", 514)]),
                 TestFunc(get_stack().synch.add_synch_element,
                     [SynchPoint("TMAP/CG/VRC/BV-09-C", 504), SynchPoint("TMAP/CG/VRC/BV-09-C_LT2", 504)]),
+                TestFunc(get_stack().synch.add_synch_element,
+                    [SynchPoint("TMAP/CG/VRC/BV-09-C", 502), SynchPoint("TMAP/CG/VRC/BV-09-C_LT2", 502)]),
                 TestFunc(get_stack().synch.add_synch_element,
                     [SynchPoint("TMAP/CG/VRC/BV-09-C", 20110), SynchPoint("TMAP/CG/VRC/BV-09-C_LT2", 20110)]),
                 TestFunc(get_stack().synch.add_synch_element,

--- a/autopts/wid/tmap.py
+++ b/autopts/wid/tmap.py
@@ -926,6 +926,7 @@ def hdl_wid_20110(params: WIDParams):
     if match:
         volume_setting = match.group(1)
         btp.vcp_set_vol(volume_setting, addr_type, addr)
+        get_stack().vcp.wait_vcp_procedure_ev(addr_type, addr, 10)
 
     return True
 


### PR DESCRIPTION
Apply TMAP PIXIT defaults consistently to both PTS
instances and add missing LT sync for multi-LT CG
VRC cases.

The following conformance tests now pass:
TMAP/CG/VRC/BV-02-C
TMAP/CG/VRC/BV-02-C_LT2
TMAP/CG/VRC/BV-03-C
TMAP/CG/VRC/BV-03-C_LT2
TMAP/CG/VRC/BV-09-C
TMAP/CG/VRC/BV-09-C_LT2

Testing
nRF5340 Audio DK
nRF54L15 DK