### PR TITLE
mynewt: fix set pixit section in GATT and L2CAP

### DIFF
--- a/autopts/ptsprojects/mynewt/gatt.py
+++ b/autopts/ptsprojects/mynewt/gatt.py
@@ -126,19 +126,7 @@ def set_pixits(ptses):
     pts2 = ptses[1]
 
     pts2.set_pixit("GATT", "TSPX_bd_addr_iut", "DEADBEEFDEAD")
-    pts2.set_pixit("GATT", "TSPX_iut_device_name_in_adv_packet_for_random_address", "")
-    pts2.set_pixit("GATT", "TSPX_security_enabled", "FALSE")
-    pts2.set_pixit("GATT", "TSPX_delete_link_key", "TRUE")
-    pts2.set_pixit("GATT", "TSPX_time_guard", "180000")
-    pts2.set_pixit("GATT", "TSPX_use_implicit_send", "TRUE")
-    pts2.set_pixit("GATT", "TSPX_secure_simple_pairing_pass_key_confirmation", "FALSE")
-    pts2.set_pixit("GATT", "TSPX_iut_is_client_periphral", "FALSE")
-    pts2.set_pixit("GATT", "TSPX_iut_is_server_central", "FALSE")
-    pts2.set_pixit("GATT", "TSPX_mtu_size", "23")
-    pts2.set_pixit("GATT", "TSPX_pin_code", "0000")
-    pts2.set_pixit("GATT", "TSPX_use_dynamic_pin", "FALSE")
     pts2.set_pixit("GATT", "TSPX_delete_ltk", "TRUE")
-    pts2.set_pixit("GATT", "TSPX_tester_appearance", "0000")
     pts2.set_pixit("GATT", "TSPX_bearer_for_le", "EATT")
 
 

--- a/autopts/ptsprojects/mynewt/l2cap.py
+++ b/autopts/ptsprojects/mynewt/l2cap.py
@@ -48,6 +48,9 @@ def set_pixits(ptses):
     pts.set_pixit("L2CAP", "TSPX_bd_addr_iut", "DEADBEEFDEAD")
     pts.set_pixit("L2CAP", "TSPX_spsm", "0000")
     pts.set_pixit("L2CAP", "TSPX_psm_unsupported", "0000")
+    pts.set_pixit("L2CAP", "TSPX_l2ca_cbmps_min", "0064")
+    pts.set_pixit("L2CAP", "TSPX_l2ca_cbmps_max", "0064")
+    pts.set_pixit("L2CAP", "TSPX_l2ca_cbmtu_max", "00E6")
 
 
 def test_cases(ptses):


### PR DESCRIPTION
- Few pixit values were deleted by mistake in https://github.com/auto-pts/auto-pts/pull/1823 for L2CAP tests - these should not use default values ofTSPX_l2ca_cbmps_min, TSPX_l2ca_cbmps_max, TSPX_l2ca_cbmtu_max. Fixes L2CAP/ECFC/BV-24-C
- Remove setting pixits with default values for PTS2 in GATT