### PR TITLE
GMCS: Use Goto Track for MCP inactive track setup

### DIFF
--- a/autopts/wid/gmcs.py
+++ b/autopts/wid/gmcs.py
@@ -177,11 +177,9 @@ def hdl_wid_44(params: WIDParams):
        current track to a track other than the first or last within a group
        of tracks."""
 
-    if params.test_case_name in ['GMCS/SR/MCP/BV-41-C', 'GMCS/SR/MCP/BV-45-C']:
-        # This applies only for testcases where media player is initially
-        # in inactive state
-        MEDIA_PROXY_OP_NEXT_TRACK = 0x31
-        btp.gmcs_control_point_cmd(MEDIA_PROXY_OP_NEXT_TRACK, 0)
+    MEDIA_PROXY_OP_GOTO_TRACK = 0x34
+
+    btp.gmcs_control_point_cmd(MEDIA_PROXY_OP_GOTO_TRACK, 1, 2)
 
     return True
 


### PR DESCRIPTION
BV-41-C and BV-45-C require the current track to be neither first nor
last before PTS sends the First Track or Last Track opcode. Use the
Goto Track control point opcode with parameter 2 in WID 44 to place
the player on the middle track directly.

The following conformance tests now pass:
GMCS/SR/MCP/BV-41-C

Testing
nRF5340 Audio DK
nRF54L15 DK