### PR TITLE
wid: gap: shorten GATT_CL notification waiter timeout in hdl_wid_238

### DIFF
--- a/autopts/wid/gap.py
+++ b/autopts/wid/gap.py
@@ -1476,7 +1476,7 @@ def hdl_wid_238(_: WIDParams):
     gatt = stack.gatt
 
     if stack.is_svc_supported('GATT_CL'):
-        return not stack.gatt_cl.wait_for_notifications(expected_count=0)
+        return not stack.gatt_cl.wait_for_notifications(timeout=5, expected_count=0)
 
     gatt.wait_notification_ev(timeout=5)
 


### PR DESCRIPTION
Unify GATT_CL notification timeout with the 5 second GATT notification timeout in hdl_wid_238. Holding 30-second wait allows PTS to occasionally trigger security request and send subsequent notifications mid-wait. Reducing timeout to 5 seconds eliminates PTS side-effects and stabilizes test execution.

Fixes GAP/SEC/SEM/BV-65-C for mynewt