### PR TITLE
mynewt: sm: fix SM/CEN/JW/BI-06-C

### DIFF
--- a/autopts/ptsprojects/mynewt/sm.py
+++ b/autopts/ptsprojects/mynewt/sm.py
@@ -202,6 +202,9 @@ def test_cases(ptses):
                   [TestFunc(btp.gap_set_io_capability, IOCap.display_only),
                    TestFunc(btp.gap_set_mitm_off)],
                   generic_wid_hdl=sm_wid_hdl),
+        ZTestCase("SM", "SM/CEN/JW/BI-06-C",
+                  pre_conditions + [TestFunc(btp.gap_set_mitm_off)],
+                  generic_wid_hdl=sm_wid_hdl),
     ]
 
     test_case_name_list = pts.get_test_case_list('SM')


### PR DESCRIPTION
The IUT has to transmit pairing request with MITM flags set to 0, IO cap set to any IO capability

Fixes SM/CEN/JW/BI-06-C qualification test case