### PR TITLE
BAP: fix BASS Add/Modify/Remove/Set Broadcast Code ordering

### DIFF
--- a/autopts/pybtp/btp/bap.py
+++ b/autopts/pybtp/btp/bap.py
@@ -22,9 +22,9 @@ from autopts.pybtp.btp.btp import CONTROLLER_INDEX, btp_hdr_check, pts_addr_get,
 from autopts.pybtp.btp.btp import get_iut_method as get_iut
 from autopts.pybtp.btp.gap import __gap_current_settings_update
 from autopts.pybtp.types import (
-    BASSPASyncState,
     BIGEncryption,
     BTPError,
+    PaSyncState,
     addr_str_to_le_bytes,
     hex_str_to_le_bytes,
     le_bytes_to_hex_str,
@@ -402,7 +402,7 @@ def bap_scan_delegator_add_src(broadcaster_addr_type, broadcaster_addr,
                                big_encryption, num_subgroups, subgroups):
     logging.debug("")
 
-    if not BASSPASyncState.NOT_SYNCED <= pa_sync_state <= BASSPASyncState.NO_PAST:
+    if not PaSyncState.NOT_SYNCED <= pa_sync_state <= PaSyncState.NO_PAST:
         raise BTPError(f'Invalid pa_sync_state {pa_sync_state}')
 
     if not BIGEncryption.NOT_ENCRYPTED <= big_encryption <= BIGEncryption.BAD_CODE:

--- a/autopts/pybtp/types.py
+++ b/autopts/pybtp/types.py
@@ -693,23 +693,17 @@ class PaSyncState:
     NO_PAST = 0x04
 
 
+class PaSyncRequest:
+    NO_SYNC = 0x00
+    SYNC_PAST = 0x01
+    SYNC_NO_PAST = 0x02
+
+
 class BIGEncryption:
     NOT_ENCRYPTED = 0x00
     BROADCAST_CODE_REQUIRED = 0x01
     DECRYPTING = 0x02
     BAD_CODE = 0x03
-
-
-class BASSPASyncState:
-    """Periodic Advertising state reported by the Scan Delegator.
-
-    Values match enum bt_bap_pa_state in Zephyr.
-    """
-    NOT_SYNCED = 0x00
-    INFO_REQ = 0x01
-    SYNCED = 0x02
-    FAILED = 0x03
-    NO_PAST = 0x04
 
 
 # 0xFFFF indicates "unknown" as per the BASS specification

--- a/autopts/wid/bap.py
+++ b/autopts/wid/bap.py
@@ -41,7 +41,9 @@ from autopts.pybtp.types import (
     AdType,
     ASCSState,
     AudioDir,
+    BIGEncryption,
     BTPError,
+    PaSyncRequest,
     PaSyncState,
     WIDParams,
     create_lc3_ltvs_bytes,
@@ -2211,7 +2213,7 @@ def hdl_wid_345(params: WIDParams):
     advertiser_sid = ev['advertiser_sid']
     broadcast_id = ev['broadcast_id']
     padv_interval = ev['padv_interval']
-    padv_sync = 0x02
+    padv_sync = PaSyncRequest.SYNC_NO_PAST
     num_subgroups = 1
     bis_sync = 1
     metadata_len = 0
@@ -2264,7 +2266,7 @@ def hdl_wid_346(params: WIDParams):
     advertiser_sid = ev['advertiser_sid']
     broadcast_id = ev['broadcast_id']
     padv_interval = ev['padv_interval']
-    padv_sync = 0x02
+    padv_sync = PaSyncRequest.SYNC_NO_PAST
     num_subgroups = 1
     bis_sync = 1
     metadata_len = 0
@@ -2284,14 +2286,18 @@ def hdl_wid_346(params: WIDParams):
     if ev['pa_sync_state'] == PaSyncState.SYNC_INFO_REQ:
         btp.bap_send_past(ev['src_id'])
 
+    # PTS drops the Modify Source write if the BIG sync is not established yet.
+    # PTS may report PA and BIG sync in the same notification, so only wait for
+    # another one if the one we already have does not satisfy that condition.
+    if ev['pa_sync_state'] != PaSyncState.SYNCED or ev.get('subgroups') != subgroups:
         ev = stack.bap.wait_broadcast_receive_state_ev(
-            broadcast_id, addr_type, addr, broadcaster_addr_type,
-            broadcaster_addr, WildCard(), timeout=10, remove=True)
+            broadcast_id, addr_type, addr, broadcaster_addr_type, broadcaster_addr,
+            PaSyncState.SYNCED, subgroups=subgroups, remove=True)
 
         if ev is None:
             return False
 
-    padv_sync = 0x00
+    padv_sync = PaSyncRequest.NO_SYNC
     bis_sync = 0
     metadata_len = 0
     subgroups = struct.pack('<IB', bis_sync, metadata_len)
@@ -2301,7 +2307,7 @@ def hdl_wid_346(params: WIDParams):
 
     ev = stack.bap.wait_broadcast_receive_state_ev(
         broadcast_id, addr_type, addr, broadcaster_addr_type,
-        broadcaster_addr, WildCard(), timeout=10, remove=True)
+        broadcaster_addr, PaSyncState.NOT_SYNCED, subgroups=subgroups, remove=True)
 
     if ev is None:
         return False
@@ -2332,9 +2338,9 @@ def hdl_wid_347(params: WIDParams):
     broadcast_id = ev['broadcast_id']
     padv_interval = ev['padv_interval']
     num_subgroups = 1
-    # Ignore wrong values of PA SYNC and BIS INDEX in WID description
-    padv_sync = 0x02
-    bis_sync = 1
+    # Add receive state without requesting to PA or BIS Sync as per the WID description
+    padv_sync = PaSyncRequest.NO_SYNC
+    bis_sync = 0
     metadata_len = 0
     subgroups = struct.pack('<IB', bis_sync, metadata_len)
     btp.bap_add_broadcast_src(advertiser_sid, broadcast_id, padv_sync,
@@ -2344,26 +2350,16 @@ def hdl_wid_347(params: WIDParams):
 
     ev = stack.bap.wait_broadcast_receive_state_ev(
         broadcast_id, addr_type, addr, broadcaster_addr_type,
-        broadcaster_addr, WildCard(), timeout=10, remove=True)
+        broadcaster_addr, PaSyncState.NOT_SYNCED, subgroups=subgroups, remove=True)
 
     if ev is None:
         return False
-
-    if ev['pa_sync_state'] == PaSyncState.SYNC_INFO_REQ:
-        btp.bap_send_past(ev['src_id'])
-
-        ev = stack.bap.wait_broadcast_receive_state_ev(
-            broadcast_id, addr_type, addr, broadcaster_addr_type,
-            broadcaster_addr, WildCard(), timeout=10, remove=True)
-
-        if ev is None:
-            return False
 
     btp.bap_remove_broadcast_src(ev['src_id'], addr_type, addr)
 
     ev = stack.bap.wait_broadcast_receive_state_ev(
         broadcast_id, addr_type, addr, broadcaster_addr_type,
-        broadcaster_addr, padv_sync, timeout=10, remove=False)
+        broadcaster_addr, PaSyncState.NOT_SYNCED, remove=False)
 
     if ev is None:
         return False
@@ -2394,7 +2390,7 @@ def hdl_wid_348(params: WIDParams):
     broadcast_id = ev['broadcast_id']
     padv_interval = ev['padv_interval']
     num_subgroups = 1
-    padv_sync = 0x02
+    padv_sync = PaSyncRequest.SYNC_NO_PAST
     bis_sync = 1
     metadata_len = 0
     subgroups = struct.pack('<IB', bis_sync, metadata_len)
@@ -2410,17 +2406,22 @@ def hdl_wid_348(params: WIDParams):
     if ev is None:
         return False
 
-    btp.bap_set_broadcast_code(ev['src_id'], stack.bap.broadcast_code)
-
     if ev['pa_sync_state'] == PaSyncState.SYNC_INFO_REQ:
         btp.bap_send_past(ev['src_id'])
 
+    # PTS drops the Set Broadcast Code write until it reports Broadcast_Code_Required.
+    # PTS may report PA sync and the code requirement in the same notification, so
+    # only wait for another one if the one we already have does not satisfy that.
+    if ev['pa_sync_state'] != PaSyncState.SYNCED or ev.get('big_encryption') != BIGEncryption.BROADCAST_CODE_REQUIRED:
         ev = stack.bap.wait_broadcast_receive_state_ev(
-            broadcast_id, addr_type, addr, broadcaster_addr_type,
-            broadcaster_addr, WildCard(), timeout=10, remove=True)
+            broadcast_id, addr_type, addr, broadcaster_addr_type, broadcaster_addr,
+            PaSyncState.SYNCED, big_encryption=BIGEncryption.BROADCAST_CODE_REQUIRED,
+            remove=True)
 
         if ev is None:
             return False
+
+    btp.bap_set_broadcast_code(ev['src_id'], stack.bap.broadcast_code)
 
     return True
 
@@ -2448,7 +2449,7 @@ def hdl_wid_349(params: WIDParams):
     broadcast_id = ev['broadcast_id']
     padv_interval = ev['padv_interval']
     num_subgroups = 1
-    padv_sync = PaSyncState.SYNC_INFO_REQ
+    padv_sync = PaSyncRequest.SYNC_PAST
     bis_sync = 0
     metadata_len = 0
     subgroups = struct.pack('<IB', bis_sync, metadata_len)

--- a/autopts/wid/bass.py
+++ b/autopts/wid/bass.py
@@ -23,8 +23,8 @@ from autopts.pybtp.types import (
     UUID,
     AdFlags,
     AdType,
-    BASSPASyncState,
     BIGEncryption,
+    PaSyncRequest,
     WIDParams,
     gap_settings_btp2txt,
     uuid_to_le_hex_str,
@@ -232,7 +232,7 @@ def hdl_wid_116(_: WIDParams):
     btp.bap_scan_delegator_add_src(
         broadcaster_addr_type, broadcaster_addr,
         advertiser_sid, broadcast_id,
-        BASSPASyncState.NOT_SYNCED, big_encryption, 1, subgroups)
+        PaSyncRequest.NO_SYNC, big_encryption, 1, subgroups)
 
     ev = stack.bap.wait_broadcast_receive_state_ev(
         broadcast_id, WildCard(), WildCard(),

--- a/autopts/wid/cap.py
+++ b/autopts/wid/cap.py
@@ -33,7 +33,16 @@ from autopts.pybtp.btp.audio import pack_metadata
 from autopts.pybtp.btp.cap import announcements
 from autopts.pybtp.btp.gap import gap_set_uuid16_svc_data
 from autopts.pybtp.btp.pacs import pacs_set_available_contexts
-from autopts.pybtp.types import BASS_PA_INTERVAL_UNKNOWN, UUID, Addr, ASCSState, BAPAnnouncement, CAPAnnouncement, WIDParams
+from autopts.pybtp.types import (
+    BASS_PA_INTERVAL_UNKNOWN,
+    UUID,
+    Addr,
+    ASCSState,
+    BAPAnnouncement,
+    CAPAnnouncement,
+    PaSyncRequest,
+    WIDParams,
+)
 from autopts.wid import generic_wid_hdl
 from autopts.wid.bap import (
     BAS_CONFIG_SETTINGS,
@@ -317,7 +326,7 @@ def hdl_wid_345(params: WIDParams):
         broadcast_id = ev['broadcast_id']
         padv_interval = ev['padv_interval']
 
-    padv_sync = 0x02
+    padv_sync = PaSyncRequest.SYNC_NO_PAST
     num_subgroups = 1
     bis_sync = 1
     result = re.search(r'BIS INDEX: 0x(\d+)', params.description)
@@ -396,7 +405,7 @@ def hdl_wid_347(params: WIDParams):
     advertiser_sid = ev['advertiser_sid']
     padv_interval = ev['padv_interval']
     num_subgroups = 1
-    padv_sync = 0x02
+    padv_sync = PaSyncRequest.SYNC_NO_PAST
     bis_sync = 1
     result = re.search(r'BIS INDEX: 0x(\d+)', params.description)
     if result:
@@ -426,7 +435,7 @@ def hdl_wid_347(params: WIDParams):
         broadcaster_addr, WildCard(), timeout=10, remove=True)
 
     # stop sync with Modify Source
-    padv_sync = 0x0
+    padv_sync = PaSyncRequest.NO_SYNC
     bis_sync = 0
     subgroups = struct.pack('<IB', bis_sync, metadata_len)
     source_id = (ev['src_id'])
@@ -845,7 +854,7 @@ def hdl_wid_413(params: WIDParams):
     addr_type = pts_addr_type_get()
 
     # first stop sync with Modify Source
-    pa_sync = 0x0
+    pa_sync = PaSyncRequest.NO_SYNC
     bis_sync = 0
     metadata_len = 0
     num_subgroups = 1
@@ -894,7 +903,7 @@ def hdl_wid_414(params: WIDParams):
     broadcaster_addr_type = Addr.le_random if stack.gap.iut_addr_is_random() else Addr.le_public
     broadcast_id = stack.cap.local_broadcast_id
 
-    padv_sync = 0x02
+    padv_sync = PaSyncRequest.SYNC_NO_PAST
     ev = stack.bap.wait_broadcast_receive_state_ev(
         broadcast_id, addr_type, addr, broadcaster_addr_type,
         broadcaster_addr, padv_sync, timeout=10, remove=False)


### PR DESCRIPTION
BV-05-C, 6 and 7 timed out on Lower Tester 1 because the IUT
wrote to the Broadcast Audio Scan Control Point before the
Scan Delegator was ready, so PTS acknowledged the ATT write but
never processed it as the expected test step.
WID 346: wait for the Broadcast Receive State reporting the
requested BIS_Sync before writing Modify Source.
WID 347: add the source with the PA SYNC 0x00/BIS INDEX 0x00000000
values from the WID description, otherwise the source is still
synced and PTS answers "Can't perform remove operation".
WID 348: send PAST first and write Set Broadcast Code only after
the Scan Delegator reports Broadcast_Code_Required.

The following conformance tests now pass:
BAP/BA/BASS/BV-05-C
BAP/BA/BASS/BV-06-C
BAP/BA/BASS/BV-07-C 

Testing
nRF5340 Audio DK
nRF54L15 DK