### PR TITLE
errata: Add support ticket for CAP/INI/BST

### DIFF
--- a/errata/common.yaml
+++ b/errata/common.yaml
@@ -4,6 +4,19 @@
 
 BAP/BA/BASS/BV-08-C: https://support.bluetooth.com/hc/en-us/requests/190836
 
+CAP/INI/BST/BV-01-C: https://support.bluetooth.com/hc/en-us/requests/191389
+CAP/INI/BST/BV-02-C: https://support.bluetooth.com/hc/en-us/requests/191389
+CAP/INI/BST/BV-03-C: https://support.bluetooth.com/hc/en-us/requests/191389
+CAP/INI/BST/BV-04-C: https://support.bluetooth.com/hc/en-us/requests/191389
+CAP/INI/BST/BV-05-C: https://support.bluetooth.com/hc/en-us/requests/191389
+CAP/INI/BST/BV-06-C: https://support.bluetooth.com/hc/en-us/requests/191389
+CAP/INI/BST/BV-07-C: https://support.bluetooth.com/hc/en-us/requests/191389
+CAP/INI/BST/BV-08-C: https://support.bluetooth.com/hc/en-us/requests/191389
+CAP/INI/BST/BV-09-C: https://support.bluetooth.com/hc/en-us/requests/191389
+CAP/INI/BST/BV-10-C: https://support.bluetooth.com/hc/en-us/requests/191389
+CAP/INI/BST/BV-16-C: https://support.bluetooth.com/hc/en-us/requests/191389
+CAP/INI/BST/BV-17-C: https://support.bluetooth.com/hc/en-us/requests/191389
+
 GAP/CONN/CPUP/BV-08-C: Laird PTS LE-only dongle required
 GAP/CONN/CPUP/BV-10-C: Laird PTS LE-only dongle required
 GAP/CONN/DCON/BV-05-C: Request ID 183721


### PR DESCRIPTION
PTS 8.14.1 seems to have regression with missing IXIT in CAP.