### PR TITLE
Add A2DP profile support and openvela client

### DIFF
--- a/autopts/ptsprojects/openvela/__init__.py
+++ b/autopts/ptsprojects/openvela/__init__.py
@@ -1,0 +1,26 @@
+#
+# auto-pts - The Bluetooth PTS Automation Framework
+#
+# Copyright (c) 2026, Xiaomi Corporation.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms and conditions of the GNU General Public License,
+# version 2, as published by the Free Software Foundation.
+#
+# This program is distributed in the hope it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+
+"""openvela auto PTS project (A2DP only)
+
+The autopts framework accesses profile modules via:
+    getattr(autoprojects, 'a2dp', None)  -> openvela.a2dp module
+
+Each profile module must export: set_pixits(), test_cases()
+"""
+
+# Import profile modules so they are accessible via getattr
+from autopts.ptsprojects.openvela import a2dp as a2dp
+from autopts.ptsprojects.openvela import iutctl as iutctl

--- a/autopts/ptsprojects/openvela/a2dp.py
+++ b/autopts/ptsprojects/openvela/a2dp.py
@@ -1,0 +1,88 @@
+#
+# auto-pts - The Bluetooth PTS Automation Framework
+#
+# Copyright (c) 2026, Xiaomi Corporation.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms and conditions of the GNU General Public License,
+# version 2, as published by the Free Software Foundation.
+#
+# This program is distributed in the hope it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+
+"""openvela A2DP test cases"""
+
+from autopts.ptsprojects.openvela.testcase import OpenVelaTestCase
+from autopts.ptsprojects.stack import get_stack
+from autopts.ptsprojects.testcase import TestFunc
+from autopts.pybtp import btp
+from autopts.pybtp.types import Addr
+from autopts.wid.a2dp import a2dp_wid_hdl
+
+
+def set_pixits(ptses):
+    """Set A2DP PIXIT values.
+
+    TSPX_bd_addr_iut is intentionally not set here: the IUT address depends on
+    whichever controller is attached to the emulator, so it is read from the IUT
+    at runtime in test_cases() instead of being hardcoded.
+    """
+    pts = ptses[0]
+    pts.set_pixit("A2DP", "TSPX_time_guard", "300000")
+
+    # Keep both sides bonded across cases. The IUT keeps its bond, so letting
+    # PTS drop its link key leaves the two disagreeing and authentication ends
+    # in HCI_PIN_OR_KEY_MISSING before AVDTP is reached. Same reasoning as
+    # rfcomm, hfp and hid, and it pairs with hdl_wid_12 not unpairing either.
+    pts.set_pixit("A2DP", "TSPX_delete_link_key", "FALSE")
+
+
+def test_cases(ptses):
+    """Build A2DP test case list"""
+    pts = ptses[0]
+    stack = get_stack()
+
+    pts_bd_addr = pts.q_bd_addr
+
+    pre_conditions = [
+        TestFunc(btp.core_reg_svc_gap),
+        TestFunc(stack.gap_init),
+        # Without a2dp_init() stack.a2dp stays None and the A2DP event handlers
+        # have nowhere to record connected / audio_streaming, so WIDs that check
+        # the IUT's reported state cannot work.
+        TestFunc(stack.a2dp_init),
+        TestFunc(btp.set_pts_addr, pts_bd_addr, Addr.le_public),
+        TestFunc(btp.gap_set_powered_on),
+        # Read the real IUT address from the controller and push it into the
+        # PIXIT, otherwise PTS tries to reach a stale hardcoded address and
+        # every test times out without the IUT ever seeing a single packet.
+        TestFunc(btp.gap_read_controller_info),
+        TestFunc(lambda: pts.update_pixit_param(
+            "A2DP", "TSPX_bd_addr_iut",
+            stack.gap.iut_addr_get_str())),
+        TestFunc(btp.gap_set_connectable),
+        TestFunc(btp.gap_set_general_discoverable),
+        TestFunc(btp.core_reg_svc_a2dp),
+    ]
+
+    test_case_name_list = pts.get_test_case_list('A2DP')
+    tc_list = []
+
+    for tc_name in test_case_name_list:
+        # The shim's bt_a2dp_connect/disconnect/start/stop are role-specific in
+        # the Framework (sink vs source service), so tell the IUT which role to
+        # play before the test runs. 0 = sink, 1 = source. It must come after
+        # core_reg_svc_a2dp (which registers the A2DP service handlers), so the
+        # SET_ROLE command has a handler to hit.
+        role = 1 if '/SRC/' in tc_name else 0
+        pre = pre_conditions + [TestFunc(btp.a2dp_set_role, role)]
+
+        instance = OpenVelaTestCase('A2DP', tc_name,
+                                    cmds=pre,
+                                    generic_wid_hdl=a2dp_wid_hdl)
+        tc_list.append(instance)
+
+    return tc_list

--- a/autopts/ptsprojects/openvela/iutctl.py
+++ b/autopts/ptsprojects/openvela/iutctl.py
@@ -1,0 +1,323 @@
+#
+# auto-pts - The Bluetooth PTS Automation Framework
+#
+# Copyright (c) 2026, Xiaomi Corporation.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms and conditions of the GNU General Public License,
+# version 2, as published by the Free Software Foundation.
+#
+# This program is distributed in the hope it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+
+"""openvela IUT Control Module
+
+This module provides IUT (Implementation Under Test) control for openvela
+running on QEMU. It connects to the bttester application via TCP socket
+through adb port forwarding.
+
+Architecture:
+    auto-pts (Host) <--TCP:9876--> adb forward <--TCP:9876--> bttester (QEMU)
+"""
+
+import logging
+import socket
+import subprocess
+import time
+
+from autopts.ptsprojects.stack import Stack, get_stack
+from autopts.pybtp import btp, defs
+from autopts.pybtp.iutctl_common import BTPSocketCli, BTPWorker
+from autopts.pybtp.types import BTPInitError
+
+log = logging.debug
+
+openvela = None
+
+
+def _first(value, default):
+    """Unwrap a possibly list-valued CLI argument, falling back to default."""
+    if value is None:
+        return default
+    if isinstance(value, (list, tuple)):
+        return value[0] if value else default
+    return value
+
+
+# Default BTP TCP port used by bttester
+BTP_TCP_PORT = 9876
+
+
+class OpenVelaCtl:
+    """openvela IUT Control Class
+
+    This class manages the connection to openvela bttester running in QEMU.
+    It uses TCP socket connection through adb port forwarding.
+    """
+
+    def __init__(self, args):
+        """Constructor.
+
+        Args:
+            args: Command line arguments containing:
+                - btp_tcp_port: TCP port for BTP connection (default: 9876)
+                - btp_tcp_ip: TCP host for BTP connection (default: 127.0.0.1)
+                - adb_device: ADB device serial (optional)
+        """
+        log(f"{self.__class__}.{self.__init__.__name__}")
+
+        # Use standard auto-pts parameter names
+        # --btp-tcp-port/--btp-tcp-ip are declared with nargs='+', so passing
+        # them explicitly yields a list. Unwrap it, otherwise the value ends up
+        # formatted as "tcp:[9876]" and adb rejects it.
+        self.btp_tcp_port = _first(getattr(args, 'btp_tcp_port', None), BTP_TCP_PORT)
+        self.btp_tcp_host = _first(getattr(args, 'btp_tcp_ip', None), '127.0.0.1')
+        self.adb_device = getattr(args, 'adb_device', None)
+
+        self.is_running = False
+        self.socket_srv = None
+        self.btp_socket = None
+        self.test_case = None
+        self._adb_forward_setup = False
+
+        self.iut_mode = "btp_tcp_client"
+
+        # btp._get_stack() resolves the stack through get_iut().get_stack(),
+        # so every IUT control class has to own its Stack instance the way
+        # ptsprojects.iutctl.IutCtl does.
+        self.stack = Stack()
+        self.stack.synch_init()
+
+    def _setup_adb_forward(self):
+        """Setup adb port forwarding for BTP TCP connection."""
+        # Always re-setup to ensure the forward is active
+        log(f"Setting up adb forward tcp:{self.btp_tcp_port} tcp:{self.btp_tcp_port}")
+
+        cmd = ['adb']
+        if self.adb_device:
+            cmd.extend(['-s', self.adb_device])
+        cmd.extend(['forward', f'tcp:{self.btp_tcp_port}', f'tcp:{self.btp_tcp_port}'])
+
+        try:
+            subprocess.run(cmd, check=True, capture_output=True)
+            self._adb_forward_setup = True
+            log("adb forward setup successful")
+        except subprocess.CalledProcessError as e:
+            log(f"adb forward failed: {e.stderr.decode()}")
+            raise Exception(f"Failed to setup adb forward: {e}") from e
+
+    def _remove_adb_forward(self):
+        """Remove adb port forwarding."""
+        if not self._adb_forward_setup:
+            return
+
+        log(f"Removing adb forward tcp:{self.btp_tcp_port}")
+
+        cmd = ['adb']
+        if self.adb_device:
+            cmd.extend(['-s', self.adb_device])
+        cmd.extend(['forward', '--remove', f'tcp:{self.btp_tcp_port}'])
+
+        try:
+            subprocess.run(cmd, check=True, capture_output=True)
+        except subprocess.CalledProcessError:
+            pass  # Ignore errors when removing forward
+
+        self._adb_forward_setup = False
+
+    def start(self, test_case):
+        """Start the IUT for a test case.
+
+        Args:
+            test_case: The test case object
+        """
+        log(">>> OpenVelaCtl.start called")
+
+        self.test_case = test_case
+
+        # Setup adb port forwarding (idempotent)
+        self._setup_adb_forward()
+
+        # Create TCP socket connection to bttester
+        log(">>> OpenVelaCtl.start: creating BTPSocketCliTcp")
+        self.socket_srv = BTPSocketCliTcp(test_case.log_dir)
+        self.socket_srv.open((self.btp_tcp_host, self.btp_tcp_port))
+        self.btp_socket = BTPWorker(self.socket_srv)
+
+        # Connect to bttester
+        log(f">>> OpenVelaCtl.start: connecting to {self.btp_tcp_host}:{self.btp_tcp_port}")
+        self.btp_socket.accept(timeout=30.0)
+        log(">>> OpenVelaCtl.start: connected OK")
+
+        self.is_running = True
+
+    def stop(self):
+        """Stop the IUT (disconnect TCP, keep bttester running)."""
+        log(f"{self.__class__}.{self.stop.__name__}")
+
+        if not self.is_running:
+            return
+
+        # Close BTP socket (bttester stays running, waits for new connection)
+        if self.btp_socket:
+            self.btp_socket.close()
+            self.btp_socket = None
+
+        if self.socket_srv:
+            self.socket_srv.close()
+            self.socket_srv = None
+
+        self.is_running = False
+
+    def wait_iut_ready_event(self, reset=True):
+        """Wait for IUT ready event.
+
+        Args:
+            reset: Whether to reset the IUT (restart bttester)
+        """
+        log(f">>> OpenVelaCtl.wait_iut_ready_event reset={reset}")
+
+        stack = get_stack()
+
+        if reset:
+            log(">>> OpenVelaCtl.wait_iut_ready_event: stop+start")
+            self.stop()
+            self.start(self.test_case)
+
+        # Wait for IUT ready event
+        log(">>> OpenVelaCtl.wait_iut_ready_event: waiting for IUT ready ev...")
+        ev = stack.core.wait_iut_ready_ev(30)
+        stack.core.event_queues[defs.BTP_CORE_EV_IUT_READY].clear()
+
+        if not ev:
+            log(">>> OpenVelaCtl.wait_iut_ready_event: TIMEOUT - no IUT ready event!")
+            self.stop()
+            raise BTPInitError('IUT ready event NOT received!')
+
+        log(">>> OpenVelaCtl.wait_iut_ready_event: IUT ready event received OK")
+
+    def get_supported_svcs(self):
+        """Get supported BTP services."""
+        btp.read_supp_svcs()
+
+    def get_stack(self):
+        """Return the Stack owned by this IUT."""
+        return self.stack
+
+    def cleanup_stack(self):
+        """Reset the Stack between test cases."""
+        self.stack.cleanup()
+
+
+class BTPSocketCliTcp(BTPSocketCli):
+    """BTP Socket Client using TCP connection.
+
+    This extends BTPSocketCli to use TCP instead of Unix domain socket.
+    """
+
+    def __init__(self, log_dir=None):
+        super().__init__(log_dir)
+        self._connected = False
+
+    def open(self, addr):
+        """Open connection to the specified address.
+
+        Args:
+            addr: Tuple of (host, port)
+        """
+        self.addr = addr
+        log(f"BTPSocketCliTcp.open addr={addr}")
+
+    def accept(self, timeout=10.0):
+        """Connect to the BTP server (bttester).
+
+        Args:
+            timeout: Connection timeout in seconds
+        """
+        log(f"BTPSocketCliTcp.accept timeout={timeout}")
+
+        self.conn = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        self.conn.settimeout(timeout)
+
+        # Retry connection with backoff
+        max_retries = 10
+        retry_delay = 0.5
+
+        for i in range(max_retries):
+            error = self._try_connect()
+            if error is None:
+                return
+
+            log(f"Connection attempt {i + 1}/{max_retries} failed: {error}")
+            if i < max_retries - 1:
+                time.sleep(retry_delay)
+                retry_delay *= 1.5  # Exponential backoff
+
+        raise Exception(f"Failed to connect to {self.addr} after {max_retries} attempts")
+
+    def _try_connect(self):
+        """Try a single TCP connection attempt.
+
+        Returns:
+            The exception raised on failure, or None on success.
+        """
+        try:
+            self.conn.connect(self.addr)
+        except (ConnectionRefusedError, TimeoutError) as e:
+            return e
+
+        self._connected = True
+        log(f"Connected to {self.addr}")
+        self.conn.settimeout(None)
+        return None
+
+    def close(self):
+        """Close the TCP connection."""
+        log("BTPSocketCliTcp.close")
+
+        if self.conn and self._connected:
+            try:
+                self.conn.shutdown(socket.SHUT_RDWR)
+            except OSError:
+                pass
+            try:
+                self.conn.close()
+            except OSError:
+                pass
+
+        self.conn = None
+        self._connected = False
+
+        if self.log_file:
+            self.log_file.close()
+            self.log_file = None
+
+
+def get_iut():
+    """Get the openvela IUT instance."""
+    return openvela
+
+
+def init(args):
+    """Initialize the openvela IUT.
+
+    Args:
+        args: Command line arguments
+    """
+    global openvela
+
+    log("openvela IUT init")
+    openvela = OpenVelaCtl(args)
+
+
+def cleanup():
+    """Cleanup the openvela IUT."""
+    global openvela
+
+    if openvela:
+        openvela.stop()
+        openvela._remove_adb_forward()
+        openvela = None

--- a/autopts/ptsprojects/openvela/testcase.py
+++ b/autopts/ptsprojects/openvela/testcase.py
@@ -1,0 +1,75 @@
+#
+# auto-pts - The Bluetooth PTS Automation Framework
+#
+# Copyright (c) 2026, Xiaomi Corporation.
+# Copyright (c) 2017, Intel Corporation.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms and conditions of the GNU General Public License,
+# version 2, as published by the Free Software Foundation.
+#
+# This program is distributed in the hope it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+
+"""Test case that manages the openvela IUT.
+
+Drives the IUT lifecycle (start, wait ready, read supported services, run the
+test case commands, clean up) for a bttester DUT in QEMU over TCP.
+"""
+
+from autopts.ptsprojects.testcase import TestCaseLT1, TestFunc, TestFuncCleanUp
+from autopts.pybtp.btp import get_iut
+
+
+class OpenVelaTestCase(TestCaseLT1):
+    """An openvela test case whose DUT is bttester running in QEMU over TCP."""
+
+    def __init__(self, *args, **kwargs) -> None:
+        """Refer to ``TestCase.__init__`` for parameters and their documentation."""
+
+        super().__init__(*args, ptsproject_name="openvela", **kwargs)
+
+        self.cmds.insert(0, TestFunc(self._test_case_start))
+        self.cmds.append(TestFuncCleanUp(self._test_case_cleanup))
+
+    def _test_case_start(self) -> None:
+        """Bring the IUT up before the test case commands run."""
+
+        iut = get_iut()
+
+        for iut_id in range(self.iut_count):
+            if hasattr(iut, 'select_iut'):
+                iut.select_iut(iut_id)
+
+            # Init stack.core to be able to receive the IUT ready event.
+            iut.get_stack().core_init()
+            # Open the BTP socket and connect to bttester.
+            iut.start(self)
+            # Await the IUT ready event.
+            iut.wait_iut_ready_event(False)
+            # Read the BTP services the IUT supports.
+            iut.get_supported_svcs()
+
+        if hasattr(iut, 'select_iut'):
+            iut.select_iut(0)
+
+    def _test_case_cleanup(self) -> None:
+        """Reset the IUT after the test case commands have run."""
+
+        iut = get_iut()
+
+        for iut_id in range(self.iut_count):
+            if hasattr(iut, 'select_iut'):
+                iut.select_iut(iut_id)
+
+            iut.stack.cleanup()
+
+            # For openvela this closes the BTP socket but keeps bttester
+            # running, waiting for the next connection.
+            iut.stop()
+
+        if hasattr(iut, 'select_iut'):
+            iut.select_iut(0)

--- a/autopts/ptsprojects/stack/layers/a2dp.py
+++ b/autopts/ptsprojects/stack/layers/a2dp.py
@@ -1,0 +1,52 @@
+#
+# auto-pts - The Bluetooth PTS Automation Framework
+#
+# Copyright (c) 2026, Xiaomi Corporation.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms and conditions of the GNU General Public License,
+# version 2, as published by the Free Software Foundation.
+#
+# This program is distributed in the hope it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+
+from autopts.ptsprojects.stack.common import wait_event_with_condition, wait_for_event
+from autopts.pybtp import defs
+
+
+class A2DP:
+    def __init__(self):
+        self.connected = False
+        self.addr = None
+        self.audio_streaming = False
+
+        # Same shape as the other layers that carry events a handler consumes
+        # (mics, vcp, ascs and the rest): a queue per event type, appended by
+        # event_received() and drained with wait_event_with_condition().
+        self.event_queues = {
+            defs.BTP_A2DP_EV_OPERATION_REQ: [],
+        }
+
+    def event_received(self, event_type, event_data_tuple):
+        self.event_queues[event_type].append(event_data_tuple)
+
+    def is_connected(self):
+        return self.connected
+
+    def wait_for_connection(self, timeout=20):
+        wait_for_event(timeout, self.is_connected)
+        return self.connected
+
+    def wait_operation_req_ev(self, signal_id, timeout, remove=True):
+        """Wait for the IUT to report that an AVDTP operation needs a decision.
+
+        Returns None on timeout, which is the normal outcome for an IUT whose
+        stack answers these operations itself, and is what makes the "if
+        necessary" in the PTS prompts answerable.
+        """
+        return wait_event_with_condition(
+            self.event_queues[defs.BTP_A2DP_EV_OPERATION_REQ],
+            lambda sig, *_: sig == signal_id, timeout, remove)

--- a/autopts/ptsprojects/stack/stack.py
+++ b/autopts/ptsprojects/stack/stack.py
@@ -15,6 +15,7 @@
 #
 import logging
 
+from autopts.ptsprojects.stack.layers.a2dp import A2DP
 from autopts.ptsprojects.stack.layers.aics import AICS
 from autopts.ptsprojects.stack.layers.ascs import ASCS
 from autopts.ptsprojects.stack.layers.bap import BAP
@@ -90,6 +91,7 @@ class Stack:
         self.sdp = None
         self.csis = None
         self.rfcomm = None
+        self.a2dp = None
         # GENERATOR append 2
         self.supported_svcs_cmds = common.supported_svcs_cmds
 
@@ -210,6 +212,9 @@ class Stack:
     def rfcomm_init(self):
         self.rfcomm = RFCOMM()
 
+    def a2dp_init(self):
+        self.a2dp = A2DP()
+
     # GENERATOR append 3
 
     def cleanup(self):
@@ -302,6 +307,9 @@ class Stack:
 
         if self.rfcomm:
             self.rfcomm_init()
+
+        if self.a2dp:
+            self.a2dp_init()
 
         # GENERATOR append 4
 

--- a/autopts/pybtp/btp/__init__.py
+++ b/autopts/pybtp/btp/__init__.py
@@ -15,6 +15,7 @@
 
 """BTP"""
 
+from autopts.pybtp.btp.a2dp import *  # noqa: F403 # used in many files : TODO import directly in files not with *
 from autopts.pybtp.btp.aics import *  # noqa: F403 # used in many files : TODO import directly in files not with *
 from autopts.pybtp.btp.ascs import *  # noqa: F403 # used in many files : TODO import directly in files not with *
 from autopts.pybtp.btp.bap import *  # noqa: F403 # used in many files : TODO import directly in files not with *

--- a/autopts/pybtp/btp/a2dp.py
+++ b/autopts/pybtp/btp/a2dp.py
@@ -1,0 +1,262 @@
+#
+# auto-pts - The Bluetooth PTS Automation Framework
+#
+# Copyright (c) 2026, Xiaomi Corporation.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms and conditions of the GNU General Public License,
+# version 2, as published by the Free Software Foundation.
+#
+# This program is distributed in the hope it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+
+"""Wrapper around BTP A2DP messages."""
+
+import logging
+import struct
+
+from autopts.pybtp import defs
+from autopts.pybtp.btp.btp import CONTROLLER_INDEX, pts_addr_get, pts_addr_type_get
+from autopts.pybtp.btp.btp import get_iut_method as get_iut
+from autopts.pybtp.types import addr_str_to_le_bytes
+
+log = logging.debug
+
+A2DP = {
+    'read_supported_cmds': (defs.BTP_SERVICE_ID_A2DP,
+                            defs.BTP_A2DP_CMD_READ_SUPPORTED_COMMANDS,
+                            defs.BTP_INDEX_NONE, ""),
+    'connect': (defs.BTP_SERVICE_ID_A2DP, defs.BTP_A2DP_CMD_CONNECT,
+                CONTROLLER_INDEX),
+    'disconnect': (defs.BTP_SERVICE_ID_A2DP, defs.BTP_A2DP_CMD_DISCONNECT,
+                   CONTROLLER_INDEX),
+    'start_stream': (defs.BTP_SERVICE_ID_A2DP, defs.BTP_A2DP_CMD_START_STREAM,
+                     CONTROLLER_INDEX),
+    'stop_stream': (defs.BTP_SERVICE_ID_A2DP, defs.BTP_A2DP_CMD_STOP_STREAM,
+                    CONTROLLER_INDEX),
+    'set_role': (defs.BTP_SERVICE_ID_A2DP, defs.BTP_A2DP_CMD_SET_ROLE,
+                 defs.BTP_INDEX_NONE),
+    'operation_rsp': (defs.BTP_SERVICE_ID_A2DP,
+                      defs.BTP_A2DP_CMD_OPERATION_RSP, CONTROLLER_INDEX),
+    'send_delay_report': (defs.BTP_SERVICE_ID_A2DP,
+                          defs.BTP_A2DP_CMD_SEND_DELAY_REPORT,
+                          CONTROLLER_INDEX),
+    'get_capability': (defs.BTP_SERVICE_ID_A2DP,
+                       defs.BTP_A2DP_CMD_GET_CAPABILITY, defs.BTP_INDEX_NONE),
+}
+
+
+def a2dp_connect(bd_addr=None, bd_addr_type=None):
+    logging.debug("%s %r", a2dp_connect.__name__, bd_addr)
+    iutctl = get_iut()
+
+    data_ba = bytearray()
+    bd_addr_ba = addr_str_to_le_bytes(pts_addr_get(bd_addr))
+    bd_addr_type_ba = struct.pack('B', pts_addr_type_get(bd_addr_type))
+
+    data_ba.extend(bd_addr_type_ba)
+    data_ba.extend(bd_addr_ba)
+
+    iutctl.btp_socket.send_wait_rsp(*A2DP['connect'], data=data_ba)
+
+
+def a2dp_disconnect(bd_addr=None, bd_addr_type=None):
+    logging.debug("%s %r", a2dp_disconnect.__name__, bd_addr)
+    iutctl = get_iut()
+
+    data_ba = bytearray()
+    bd_addr_ba = addr_str_to_le_bytes(pts_addr_get(bd_addr))
+    bd_addr_type_ba = struct.pack('B', pts_addr_type_get(bd_addr_type))
+
+    data_ba.extend(bd_addr_type_ba)
+    data_ba.extend(bd_addr_ba)
+
+    iutctl.btp_socket.send_wait_rsp(*A2DP['disconnect'], data=data_ba)
+
+
+def a2dp_start_stream(bd_addr=None, bd_addr_type=None):
+    logging.debug("%s %r", a2dp_start_stream.__name__, bd_addr)
+    iutctl = get_iut()
+
+    data_ba = bytearray()
+    bd_addr_ba = addr_str_to_le_bytes(pts_addr_get(bd_addr))
+    bd_addr_type_ba = struct.pack('B', pts_addr_type_get(bd_addr_type))
+
+    data_ba.extend(bd_addr_type_ba)
+    data_ba.extend(bd_addr_ba)
+
+    iutctl.btp_socket.send_wait_rsp(*A2DP['start_stream'], data=data_ba)
+
+
+def a2dp_stop_stream(bd_addr=None, bd_addr_type=None):
+    logging.debug("%s %r", a2dp_stop_stream.__name__, bd_addr)
+    iutctl = get_iut()
+
+    data_ba = bytearray()
+    bd_addr_ba = addr_str_to_le_bytes(pts_addr_get(bd_addr))
+    bd_addr_type_ba = struct.pack('B', pts_addr_type_get(bd_addr_type))
+
+    data_ba.extend(bd_addr_type_ba)
+    data_ba.extend(bd_addr_ba)
+
+    iutctl.btp_socket.send_wait_rsp(*A2DP['stop_stream'], data=data_ba)
+
+
+def a2dp_set_role(role):
+    """Set the A2DP role the IUT plays (0 = sink, 1 = source)."""
+    logging.debug("%s %r", a2dp_set_role.__name__, role)
+    iutctl = get_iut()
+
+    data_ba = bytearray(struct.pack('B', role))
+    iutctl.btp_socket.send_wait_rsp(*A2DP['set_role'], data=data_ba)
+
+
+def a2dp_send_delay_report(delay, bd_addr=None, bd_addr_type=None):
+    """Send an AVDTP DELAYREPORT with 'delay' in 1/10 ms.
+
+    Not every IUT can emit one on demand; check a2dp_supports() first, since a
+    stack that declares delay reporting as an endpoint capability and negotiates
+    it itself has no way to send one at a chosen moment.
+    """
+    logging.debug("%s delay=%d", a2dp_send_delay_report.__name__, delay)
+
+    iutctl = get_iut()
+
+    data_ba = bytearray()
+    data_ba.extend(struct.pack('B', pts_addr_type_get(bd_addr_type)))
+    data_ba.extend(addr_str_to_le_bytes(pts_addr_get(bd_addr)))
+    data_ba.extend(struct.pack('<H', delay))
+    iutctl.btp_socket.send_wait_rsp(*A2DP['send_delay_report'], data=data_ba)
+
+
+def a2dp_get_capability(capability, value=0):
+    """Ask the IUT a yes/no question about itself, returning True or False.
+
+    Used for the prompts PTS phrases as a question about the implementation. The
+    IUT answers from its own behaviour, so the same handler is correct for any
+    IUT rather than encoding one implementation's answer.
+    """
+    logging.debug("%s cap=0x%02x value=%d", a2dp_get_capability.__name__,
+                  capability, value)
+
+    iutctl = get_iut()
+
+    data_ba = bytearray(struct.pack('<BH', capability, value))
+    iutctl.btp_socket.send_wait_rsp(*A2DP['get_capability'], data=data_ba)
+
+    tuple_data = iutctl.btp_socket.read()[1]
+    data = tuple_data[0] if isinstance(tuple_data, tuple) else tuple_data
+
+    return bool(data and data[0])
+
+
+def a2dp_supports(opcode):
+    """Whether the IUT advertises a given A2DP BTP command.
+
+    Read from the READ_SUPPORTED_COMMANDS bitmap that core_reg_svc_univ() already
+    collects into stack.supported_cmds, so a handler can skip work the IUT cannot
+    do instead of waiting to find out.
+
+    Defaults to False when the bitmap is missing, which is the safe direction: a
+    handler that skips an unsupported command costs nothing, while one that issues
+    it fails visibly the first time.
+    """
+    from autopts.ptsprojects.stack import get_stack
+
+    try:
+        stack = get_stack()
+        bitmap = (stack.supported_cmds or {}).get('A2DP')
+    except Exception:
+        # get_stack() raises rather than returning None when there is no IUT.
+        return False
+
+    if not bitmap:
+        return False
+
+    return bool(bitmap >> opcode & 1)
+
+
+def a2dp_operation_rsp(signal_id, accept=True, error_code=0, bd_addr=None,
+                       bd_addr_type=None):
+    """Answer an AVDTP operation the IUT reported through
+    BTP_A2DP_EV_OPERATION_REQ.
+
+    Only meaningful in response to that event: an IUT which answers these
+    operations itself never raises it, and answering an event that never arrived
+    is rejected. Use A2DP.take_pending_operation() to decide whether to call
+    this at all - that is the "if necessary" in the PTS prompts.
+
+    'error_code' is an AVDTP Error Code and is only read when accept is False.
+    """
+    logging.debug("%s signal_id=0x%02x accept=%s error=0x%02x",
+                  a2dp_operation_rsp.__name__, signal_id, accept, error_code)
+
+    iutctl = get_iut()
+
+    data_ba = bytearray()
+    data_ba.extend(struct.pack('B', pts_addr_type_get(bd_addr_type)))
+    data_ba.extend(addr_str_to_le_bytes(pts_addr_get(bd_addr)))
+    data_ba.extend(struct.pack('BBB', signal_id, 1 if accept else 0, error_code))
+    iutctl.btp_socket.send_wait_rsp(*A2DP['operation_rsp'], data=data_ba)
+
+
+# A2DP event handlers
+
+def a2dp_connected_ev_(a2dp, data, data_len):
+    """Handle A2DP connected event."""
+    import logging
+    logging.debug("%s", a2dp_connected_ev_.__name__)
+    if a2dp:
+        a2dp.connected = True
+        if data_len >= 7:
+            a2dp.addr = data[:7]
+
+
+def a2dp_disconnected_ev_(a2dp, data, data_len):
+    """Handle A2DP disconnected event."""
+    import logging
+    logging.debug("%s", a2dp_disconnected_ev_.__name__)
+    if a2dp:
+        a2dp.connected = False
+
+
+# Every A2DP event starts with bt_addr_le_t, which is 7 bytes, so payload fields
+# begin at offset 7. Reading data[0] picks up the address type instead - 0 for a
+# public BR/EDR address, which passes for a valid value and reads as "not
+# streaming" no matter what the IUT reported.
+_EV_PAYLOAD_OFFSET = 7
+
+
+def a2dp_audio_state_ev_(a2dp, data, data_len):
+    """Handle A2DP audio state event."""
+    import logging
+    logging.debug("%s", a2dp_audio_state_ev_.__name__)
+    if a2dp and data_len > _EV_PAYLOAD_OFFSET:
+        a2dp.audio_streaming = (data[_EV_PAYLOAD_OFFSET] != 0)
+
+
+def a2dp_operation_req_ev_(a2dp, data, data_len):
+    """An AVDTP operation is waiting on a decision from the client.
+
+    Only an IUT that defers these decisions to the application raises this;
+    an IUT whose stack answers them internally never raises it. Queuing the
+    signal id is what lets a WID handler tell "the IUT needs me to accept this"
+    from "the IUT already did".
+    """
+    import logging
+    logging.debug("%s", a2dp_operation_req_ev_.__name__)
+    if a2dp and data_len > _EV_PAYLOAD_OFFSET:
+        signal_id = data[_EV_PAYLOAD_OFFSET]
+        logging.debug("a2dp operation req: signal_id=0x%02x", signal_id)
+        a2dp.event_received(defs.BTP_A2DP_EV_OPERATION_REQ, (signal_id,))
+
+
+A2DP_EV = {
+    defs.BTP_A2DP_EV_CONNECTED: a2dp_connected_ev_,
+    defs.BTP_A2DP_EV_DISCONNECTED: a2dp_disconnected_ev_,
+    defs.BTP_A2DP_EV_AUDIO_STATE: a2dp_audio_state_ev_,
+    defs.BTP_A2DP_EV_OPERATION_REQ: a2dp_operation_req_ev_,
+}

--- a/autopts/pybtp/btp/btp.py
+++ b/autopts/pybtp/btp/btp.py
@@ -607,6 +607,10 @@ def core_reg_svc_rfcomm():
     core_reg_svc_univ("rfcomm_reg", "RFCOMM")
 
 
+def core_reg_svc_a2dp():
+    core_reg_svc_univ("a2dp_reg", "A2DP")
+
+
 # GENERATOR append 1
 
 
@@ -699,6 +703,7 @@ set_get_stack_method(_get_stack)
 def event_handler(hdr, data):
     logging.debug("%r %r", hdr, data)
     from .event_map import (
+        A2DP_EV,
         AICS_EV,
         ASCS_EV,
         BAP_EV,
@@ -763,6 +768,7 @@ def event_handler(hdr, data):
         defs.BTP_SERVICE_ID_PBP: (PBP_EV, stack.pbp),
         defs.BTP_SERVICE_ID_SDP: (SDP_EV, stack.sdp),
         defs.BTP_SERVICE_ID_RFCOMM: (RFCOMM_EV, stack.rfcomm),
+        defs.BTP_SERVICE_ID_A2DP: (A2DP_EV, stack.a2dp),
         # GENERATOR append 3
     }
 

--- a/autopts/pybtp/btp/event_map.py
+++ b/autopts/pybtp/btp/event_map.py
@@ -1,3 +1,4 @@
+from .a2dp import A2DP_EV
 from .aics import AICS_EV
 from .ascs import ASCS_EV
 from .bap import BAP_EV
@@ -58,5 +59,6 @@ __all__ = [
     "VCP_EV",
     "VCS_EV",
     "VOCS_EV",
+    "A2DP_EV",
 # GENERATOR append 2
 ]

--- a/autopts/pybtp/btp/gap.py
+++ b/autopts/pybtp/btp/gap.py
@@ -79,6 +79,8 @@ GAP = {
                       CONTROLLER_INDEX, defs.GAP_GENERAL_DISCOVERABLE),
     "set_limdiscov": (defs.BTP_SERVICE_ID_GAP, defs.BTP_GAP_CMD_SET_DISCOVERABLE,
                       CONTROLLER_INDEX, defs.GAP_LIMITED_DISCOVERABLE),
+    "set_br_scan_mode": (defs.BTP_SERVICE_ID_GAP,
+                         defs.BTP_GAP_CMD_SET_BR_SCAN_MODE, CONTROLLER_INDEX),
     "set_powered_on": (defs.BTP_SERVICE_ID_GAP, defs.BTP_GAP_CMD_SET_POWERED,
                        CONTROLLER_INDEX, 1),
     "set_powered_off": (defs.BTP_SERVICE_ID_GAP, defs.BTP_GAP_CMD_SET_POWERED,
@@ -1046,6 +1048,25 @@ def gap_set_limited_discoverable():
 
     tuple_data = gap_command_rsp_succ()
     __gap_current_settings_update(tuple_data)
+
+
+def gap_set_br_scan_mode(mode=defs.BT_SCAN_MODE_CONNECTABLE_DISCOVERABLE,
+                         bondable=True):
+    """Set the BR/EDR page and inquiry scan mode.
+
+    gap_set_connectable() and gap_set_general_discoverable() only affect LE, so
+    this is what actually makes the IUT reachable or findable over BR/EDR. The
+    "prepare the IUT into a connectable mode" prompts need it: without it a
+    handler can only assume something outside the test already arranged the scan
+    mode, which holds for this tester but not for other systems.
+    """
+    logging.debug("%s mode=%d bondable=%s", gap_set_br_scan_mode.__name__,
+                  mode, bondable)
+
+    iutctl = get_iut()
+
+    data = struct.pack('BB', mode, 1 if bondable else 0)
+    iutctl.btp_socket.send_wait_rsp(*GAP['set_br_scan_mode'], data=data)
 
 
 def gap_set_powered_on():

--- a/autopts/pybtp/common.py
+++ b/autopts/pybtp/common.py
@@ -603,6 +603,10 @@ supported_svcs_cmds = {
         "service": 1 << defs.BTP_SERVICE_ID_RFCOMM,
         "supported_commands": defs.BTP_RFCOMM_CMD_READ_SUPPORTED_COMMANDS
     },
+    "A2DP": {
+        "service": 1 << defs.BTP_SERVICE_ID_A2DP,
+        "supported_commands": defs.BTP_A2DP_CMD_READ_SUPPORTED_COMMANDS
+    },
 # GENERATOR append 1
     "VENDOR": {
         "service": 1 << defs.BTP_SERVICE_ID_VENDOR,
@@ -685,6 +689,8 @@ reg_unreg_service = {
                 defs.BTP_INDEX_NONE, defs.BTP_SERVICE_ID_SDP),
     "rfcomm_reg": (defs.BTP_SERVICE_ID_CORE, defs.BTP_CORE_CMD_REGISTER_SERVICE,
                  defs.BTP_INDEX_NONE, defs.BTP_SERVICE_ID_RFCOMM),
+    "a2dp_reg": (defs.BTP_SERVICE_ID_CORE, defs.BTP_CORE_CMD_REGISTER_SERVICE,
+                 defs.BTP_INDEX_NONE, defs.BTP_SERVICE_ID_A2DP),
 # GENERATOR append 2
     "vendor_reg": (defs.BTP_SERVICE_ID_CORE, defs.BTP_CORE_CMD_REGISTER_SERVICE,
                    defs.BTP_INDEX_NONE, defs.BTP_SERVICE_ID_VENDOR),

--- a/autopts/pybtp/defs.py
+++ b/autopts/pybtp/defs.py
@@ -57,6 +57,7 @@ BTP_SERVICE_ID_OTS = 0x1d
 BTP_SERVICE_ID_PBP = 0x1e
 BTP_SERVICE_ID_SDP = 0x1f
 BTP_SERVICE_ID_RFCOMM = 0x20
+BTP_SERVICE_ID_A2DP = 0x21
 # GENERATOR append 1
 BTP_SERVICE_ID_VENDOR = 0xff
 
@@ -178,6 +179,17 @@ BTP_GAP_CMD_SET_EAD_KEY_MATERIAL = 0x31
 BTP_GAP_CMD_ENCRYPT_EAD_DATA = 0x32
 BTP_GAP_CMD_DECRYPT_EAD_DATA = 0x33
 BTP_GAP_CMD_PAWR_CONFIGURE = 0x34
+
+# BR/EDR page and inquiry scan. BTP_GAP_CMD_SET_CONNECTABLE and
+# _SET_DISCOVERABLE are LE-only by design, so they cannot make the IUT reachable
+# over BR/EDR.
+BTP_GAP_CMD_SET_BR_SCAN_MODE = 0x40
+
+# Values for BTP_GAP_CMD_SET_BR_SCAN_MODE. Discoverable implies connectable, so
+# this is a tri-state rather than two independent flags.
+BT_SCAN_MODE_NONE = 0x00
+BT_SCAN_MODE_CONNECTABLE = 0x01
+BT_SCAN_MODE_CONNECTABLE_DISCOVERABLE = 0x02
 BTP_GAP_EV_NEW_SETTINGS = 0x80
 GAP_DEVICE_FOUND_FLAG_RSSI = 0x01
 GAP_DEVICE_FOUND_FLAG_AD = 0x02
@@ -1012,6 +1024,59 @@ BTP_RFCOMM_EV_CONNECTED = 0x80
 BTP_RFCOMM_EV_DISCONNECTED = 0x81
 BTP_RFCOMM_EV_DATA_RECEIVED = 0x82
 BTP_RFCOMM_EV_DATA_SENT = 0x83
+
+# A2DP BTP commands and events
+BTP_A2DP_CMD_READ_SUPPORTED_COMMANDS = 0x01
+BTP_A2DP_CMD_CONNECT = 0x02
+BTP_A2DP_CMD_DISCONNECT = 0x03
+BTP_A2DP_CMD_START_STREAM = 0x04
+BTP_A2DP_CMD_STOP_STREAM = 0x05
+BTP_A2DP_CMD_SET_CONFIGURATION = 0x06
+BTP_A2DP_CMD_GET_CONFIGURATION = 0x07
+BTP_A2DP_CMD_SET_ROLE = 0x08
+
+# Answer an AVDTP operation the tester initiated. Modelled on
+# BTP_GAP_EV_PAIRING_CONSENT_REQ / BTP_GAP_PAIRING_CONSENT: the IUT raises
+# BTP_A2DP_EV_OPERATION_REQ when a decision is actually pending and the client
+# answers it. An IUT whose stack answers these itself never raises the event, so
+# the exchange stays silent rather than the client sending a command documented
+# to do nothing.
+BTP_A2DP_CMD_OPERATION_RSP = 0x09
+BTP_A2DP_CMD_SEND_DELAY_REPORT = 0x0a
+BTP_A2DP_CMD_GET_CAPABILITY = 0x0b
+# Questions BTP_A2DP_CMD_GET_CAPABILITY can ask. Some PTS prompts are yes/no
+# questions about the implementation rather than instructions, and the answer
+# belongs to the IUT - a client that hardcodes it is describing whichever
+# implementation it was written against.
+A2DP_CAP_CONNECT_UNPAIRED = 0x01
+A2DP_CAP_DELAY_ACCEPTABLE = 0x02
+BTP_A2DP_EV_OPERATION_REQ = 0x83
+
+# AVDTP Signal Identifiers (AVDTP 8.5), carried by the event and the response.
+AVDTP_SIG_DISCOVER = 0x01
+AVDTP_SIG_GET_CAPABILITIES = 0x02
+AVDTP_SIG_SET_CONFIGURATION = 0x03
+AVDTP_SIG_GET_CONFIGURATION = 0x04
+AVDTP_SIG_RECONFIGURE = 0x05
+AVDTP_SIG_OPEN = 0x06
+AVDTP_SIG_START = 0x07
+AVDTP_SIG_CLOSE = 0x08
+AVDTP_SIG_SUSPEND = 0x09
+AVDTP_SIG_ABORT = 0x0a
+AVDTP_SIG_SECURITY_CONTROL = 0x0b
+AVDTP_SIG_GET_ALL_CAPABILITIES = 0x0c
+AVDTP_SIG_DELAYREPORT = 0x0d
+
+# Not AVDTP signals, but part of the same family of prompts: accepting the
+# signalling channel itself and the transport channels of a configured stream.
+AVDTP_SIG_SIGNALING_CHANNEL = 0xf0
+AVDTP_SIG_TRANSPORT_CHANNEL = 0xf1
+
+# AVDTP Error Codes (AVDTP 8.20.6), for rejecting an operation.
+AVDTP_ERR_NOT_SUPPORTED_SAMPLING_FREQUENCY = 0x33
+BTP_A2DP_EV_CONNECTED = 0x80
+BTP_A2DP_EV_DISCONNECTED = 0x81
+BTP_A2DP_EV_AUDIO_STATE = 0x82
 
 # GENERATOR append 2
 

--- a/autopts/wid/a2dp.py
+++ b/autopts/wid/a2dp.py
@@ -1,0 +1,337 @@
+#
+# auto-pts - The Bluetooth PTS Automation Framework
+#
+# Copyright (c) 2026, Xiaomi Corporation.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms and conditions of the GNU General Public License,
+# version 2, as published by the Free Software Foundation.
+#
+# This program is distributed in the hope it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+"""WID handlers for A2DP.
+
+Every docstring below is the prompt PTS actually sends, copied verbatim from a
+run over the full A2DP suite (49 cases: SRC 19, SNK 30). Only numbers observed in
+that run have a handler: an unobserved number can only be implemented by guessing
+what it means, and a guess that lands on a number PTS does use answers the wrong
+thing silently - WID 102 did exactly that, claiming "Accept A2DP disconnection"
+while PTS was asking the IUT to connect, and the case waited out five minutes.
+
+An unhandled WID raises MissingWIDError, which is the honest outcome: it names
+the number and the prompt so a handler can be written against the real text.
+"""
+
+import logging
+import re
+
+from autopts.ptsprojects.stack import get_stack
+from autopts.pybtp import btp, defs
+from autopts.pybtp.types import WIDParams
+
+log = logging.debug
+
+# How long to wait for BTP_A2DP_EV_OPERATION_REQ before concluding the IUT
+# answered the operation itself. PTS gives a prompt about 20s before deciding the
+# operator never confirmed it, so this has to stay well short of that - on this
+# IUT the timeout is the expected outcome, not the exception.
+_PENDING_OP_TIMEOUT = 2
+
+
+def a2dp_wid_hdl(wid, description, test_case_name):
+    from autopts.wid import generic_wid_hdl
+    log(f'{a2dp_wid_hdl.__name__}, {wid}, {description}, {test_case_name}')
+    return generic_wid_hdl(wid, description, test_case_name, [__name__])
+
+
+# Delay used when the IUT is asked to emit a Delay Report and the prompt does not
+# name one. AVDTP carries the delay in 1/10 ms; this is 100 ms.
+_DEFAULT_DELAY = 1000
+
+
+def _delay_from(description):
+    """Pull the delay value out of a prompt, in ms.
+
+    PTS names it inline ("Is the delay value 1000, ..."), and it is not fixed per
+    test case, so parse it rather than hardcoding.
+    """
+    match = re.search(r'delay value\s+(\d+)', description, re.IGNORECASE)
+    if not match:
+        raise ValueError(f'no delay value in description: {description!r}')
+
+    return int(match.group(1))
+
+
+def _answer_if_pending(signal_id, accept=True, error_code=0):
+    """Answer an AVDTP operation, but only if this IUT expects to be asked.
+
+    This is the "if necessary" in the PTS prompts, and the decision is made from
+    READ_SUPPORTED_COMMANDS rather than from a timeout. An IUT that answers these
+    operations itself does not advertise BTP_A2DP_OPERATION_RSP, so there is
+    nothing to wait for and the handler returns immediately.
+
+    Waiting instead would cost real time for nothing: these prompts occur 184
+    times across the 49 case A2DP suite, so even a 2s wait each adds six minutes
+    of certain timeouts on an IUT that answers these internally.
+
+    Only when the IUT does advertise the command is the event worth waiting for -
+    then the wait is bounded well short of the roughly 20s PTS allows before it
+    decides the prompt was never confirmed.
+    """
+    if not btp.a2dp_supports(defs.BTP_A2DP_CMD_OPERATION_RSP):
+        log(f'AVDTP signal 0x{signal_id:02x}: IUT answers these itself')
+        return True
+
+    stack = get_stack()
+
+    if stack.a2dp.wait_operation_req_ev(signal_id, _PENDING_OP_TIMEOUT) is None:
+        log(f'AVDTP signal 0x{signal_id:02x}: nothing pending')
+        return True
+
+    btp.a2dp_operation_rsp(signal_id, accept=accept, error_code=error_code)
+    return True
+
+
+def hdl_wid_6(params: WIDParams):
+    '''Is the delay value 1000, within a device acceptable range?'''
+    # A question about the IUT, so ask it rather than answering for it. The delay
+    # is quoted in ms in the prompt and carried in 1/10 ms on the wire.
+    delay = _delay_from(params.description)
+    return btp.a2dp_get_capability(defs.A2DP_CAP_DELAY_ACCEPTABLE, delay * 10)
+
+
+def hdl_wid_9(_: WIDParams):
+    '''Take action if necessary to initiate a Delay Reporting command.'''
+    # An action, so drive it. Not every IUT can emit a delay report on demand -
+    # one that declares it as an endpoint capability and lets the stack negotiate
+    # it has no such call - hence the "if necessary" in the prompt.
+    if not btp.a2dp_supports(defs.BTP_A2DP_CMD_SEND_DELAY_REPORT):
+        log('IUT cannot send a delay report on demand')
+        return True
+
+    btp.a2dp_send_delay_report(_DEFAULT_DELAY, bd_addr_type=defs.BTP_BR_ADDRESS_TYPE)
+    return True
+
+
+def hdl_wid_12(_: WIDParams):
+    '''Delete the link key with PTS on the Implementation Under Test (IUT), and
+    then click OK to continue. Description: For end product, this can be
+    achieved by forgetting PTS from the IUT.
+    '''
+    # gap_unpair() exists and is the command for this prompt, but it must not be
+    # used here: PTS keeps its own link key, so dropping the IUT's leaves the two
+    # sides asymmetric - PTS answers the next SEC_LINK_KEY_REQUEST with a key the
+    # IUT no longer has, authentication ends in HCI_PIN_OR_KEY_MISSING and the
+    # AVDTP channel never opens.
+    #
+    # TSPX_delete_link_key encodes the same choice, and rfcomm, hfp and hid all
+    # answer this prompt the same way.
+    return True
+
+
+def hdl_wid_13(_: WIDParams):
+    '''Is the IUT capable of establishing connection to an unpaired device?'''
+    # A question about the IUT, so ask it.
+    return btp.a2dp_get_capability(defs.A2DP_CAP_CONNECT_UNPAIRED)
+
+
+def hdl_wid_15(_: WIDParams):
+    '''Please prepare the IUT to reject an AVDTP SET CONFIGURATION command with
+    error code NOT_SUPPORTED_SAMPLING_FREQUENCY, then press 'OK' to continue.'''
+    # The IUT's stack validates SET CONFIGURATION against the registered endpoint
+    # capabilities and answers the matching AVDTP error on its own, so it cannot
+    # be told to reject a request it would otherwise accept.
+    return _answer_if_pending(
+        defs.AVDTP_SIG_SET_CONFIGURATION, accept=False,
+        error_code=defs.AVDTP_ERR_NOT_SUPPORTED_SAMPLING_FREQUENCY)
+
+
+def hdl_wid_102(_: WIDParams):
+    '''Please send an HCI connect request to establish a basic rate connection
+    after the IUT discovers the Lower Tester over BR and LE.
+
+    Connecting A2DP brings up the ACL on the way, which is what the prompt is
+    after. This number used to carry an invented "Accept A2DP disconnection"
+    meaning and simply returned True, so the case sat waiting for a connection
+    that was never attempted until PTS gave up.
+    '''
+    btp.a2dp_connect(bd_addr_type=defs.BTP_BR_ADDRESS_TYPE)
+    return True
+
+
+def hdl_wid_1001(_: WIDParams):
+    '''If necessary, take action to accept the AVDTP Close operation initiated
+    by the tester.'''
+    # The IUT's stack closes the AVDTP transport channel itself.
+    return _answer_if_pending(defs.AVDTP_SIG_CLOSE)
+
+
+def hdl_wid_1002(_: WIDParams):
+    '''If necessary, take action to accept the AVDTP Signaling Channel
+    Connection initiated by the tester. Description: Make sure the IUT
+    (Implementation Under Test) is in a state to accept incoming Bluetooth
+    connections. Some devices may need to be on a specific screen, like a
+    Bluetooth settings screen, in order to pair with PTS. If the IUT is still
+    having problems pairing with PTS, try running a test case where the IUT
+    connects to PTS to establish pairing.'''
+    # The IUT's stack registers the AVDTP signalling PSM at startup and accepts
+    # the L2CAP connection on its own.
+    return _answer_if_pending(defs.AVDTP_SIG_SIGNALING_CHANNEL)
+
+
+def hdl_wid_1004(_: WIDParams):
+    '''If necessary, take action to accept the AVDTP Discover operation
+    initiated by the tester.'''
+    # The IUT's stack answers Discover from its registered stream endpoints.
+    return _answer_if_pending(defs.AVDTP_SIG_DISCOVER)
+
+
+def hdl_wid_1006(_: WIDParams):
+    '''If necessary, take action to accept the AVDTP Open operation initiated by
+    the tester.'''
+    # The IUT's stack accepts the AVDTP transport channel itself.
+    return _answer_if_pending(defs.AVDTP_SIG_OPEN)
+
+
+def hdl_wid_1009(_: WIDParams):
+    '''If necessary, take action to accept the AVDTP Set Configuration operation
+    initiated by the tester.'''
+    # The IUT's stack negotiates the codec configuration itself.
+    return _answer_if_pending(defs.AVDTP_SIG_SET_CONFIGURATION)
+
+
+def hdl_wid_1010(_: WIDParams):
+    '''If necessary, take action to accept the AVDTP Start operation initiated
+    by the tester.'''
+    # The IUT's stack answers Start itself.
+    return _answer_if_pending(defs.AVDTP_SIG_START)
+
+
+def hdl_wid_1012(_: WIDParams):
+    '''If necessary, take action to accept the AVDTP Suspend operation initiated
+    by the tester.'''
+    # The IUT's stack answers Suspend itself, same as Start.
+    #
+    # SNK/SUS/BV-01-C used to pass with no handler at all, which is misleading:
+    # the prompt raised MissingWIDError, the case still passed because PTS does
+    # not gate the verdict on this confirmation, and the failure was only
+    # visible in the client log. A passing verdict is not evidence a handler ran.
+    return _answer_if_pending(defs.AVDTP_SIG_SUSPEND)
+
+
+def hdl_wid_1015(_: WIDParams):
+    '''Close the streaming channel. Action: Disconnect the streaming channel, or
+    close the Bluetooth connection to the PTS.
+
+    The prompt wants an AVDTP Close. Stopping the stream sends Suspend, which is
+    a different signal and leaves the tester waiting for Close, so disconnect
+    instead - the IUT only emits Close as part of tearing the A2DP connection
+    down, having no notion of closing a stream on its own.
+    '''
+    btp.a2dp_disconnect(bd_addr_type=defs.BTP_BR_ADDRESS_TYPE)
+    return True
+
+
+def hdl_wid_1016(_: WIDParams):
+    '''Create an AVDTP signaling channel. Action: Create an audio or video
+    connection with PTS.
+
+    a2dp_connect() already brings the signaling channel up along with the ACL,
+    and by the time this prompt arrives that connect is in flight, so there is
+    nothing further to drive from here.
+    '''
+    return True
+
+
+def hdl_wid_1020(_: WIDParams):
+    '''Open a streaming media channel. Action: If the IUT (Implementation Under
+    Test) is already connected to PTS, attempting to send or receive streaming
+    media should trigger this action. If the IUT is not connected to PTS,
+    attempting to connect may trigger this action.'''
+    btp.a2dp_start_stream(bd_addr_type=defs.BTP_BR_ADDRESS_TYPE)
+    return True
+
+
+def hdl_wid_1029(_: WIDParams):
+    '''Move the IUT out of range to create a link loss scenario. Action: This can
+    be also be done by placing the IUT or PTS in an RF shielded box.
+
+    Both of the actions PTS offers are physical, and neither is reachable behind
+    btproxy. Answering Ok used to leave PTS waiting for a link loss that never
+    comes: the case burned its full five minute guard, came back PTS TIMEOUT,
+    and left both sides mid-procedure so the rest of the session had to be
+    rebuilt before it could be trusted.
+
+    Cancel instead. The case ends immediately as INCONC, which is what it
+    honestly is - not performed - and the session stays usable. Do not turn this
+    into Ok to make a number look better; a pass obtained by claiming a link
+    loss that did not happen is not evidence.
+    '''
+    log('WID 1029: RF link loss cannot be produced in this setup, cancelling')
+    return False
+
+
+def hdl_wid_1032(_: WIDParams):
+    '''Send a start command to PTS. Action: If the IUT (Implementation Under
+    Test) is already connected to PTS, attempting to send or receive streaming
+    media should trigger this action. If the IUT is not connected to PTS,
+    attempting to connect may trigger this action.
+
+    Some procedures ask for the start right after the signalling channel is
+    accepted, before the IUT has finished coming up. Its A2DP state machine
+    drops a start request while it is still Idle, so wait for the connection to
+    be reported first - otherwise the command is silently swallowed and the
+    tester waits out its timeout for a Start that was never sent.
+    '''
+    stack = get_stack()
+    if not stack.a2dp.wait_for_connection(timeout=20):
+        log('hdl_wid_1032: A2DP still not connected, starting anyway')
+
+    btp.a2dp_start_stream(bd_addr_type=defs.BTP_BR_ADDRESS_TYPE)
+    return True
+
+
+def hdl_wid_1037(_: WIDParams):
+    '''If necessary, take action to accept the AVDTP Get All Capabilities
+    operation initiated by the tester.'''
+    # The IUT's stack answers Get All Capabilities itself.
+    return _answer_if_pending(defs.AVDTP_SIG_GET_ALL_CAPABILITIES)
+
+
+def hdl_wid_1042(_: WIDParams):
+    '''Take action to accept transport channels for the recently configured
+    media stream.'''
+    # The IUT's stack accepts the transport channels itself.
+    return _answer_if_pending(defs.AVDTP_SIG_TRANSPORT_CHANNEL)
+
+
+def hdl_wid_1043(_: WIDParams):
+    '''Is the test system properly playing back the media being sent by the IUT?
+
+    Nothing here can observe the tester's own playback. What decides the case is
+    whether PTS actually received media packets, which it checks itself and fails
+    on beforehand if the IUT sent none.
+    '''
+    return True
+
+
+def hdl_wid_1046(_: WIDParams):
+    '''Begin streaming media ... Note: If the IUT has suspended the stream please
+    restart the stream to begin streaming media.'''
+    btp.a2dp_start_stream(bd_addr_type=defs.BTP_BR_ADDRESS_TYPE)
+    return True
+
+
+def hdl_wid_20000(_: WIDParams):
+    '''Please prepare IUT into a connectable mode in BR/EDR. Description: Verify
+    that the Implementation Under Test (IUT) can accept GATT connect request from
+    PTS.'''
+    # Set the BR/EDR scan mode rather than relying on the pre_conditions having
+    # done it: that is what decides whether a peer can page the IUT, and a caller
+    # of these handlers cannot be assumed to have set it - other systems'
+    # pre_conditions may not include the step at all.
+    btp.gap_set_br_scan_mode(defs.BT_SCAN_MODE_CONNECTABLE_DISCOVERABLE)
+    return True

--- a/autoptsclient-openvela.py
+++ b/autoptsclient-openvela.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python
+
+#
+# auto-pts - The Bluetooth PTS Automation Framework
+#
+# Copyright (c) 2026, Xiaomi Corporation.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms and conditions of the GNU General Public License,
+# version 2, as published by the Free Software Foundation.
+#
+# This program is distributed in the hope it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+
+"""openvela auto PTS client
+
+This client connects to openvela bttester running in QEMU via TCP socket.
+
+Usage:
+    1. Start QEMU with openvela:
+
+    2. Start bttester in QEMU:
+       adb shell "bttester &"
+
+    3. Setup adb port forwarding:
+       adb forward tcp:9876 tcp:9876
+
+    4. Run this client:
+       python autoptsclient-openvela.py <workspace> -i <pts_ip> --btp-tcp-port 9876
+"""
+
+import importlib
+
+from autopts import client as autoptsclient
+from autopts.ptsprojects.openvela.iutctl import get_iut
+from cliparser import CliParser
+
+
+class OpenVelaCliParser(CliParser):
+    """CLI parser with openvela-specific options."""
+
+    def __init__(self, iut_modes=None, board_names=None, add_help=True):
+        # openvela only supports TCP mode
+        if iut_modes is None:
+            iut_modes = ['btp_tcp_client']
+        super().__init__(iut_modes, board_names, add_help)
+        self._add_openvela_options()
+
+    def _add_openvela_options(self):
+        """Add openvela-specific command line options."""
+        self.add_argument('--adb-device',
+                          type=str,
+                          default=None,
+                          help='ADB device serial number')
+
+    def get_iut_mode(self, args):
+        """openvela always uses TCP mode."""
+        # Set default TCP port if not specified
+        if args.btp_tcp_port is None:
+            args.btp_tcp_port = 9876
+        return 'btp_tcp_client'
+
+    def check_args_btp_tcp_client(self, args):
+        """Override port range check - openvela bttester uses port 9876."""
+        if not 1024 <= args.btp_tcp_port <= 65535:
+            return (
+                f'btp_tcp_client mode: Invalid server port number={args.btp_tcp_port}, expected '
+                'range <1024,65535>'
+            )
+        return ''
+
+
+class OpenVelaClient(autoptsclient.Client):
+    """openvela auto-pts client."""
+
+    def __init__(self):
+        # Import the openvela project package, which exposes the profile
+        # modules (iutctl, a2dp) the framework looks up by name.
+        project = importlib.import_module('autopts.ptsprojects.openvela')
+        super().__init__(get_iut, project, 'openvela',
+                         parser_class=OpenVelaCliParser)
+
+
+def main():
+    """Main entry point."""
+    client = OpenVelaClient()
+    client.start()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Add an openvela auto-pts project driving bttester over TCP (adb forward) with A2DP support:

- BTP plumbing: A2DP service id, commands/events in defs, event map, event_handler dispatch, stack layer, and reg/unreg + supported-services entries, mirroring the existing RFCOMM/SDP pattern.
- AVDTP operation request/response: BTP_A2DP_EV_OPERATION_REQ / BTP_A2DP_CMD_OPERATION_RSP with AVDTP signal and error codes, so WID handlers answer Discover/Open/Start/etc. only when the IUT actually defers the decision (checked via READ_SUPPORTED_COMMANDS).
- gap: add gap_set_br_scan_mode (BR/EDR page/inquiry scan) since the LE-only set_connectable/set_discoverable cannot make the IUT reachable over BR/EDR.
- wid/a2dp: handlers for the A2DP WIDs observed over the full suite.
- openvela project: iutctl (adb/TCP bttester transport), a2dp test_cases, and OpenVelaTestCase.
- Add autoptsclient-openvela.py entry point.