### PR TITLE
errata: Add support ticket for GATT/SR/GAW/BV-01-C

### DIFF
--- a/errata/common.yaml
+++ b/errata/common.yaml
@@ -36,6 +36,7 @@ GAP/SEC/AUT/BV-13-C: ES-28650
 GAP/SEC/AUT/BV-14-C: ES-28650
 
 GATT/CL/GAS/BV-01-C: Request ID 184148
+GATT/SR/GAW/BV-01-C: https://support.bluetooth.com/hc/en-us/requests/191618
 
 L2CAP/COS/CED/BI-29-C: ES-28495
 


### PR DESCRIPTION
This test is randomly failing (due to PTS not doing ATT Read) when EATT is used.