### PR TITLE
errata: Add reference to TSE for GMCS/SR/MCP/BV-14-C

### DIFF
--- a/errata/common.yaml
+++ b/errata/common.yaml
@@ -12,6 +12,8 @@ GAP/SEC/AUT/BV-14-C: ES-28650
 
 GATT/CL/GAS/BV-01-C: Request ID 184148
 
+GMCS/SR/MCP/BV-14-C: https://bluetooth.atlassian.net/browse/ES-29526
+
 L2CAP/COS/CED/BI-29-C: ES-28495
 
 GTBS/SR/CP/BV-09-C: https://bluetooth.atlassian.net/browse/ES-29033


### PR DESCRIPTION
There is a TSE that prevents this test from passing.