### PR TITLE
BAP: wait for BIGInfo before synchronizing BISes

### DIFF
--- a/autopts/wid/bap.py
+++ b/autopts/wid/bap.py
@@ -765,11 +765,14 @@ def hdl_wid_100(params: WIDParams):
     if params.test_case_name.startswith('BAP/BA'):
         return True
 
+    biginfo = stack.gap.read_periodic_biginfo(timeout=20)
+    if biginfo is None:
+        log(f'BIGInfo not found for broadcast ID {broadcast_id}')
+        return False
+
     bis_events = {}
-    while True:
-        # Only apply a long timeout for the first event as any remaining events would come right after
-        wait_timeout = 20 if not bis_events else 1
-        bis_event = stack.bap.wait_bis_found_ev(broadcast_id, wait_timeout, True)
+    for _ in range(biginfo.num_bis):
+        bis_event = stack.bap.wait_bis_found_ev(broadcast_id, 20, True)
         if bis_event is None:
             break
         bis_events[bis_event['bis_id']] = bis_event

--- a/autopts/wid/bass.py
+++ b/autopts/wid/bass.py
@@ -188,6 +188,11 @@ def hdl_wid_113(_: WIDParams):
 
     # BIS_Sync bitfield uses bit 0 for BIS Index 1
     requested_bis_sync = 1 << (ev['bis_id'] - 1)
+
+    if stack.gap.read_periodic_biginfo(timeout=20) is None:
+        log(f'BIGInfo not found for broadcast ID {broadcast_id}')
+        return False
+
     btp.bap_broadcast_sink_bis_sync(ev['broadcast_id'], requested_bis_sync)
 
     bis_id = ev['bis_id']

--- a/autopts/wid/pbp.py
+++ b/autopts/wid/pbp.py
@@ -79,6 +79,11 @@ def hdl_wid_100(_: WIDParams):
 
     bis_id = 1
     requested_bis_sync = 1
+
+    if stack.gap.read_periodic_biginfo() is None:
+        log(f'BIGInfo not found for broadcast ID {broadcast_id}')
+        return False
+
     btp.bap_broadcast_sink_bis_sync(broadcast_id, requested_bis_sync, addr_type, addr)
 
     ev = stack.bap.wait_bis_synced_ev(broadcast_id, bis_id, 20, False)

--- a/autopts/wid/tmap.py
+++ b/autopts/wid/tmap.py
@@ -104,6 +104,10 @@ def hdl_wid_100(params: WIDParams):
     requested_bis_sync = 1
     bis_ids = [1]
 
+    if stack.gap.read_periodic_biginfo(timeout=20) is None:
+        log(f'BIGInfo not found for broadcast ID {broadcast_id}')
+        return False
+
     btp.bap_broadcast_sink_bis_sync(broadcast_id, requested_bis_sync)
 
     for bis_id in bis_ids:


### PR DESCRIPTION
Wait for the Periodic BIGInfo event after discovering BISes
and before requesting BIS synchronization. This avoids racing
BIS discovery against BIGInfo processing on the broadcast sink
and fixes BSNK STR synchronization failures.